### PR TITLE
feat(experimental): Diffusion RL post-training — Phase 1 PoC (SD1.5 + LoRA + REINFORCE)

### DIFF
--- a/areal/experimental/diffusion/__init__.py
+++ b/areal/experimental/diffusion/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Experimental diffusion RL post-training (Phase 1: SD1.5 + GRPO PoC).
+
+This package adds a diffusion-model RL post-training path on top of AReaL's
+``Workflow -> Engine -> Reward -> Training`` abstractions without touching the
+existing LLM code path. See ``docs/exec-plans/active/`` for the design rationale.
+"""
+
+from areal.experimental.diffusion.diffusion_api import (
+    DiffusionModelRequest,
+    DiffusionModelResponse,
+)
+from areal.experimental.diffusion.diffusion_engine import DiffusionInferenceEngine
+from areal.experimental.diffusion.diffusion_loss import (
+    compute_group_advantages,
+    diffusion_grpo_loss_fn,
+)
+from areal.experimental.diffusion.diffusion_workflow import DiffusionRolloutWorkflow
+
+__all__ = [
+    "DiffusionModelRequest",
+    "DiffusionModelResponse",
+    "DiffusionInferenceEngine",
+    "DiffusionRolloutWorkflow",
+    "compute_group_advantages",
+    "diffusion_grpo_loss_fn",
+]

--- a/areal/experimental/diffusion/aesthetic_reward.py
+++ b/areal/experimental/diffusion/aesthetic_reward.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Aesthetic reward for diffusion RL post-training.
+
+This implements the LAION aesthetic predictor: a CLIP ViT-L/14 image embedding
+fed into a small MLP head that regresses a 1-10 aesthetic score. It is the
+canonical reward used by ddpo-pytorch / DDPO for SD1.5 alignment.
+
+Why scoring runs synchronously in the main process (Phase 1 decision):
+``areal.api.reward_api.AsyncRewardWrapper`` dispatches reward functions through
+a ``ProcessPoolExecutor``, which requires the reward callable *and its captured
+state* to be picklable. The aesthetic scorer holds a CLIP backbone plus an MLP
+head -- live model objects that are not picklable -- so wrapping it would crash.
+For a single-GPU PoC, rollout throughput is not the bottleneck, so we score
+inline. Phase 2 can revisit this with a per-process lazy singleton.
+
+The CLIP backbone and MLP weights are loaded lazily on first use and cached on
+the scorer instance, so repeated calls do not reload the model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from areal.utils import logging
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+
+logger = logging.getLogger("AestheticReward")
+
+# Default LAION aesthetic predictor (linear head over CLIP ViT-L/14 embeddings).
+_DEFAULT_CLIP_MODEL = "openai/clip-vit-large-patch14"
+
+
+class AestheticScorer:
+    """LAION aesthetic predictor: CLIP embedding -> MLP -> scalar score.
+
+    Args:
+        weights_path: Path to the aesthetic MLP head state-dict
+            (``sac+logos+ava1-l14-linearMSE.pth`` style). If ``None`` or the
+            file is missing, scoring raises a clear error rather than silently
+            returning zeros.
+        clip_model: HuggingFace id of the CLIP backbone.
+        device: Device to run the scorer on.
+    """
+
+    def __init__(
+        self,
+        weights_path: str | None = None,
+        clip_model: str = _DEFAULT_CLIP_MODEL,
+        device: str = "cuda",
+    ):
+        self.weights_path = weights_path
+        self.clip_model = clip_model
+        self.device = device
+
+        self._clip = None
+        self._processor = None
+        self._mlp = None
+
+    def _lazy_init(self):
+        if self._mlp is not None:
+            return
+
+        import os
+
+        if self.weights_path is None or not os.path.isfile(self.weights_path):
+            raise FileNotFoundError(
+                "Aesthetic predictor weights not found. Provide a valid "
+                "`weights_path` pointing to the LAION aesthetic MLP head "
+                "(e.g. 'sac+logos+ava1-l14-linearMSE.pth'). "
+                f"Got: {self.weights_path!r}. Phase 1 does not silently fall "
+                "back to a zero reward, because that would produce a flat, "
+                "uninformative training signal."
+            )
+
+        import torch
+        import torch.nn as nn
+        from transformers import CLIPModel, CLIPProcessor
+
+        self._clip = CLIPModel.from_pretrained(self.clip_model).to(self.device)
+        self._clip.requires_grad_(False)
+        self._processor = CLIPProcessor.from_pretrained(self.clip_model)
+
+        # The LAION aesthetic MLP head over 768-d CLIP embeddings.
+        mlp = nn.Sequential(
+            nn.Linear(768, 1024),
+            nn.Dropout(0.2),
+            nn.Linear(1024, 128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 64),
+            nn.Dropout(0.1),
+            nn.Linear(64, 16),
+            nn.Linear(16, 1),
+        )
+        state = torch.load(self.weights_path, map_location="cpu", weights_only=True)
+        # The official LAION checkpoint stores its head as an ``nn.Module`` whose
+        # submodule is named ``layers`` (keys like ``layers.0.weight``), whereas
+        # the bare ``nn.Sequential`` above expects keys like ``0.weight``. Strip
+        # the leading ``layers.`` prefix so the state dict loads cleanly.
+        if any(k.startswith("layers.") for k in state):
+            state = {
+                (k[len("layers.") :] if k.startswith("layers.") else k): v
+                for k, v in state.items()
+            }
+        mlp.load_state_dict(state)
+        self._mlp = mlp.to(self.device).eval()
+        logger.info(
+            f"Loaded aesthetic scorer: clip={self.clip_model}, "
+            f"weights={self.weights_path}"
+        )
+
+    def _extract_image_embedding(self, pixel_values):
+        """Return the projected CLIP image embedding across transformers versions."""
+        import torch
+
+        vision_outputs = self._clip.vision_model(pixel_values=pixel_values)
+        pooled_output = getattr(vision_outputs, "pooler_output", None)
+        if pooled_output is None and isinstance(vision_outputs, tuple):
+            if len(vision_outputs) < 2:
+                raise TypeError(
+                    "CLIP vision_model returned a tuple without pooler_output."
+                )
+            pooled_output = vision_outputs[1]
+        if not isinstance(pooled_output, torch.Tensor):
+            raise TypeError(
+                "CLIP vision_model did not expose a tensor pooler_output."
+            )
+        return self._clip.visual_projection(pooled_output)
+
+    def score(self, image: Image) -> float:
+        """Return the aesthetic score (typically 1-10) for a single image."""
+        self._lazy_init()
+
+        import torch
+        import torch.nn.functional as F
+
+        inputs = self._processor(images=image, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            embed = self._extract_image_embedding(inputs["pixel_values"])
+            # LAION head expects L2-normalized embeddings.
+            embed = F.normalize(embed, dim=-1)
+            score = self._mlp(embed.float())
+        return float(score.squeeze().item())
+
+
+def make_aesthetic_reward_fn(
+    weights_path: str | None = None,
+    clip_model: str = _DEFAULT_CLIP_MODEL,
+    device: str = "cuda",
+):
+    """Build a reward function closing over a cached :class:`AestheticScorer`.
+
+    Returns:
+        A callable ``reward_fn(prompt, image, **kwargs) -> float`` suitable for
+        the diffusion rollout workflow. The scorer is instantiated once and
+        reused across calls (lazy backbone load on first invocation).
+    """
+    scorer = AestheticScorer(
+        weights_path=weights_path, clip_model=clip_model, device=device
+    )
+
+    def aesthetic_reward_fn(prompt: str, image: Image, **kwargs) -> float:
+        return scorer.score(image)
+
+    return aesthetic_reward_fn

--- a/areal/experimental/diffusion/diffusion_api.py
+++ b/areal/experimental/diffusion/diffusion_api.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Data contracts for diffusion RL post-training.
+
+These dataclasses are intentionally kept separate from the token-centric
+``ModelRequest`` / ``ModelResponse`` in :mod:`areal.api.io_struct`. Diffusion
+trajectories (latents, timesteps, per-step log-probs) do not map naturally onto
+token sequences, so polluting the LLM path with diffusion-specific fields would
+break the existing abstractions. Phase 1 therefore defines parallel structs that
+live entirely under ``areal.experimental.diffusion``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+    from PIL.Image import Image
+
+
+@dataclass
+class DiffusionModelRequest:
+    """A single text-to-image generation request for RL rollout.
+
+    Mirrors the role of :class:`areal.api.io_struct.ModelRequest` but carries
+    diffusion sampling parameters instead of token / generation hyperparameters.
+
+    Args:
+        rid: Unique request id (used for tracing / grouping).
+        prompt: Text prompt fed to the text encoder.
+        num_inference_steps: Number of denoising steps. Each step produces one
+            recorded log-prob, so this also defines the trajectory length.
+        guidance_scale: Classifier-free guidance scale.
+        eta: DDIM stochasticity coefficient. ``eta > 0`` turns sampling into a
+            stochastic process whose transition kernel has a tractable Gaussian
+            log-density -- this is what makes per-step log-probs (and therefore
+            policy-gradient training) possible. ``eta == 0`` is deterministic
+            DDIM and yields no usable log-prob signal.
+        height: Output image height in pixels.
+        width: Output image width in pixels.
+        seed: Optional RNG seed for reproducible sampling.
+        metadata: Free-form per-request metadata propagated to the response.
+    """
+
+    rid: str
+    prompt: str
+    num_inference_steps: int = 50
+    guidance_scale: float = 7.5
+    eta: float = 1.0
+    height: int = 512
+    width: int = 512
+    seed: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.num_inference_steps <= 0:
+            raise ValueError(
+                f"num_inference_steps must be positive, got {self.num_inference_steps}"
+            )
+        if not 0.0 <= self.eta <= 1.0:
+            raise ValueError(f"eta must be in [0, 1], got {self.eta}")
+        if self.height <= 0 or self.width <= 0:
+            raise ValueError(
+                f"height/width must be positive, got {self.height}x{self.width}"
+            )
+
+
+@dataclass
+class DiffusionModelResponse:
+    """The denoising trajectory produced for one :class:`DiffusionModelRequest`.
+
+    Mirrors the role of :class:`areal.api.io_struct.ModelResponse`. The fields
+    ``latents`` / ``timesteps`` / ``step_logprobs`` together form the
+    trajectory consumed by the step-level GRPO loss in
+    :mod:`areal.experimental.diffusion.diffusion_loss`.
+
+    Args:
+        prompt: The prompt that generated this trajectory.
+        image: Final decoded image (PIL image), used for reward scoring.
+        latents: Per-step latent tensors along the denoising trajectory. Length
+            equals ``num_steps + 1`` (initial noise plus one latent per step).
+        timesteps: Scheduler timesteps visited during denoising. Length equals
+            ``num_steps``.
+        step_logprobs: Per-step log-probability of the sampled transition under
+            the policy (the DDIM-with-eta Gaussian kernel). Length equals
+            ``num_steps``. Shape per element: scalar (summed over latent dims).
+        version: Weight version that produced this trajectory (for async
+            staleness control in Phase 2).
+        latency: Wall-clock sampling latency in seconds.
+        metadata: Metadata propagated from the originating request.
+    """
+
+    prompt: str
+    image: Image
+    latents: list[torch.Tensor]
+    timesteps: list[int]
+    step_logprobs: list[torch.Tensor]
+    version: int = -1
+    latency: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def num_steps(self) -> int:
+        """Number of denoising steps in this trajectory."""
+        return len(self.step_logprobs)

--- a/areal/experimental/diffusion/diffusion_engine.py
+++ b/areal/experimental/diffusion/diffusion_engine.py
@@ -1,0 +1,520 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference engine for diffusion RL rollout.
+
+Design note -- why this does NOT subclass ``InferenceEngine``:
+
+``areal.api.engine_api.InferenceEngine.agenerate`` has the concrete signature
+``agenerate(req: ModelRequest) -> ModelResponse``. If we subclassed it and
+narrowed the parameter to ``DiffusionModelRequest``, any caller typed against
+``InferenceEngine`` would receive an unexpected type -- a Liskov substitution
+violation. We therefore implement a *parallel* engine with its own
+``agenerate(req: DiffusionModelRequest) -> DiffusionModelResponse``.
+
+The trade-off: this engine cannot be plugged into the async
+``engine.submit(workflow=...)`` scheduler (which is typed against
+``InferenceEngine``). Phase 1 drives it with a synchronous loop instead; Phase 2
+will introduce an adapter to bridge into the async path. This is a known,
+deliberately surfaced piece of technical debt.
+
+Heavy optional dependencies (``diffusers``, ``torch``) are imported lazily
+inside methods so that importing this module never drags in the diffusion stack.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import TYPE_CHECKING
+
+from areal.experimental.diffusion.diffusion_api import (
+    DiffusionModelRequest,
+    DiffusionModelResponse,
+)
+from areal.utils import logging
+
+if TYPE_CHECKING:
+    import torch
+
+logger = logging.getLogger("DiffusionInferenceEngine")
+
+
+class DiffusionInferenceEngine:
+    """Wraps a diffusers Stable Diffusion pipeline for RL rollout.
+
+    Phase 1 targets single-GPU SD1.5 + LoRA. The engine performs DDIM-with-eta
+    sampling and records the per-step log-probability of each sampled transition,
+    which downstream code turns into a policy-gradient signal.
+
+    Args:
+        model_path: HuggingFace model id or local path to the SD1.5 checkpoint.
+        dtype: Torch dtype for the pipeline (``"float16"`` / ``"float32"`` /
+            ``"bfloat16"``).
+        device: Device to place the pipeline on (e.g. ``"cuda"``).
+        lora_rank: Rank of the LoRA adapter injected into the UNet. Set to 0 to
+            train the full UNet (not recommended for Phase 1).
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        dtype: str = "float16",
+        device: str = "cuda",
+        lora_rank: int = 8,
+    ):
+        self.model_path = model_path
+        self.dtype_str = dtype
+        self.device = device
+        self.lora_rank = lora_rank
+
+        self.pipe = None
+        self.unet = None
+        self.scheduler = None
+        self._version = 0
+
+    def initialize(self):
+        """Load the SD pipeline and inject a trainable LoRA adapter into the UNet."""
+        import torch
+        from diffusers import DDIMScheduler, StableDiffusionPipeline
+
+        dtype = getattr(torch, self.dtype_str)
+        pipe = StableDiffusionPipeline.from_pretrained(
+            self.model_path, torch_dtype=dtype
+        )
+        # DDIM scheduler is required for the eta-parameterized stochastic sampler.
+        pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
+        pipe = pipe.to(self.device)
+
+        # Freeze everything except the LoRA adapter on the UNet.
+        pipe.vae.requires_grad_(False)
+        pipe.text_encoder.requires_grad_(False)
+        pipe.unet.requires_grad_(False)
+
+        if self.lora_rank > 0:
+            from peft import LoraConfig
+
+            lora_config = LoraConfig(
+                r=self.lora_rank,
+                lora_alpha=self.lora_rank,
+                init_lora_weights="gaussian",
+                target_modules=["to_k", "to_q", "to_v", "to_out.0"],
+            )
+            pipe.unet.add_adapter(lora_config)
+            # Re-enable grad only for LoRA params.
+            for name, param in pipe.unet.named_parameters():
+                param.requires_grad_("lora" in name)
+
+        self.pipe = pipe
+        self.unet = pipe.unet
+        self.scheduler = pipe.scheduler
+        logger.info(
+            f"Initialized diffusion engine: model={self.model_path}, "
+            f"dtype={self.dtype_str}, lora_rank={self.lora_rank}"
+        )
+
+    async def agenerate(self, req: DiffusionModelRequest) -> DiffusionModelResponse:
+        """Sample one denoising trajectory and record per-step log-probs.
+
+        The method is ``async`` to mirror the inference-engine contract, but
+        Phase 1 runs the denoising loop synchronously (diffusers is not async).
+
+        Args:
+            req: The generation request describing prompt and sampling params.
+
+        Returns:
+            A :class:`DiffusionModelResponse` carrying the final image plus the
+            full latent / timestep / log-prob trajectory.
+        """
+        if self.pipe is None:
+            raise RuntimeError("Engine not initialized; call initialize() first.")
+
+        import torch
+
+        start = time.perf_counter()
+        device = self.device
+        dtype = getattr(torch, self.dtype_str)
+
+        generator = None
+        if req.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.seed)
+
+        # ---- Text conditioning (with classifier-free guidance) ----
+        prompt_embeds, negative_embeds = self._encode_prompt(req.prompt)
+        text_embeddings = torch.cat([negative_embeds, prompt_embeds], dim=0)
+
+        # ---- Initial latent noise ----
+        num_channels = self.unet.config.in_channels
+        latent_h = req.height // self.pipe.vae_scale_factor
+        latent_w = req.width // self.pipe.vae_scale_factor
+        latents = torch.randn(
+            (1, num_channels, latent_h, latent_w),
+            generator=generator,
+            device=device,
+            dtype=dtype,
+        )
+        latents = latents * self.scheduler.init_noise_sigma
+
+        self.scheduler.set_timesteps(req.num_inference_steps, device=device)
+        timesteps = self.scheduler.timesteps
+
+        latents_traj: list[torch.Tensor] = [latents.detach().cpu()]
+        step_logprobs: list[torch.Tensor] = []
+        visited_timesteps: list[int] = []
+
+        for t in timesteps:
+            # Duplicate latents for CFG (unconditional + conditional).
+            latent_model_input = torch.cat([latents] * 2)
+            latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
+
+            with torch.no_grad():
+                noise_pred = self.unet(
+                    latent_model_input, t, encoder_hidden_states=text_embeddings
+                ).sample
+
+            noise_uncond, noise_cond = noise_pred.chunk(2)
+            noise_pred = noise_uncond + req.guidance_scale * (noise_cond - noise_uncond)
+
+            latents, logprob = self._ddim_step_with_logprob(
+                noise_pred, t, latents, eta=req.eta, generator=generator
+            )
+            latents_traj.append(latents.detach().cpu())
+            step_logprobs.append(logprob.detach().cpu())
+            visited_timesteps.append(int(t))
+
+        image = self._decode_latents(latents)
+        latency = time.perf_counter() - start
+
+        return DiffusionModelResponse(
+            prompt=req.prompt,
+            image=image,
+            latents=latents_traj,
+            timesteps=visited_timesteps,
+            step_logprobs=step_logprobs,
+            version=self._version,
+            latency=latency,
+            metadata=dict(req.metadata),
+        )
+
+    def _ddim_coeffs(self, timestep: torch.Tensor):
+        """Recover the per-timestep DDIM coefficients.
+
+        Pulled out so that both the rollout sampler and the gradient-enabled
+        recompute path use *exactly* the same scheduler math (no divergence).
+        Returns ``(alpha_prod_t, alpha_prod_t_prev, beta_prod_t)``.
+        """
+        import torch
+
+        scheduler = self.scheduler
+        prev_timestep = (
+            timestep
+            - scheduler.config.num_train_timesteps // scheduler.num_inference_steps
+        )
+        # Keep everything on the timestep's device and branch with ``torch.where``
+        # instead of a Python ``if`` on a GPU tensor: evaluating ``prev_timestep >= 0``
+        # in a Python conditional forces a device-to-host sync on every denoising
+        # step, which is a hot-path stall during both rollout and training.
+        alphas_cumprod = scheduler.alphas_cumprod.to(device=timestep.device)
+        alpha_prod_t = alphas_cumprod[timestep]
+        prev_timestep_clipped = prev_timestep.clamp(min=0)
+        alpha_prod_t_prev = torch.where(
+            prev_timestep >= 0,
+            alphas_cumprod[prev_timestep_clipped],
+            torch.as_tensor(
+                scheduler.final_alpha_cumprod,
+                device=timestep.device,
+                dtype=alphas_cumprod.dtype,
+            ),
+        )
+        beta_prod_t = 1 - alpha_prod_t
+        return alpha_prod_t, alpha_prod_t_prev, beta_prod_t
+
+    @staticmethod
+    def _ddim_mean_and_std(
+        noise_pred: torch.Tensor,
+        x_t: torch.Tensor,
+        alpha_prod_t,
+        alpha_prod_t_prev,
+        beta_prod_t,
+        eta: float,
+    ):
+        """Compute the Gaussian transition mean ``mu`` and std ``sigma``.
+
+        This is the single source of truth for the DDIM-with-eta kernel; it is
+        shared between sampling (``_ddim_step_with_logprob``) and the
+        gradient-enabled recompute (``_ddim_logprob_given_samples``) so that the
+        two can never drift apart numerically.
+        """
+        # ---- Predicted original sample x_0 (epsilon prediction) ----
+        pred_original = (x_t - beta_prod_t ** (0.5) * noise_pred) / alpha_prod_t ** (
+            0.5
+        )
+        # ---- Stochastic noise std controlled by eta ----
+        variance = (
+            (1 - alpha_prod_t_prev)
+            / (1 - alpha_prod_t)
+            * (1 - alpha_prod_t / alpha_prod_t_prev)
+        )
+        # Clamp before the square root: in float16/bfloat16, underflow or rounding
+        # can push ``variance`` (or the direction term below) slightly negative,
+        # and ``(<0) ** 0.5`` yields NaN that then propagates through the whole
+        # trajectory and destabilizes training.
+        std_dev_t = eta * variance.clamp(min=0.0) ** (0.5)
+        # ---- Direction pointing to x_t (uses the std-corrected coefficient) ----
+        pred_sample_direction = (1 - alpha_prod_t_prev - std_dev_t**2).clamp(
+            min=0.0
+        ) ** (0.5) * noise_pred
+        mean = alpha_prod_t_prev ** (0.5) * pred_original + pred_sample_direction
+        return mean, std_dev_t
+
+    @staticmethod
+    def _gaussian_logprob(x: torch.Tensor, mean: torch.Tensor, std) -> torch.Tensor:
+        """Per-sample Gaussian log-density, averaged over channel/spatial dims.
+
+        ``log N(x; mu, sigma^2) = -0.5*((x-mu)^2/sigma^2 + log(2*pi*sigma^2))``.
+        Differentiable w.r.t. ``mean`` (and therefore w.r.t. ``noise_pred`` /
+        the UNet params when ``mean`` carries grad).
+        """
+        import torch
+
+        std = std + 1e-8
+        # Use ``torch.log(std)`` rather than ``math.log(float(std))``: calling
+        # ``float()`` on a CUDA tensor forces a device-to-host sync every step
+        # (and breaks outright once ``std`` is non-scalar). Keep it on-device.
+        log_prob = -0.5 * (
+            ((x - mean) ** 2) / (std**2) + 2 * torch.log(std) + math.log(2 * math.pi)
+        )
+        return log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+
+    def _ddim_step_with_logprob(
+        self,
+        noise_pred: torch.Tensor,
+        timestep: torch.Tensor,
+        latents: torch.Tensor,
+        eta: float,
+        generator=None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """One DDIM-with-eta step that also returns the transition log-prob.
+
+        Follows the stochastic DDIM formulation used by ddpo-pytorch: the
+        forward transition ``p(x_{t-1} | x_t)`` is Gaussian with mean given by
+        the deterministic DDIM update and standard deviation ``sigma_t`` set by
+        ``eta``. We sample ``x_{t-1}`` from this Gaussian and evaluate its
+        log-density, summed over all latent dimensions.
+
+        Used during rollout (under ``no_grad``); the gradient-enabled twin is
+        :meth:`_ddim_logprob_given_samples`, which reuses the same kernel math.
+        """
+        import torch
+
+        alpha_prod_t, alpha_prod_t_prev, beta_prod_t = self._ddim_coeffs(timestep)
+        prev_sample_mean, std_dev_t = self._ddim_mean_and_std(
+            noise_pred, latents, alpha_prod_t, alpha_prod_t_prev, beta_prod_t, eta
+        )
+
+        # ---- Sample x_{t-1} ~ N(mean, std^2 I) ----
+        noise = torch.randn(
+            latents.shape,
+            generator=generator,
+            device=latents.device,
+            dtype=latents.dtype,
+        )
+        prev_sample = prev_sample_mean + std_dev_t * noise
+        log_prob = self._gaussian_logprob(prev_sample, prev_sample_mean, std_dev_t)
+        return prev_sample, log_prob
+
+    def _ddim_logprob_given_samples(
+        self,
+        noise_pred: torch.Tensor,
+        timestep: torch.Tensor,
+        x_t: torch.Tensor,
+        x_prev: torch.Tensor,
+        eta: float,
+    ) -> torch.Tensor:
+        """Gradient-enabled log-prob of an *already sampled* transition.
+
+        Teacher-forcing: given the recorded ``x_t`` (input latent) and the
+        actually sampled ``x_prev`` (the next latent), recompute the Gaussian
+        kernel mean from a fresh ``noise_pred`` (carrying grad through the UNet)
+        and evaluate ``log p(x_prev | x_t)``. Because ``x_prev`` is treated as a
+        fixed observation while ``mean`` depends on the UNet, the returned
+        log-prob is differentiable w.r.t. the LoRA parameters.
+
+        Reuses the exact same kernel math as the sampler via
+        ``_ddim_mean_and_std`` -- so the recomputed log-prob is consistent with
+        the rollout-time value (modulo the policy weight update).
+        """
+        alpha_prod_t, alpha_prod_t_prev, beta_prod_t = self._ddim_coeffs(timestep)
+        mean, std_dev_t = self._ddim_mean_and_std(
+            noise_pred, x_t, alpha_prod_t, alpha_prod_t_prev, beta_prod_t, eta
+        )
+        return self._gaussian_logprob(x_prev, mean, std_dev_t)
+
+    def iter_step_logprobs(
+        self,
+        latents_traj: list[torch.Tensor],
+        timesteps: list[int],
+        prompt: str,
+        eta: float,
+        guidance_scale: float,
+    ):
+        """Yield the per-step differentiable log-prob *one denoising step at a time*.
+
+        This is the memory-efficient twin of :meth:`recompute_step_logprobs`.
+        Instead of building the whole trajectory's autograd graph and stacking
+        all step log-probs (peak memory grows linearly with ``num_steps`` and
+        OOMs on a single GPU), this generator yields each step's scalar log-prob
+        as soon as it is computed. The caller is expected to immediately
+        ``backward()`` the (advantage-weighted) step loss and let autograd free
+        that step's graph before the next step is produced.
+
+        Mathematically this enables *exact* gradient accumulation for the
+        REINFORCE surrogate, because the trajectory loss
+        ``-(1/T) * sum_t logprob_t * advantage`` is linear in the per-step
+        log-probs: accumulating ``grad[-(advantage/T) * logprob_t]`` over steps
+        equals ``grad`` of the summed loss. Peak activation memory stays at
+        roughly a single step instead of ``T`` steps.
+
+        Args:
+            latents_traj: Recorded latent trajectory, length ``num_steps+1``
+                (``latents_traj[i]`` is the input ``x_t`` of step ``i``;
+                ``latents_traj[i+1]`` is the sampled ``x_prev``). May live on CPU.
+            timesteps: Scheduler timesteps visited, length ``num_steps``.
+            prompt: Prompt used for this trajectory (for CFG conditioning).
+            eta: DDIM stochasticity coefficient used during rollout.
+            guidance_scale: CFG scale used during rollout.
+
+        Yields:
+            For each denoising step, a differentiable scalar (``()``-shaped)
+            log-prob tensor carrying grad to the LoRA parameters.
+        """
+        if self.pipe is None:
+            raise RuntimeError("Engine not initialized; call initialize() first.")
+
+        import torch
+
+        device = self.device
+        dtype = getattr(torch, self.dtype_str)
+
+        prompt_embeds, negative_embeds = self._encode_prompt(prompt)
+        text_embeddings = torch.cat([negative_embeds, prompt_embeds], dim=0)
+
+        self.scheduler.set_timesteps(len(timesteps), device=device)
+
+        for i, t in enumerate(timesteps):
+            x_t = latents_traj[i].to(device=device, dtype=dtype)
+            x_prev = latents_traj[i + 1].to(device=device, dtype=dtype)
+            t_tensor = torch.as_tensor(t, device=device)
+
+            latent_model_input = torch.cat([x_t] * 2)
+            latent_model_input = self.scheduler.scale_model_input(
+                latent_model_input, t_tensor
+            )
+            # NOTE: grad ENABLED here (no torch.no_grad) so log_prob flows to LoRA.
+            noise_pred = self.unet(
+                latent_model_input, t_tensor, encoder_hidden_states=text_embeddings
+            ).sample
+            noise_uncond, noise_cond = noise_pred.chunk(2)
+            noise_pred = noise_uncond + guidance_scale * (noise_cond - noise_uncond)
+
+            logprob = self._ddim_logprob_given_samples(
+                noise_pred, t_tensor, x_t, x_prev, eta
+            )
+            yield logprob.reshape(())
+
+    def recompute_step_logprobs(
+        self,
+        latents_traj: list[torch.Tensor],
+        timesteps: list[int],
+        prompt: str,
+        eta: float,
+        guidance_scale: float,
+    ) -> torch.Tensor:
+        """Recompute the per-step log-probs of a recorded trajectory *under grad*.
+
+        This is the fix for the "gradient backflow gap": the rollout-time
+        log-probs are detached, so the training step must re-evaluate each
+        denoising transition through the (now LoRA-updated) UNet to obtain a
+        differentiable log-prob.
+
+        .. warning::
+            This builds the autograd graph for the *entire* trajectory at once,
+            so peak memory grows linearly with ``num_steps`` and can OOM on a
+            single GPU. For training prefer :meth:`iter_step_logprobs` with
+            per-step gradient accumulation. This method is kept for parity tests
+            and small-trajectory use.
+
+        Args:
+            latents_traj: The recorded latent trajectory, length ``num_steps+1``
+                (``latents_traj[i]`` is the input ``x_t`` of step ``i``;
+                ``latents_traj[i+1]`` is the sampled ``x_prev``). May live on
+                CPU; tensors are moved to the engine device.
+            timesteps: The scheduler timesteps visited, length ``num_steps``.
+            prompt: The prompt used for this trajectory (for CFG conditioning).
+            eta: DDIM stochasticity coefficient used during rollout.
+            guidance_scale: CFG scale used during rollout.
+
+        Returns:
+            A differentiable ``[num_steps]`` tensor of step log-probs.
+        """
+        import torch
+
+        logprobs = list(
+            self.iter_step_logprobs(
+                latents_traj, timesteps, prompt, eta, guidance_scale
+            )
+        )
+        return torch.stack(logprobs)
+
+    def _encode_prompt(self, prompt: str) -> tuple[torch.Tensor, torch.Tensor]:
+        """Encode prompt and an empty negative prompt for CFG."""
+        import torch
+
+        tokenizer = self.pipe.tokenizer
+        text_encoder = self.pipe.text_encoder
+
+        def _embed(text: str) -> torch.Tensor:
+            tokens = tokenizer(
+                text,
+                padding="max_length",
+                max_length=tokenizer.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            )
+            with torch.no_grad():
+                return text_encoder(tokens.input_ids.to(self.device))[0]
+
+        return _embed(prompt), _embed("")
+
+    def _decode_latents(self, latents: torch.Tensor):
+        """Decode latents into a PIL image via the VAE."""
+        import torch
+
+        latents = latents / self.pipe.vae.config.scaling_factor
+        with torch.no_grad():
+            image = self.pipe.vae.decode(latents).sample
+        image = (image / 2 + 0.5).clamp(0, 1)
+        image = image.cpu().permute(0, 2, 3, 1).float().numpy()[0]
+        from PIL import Image
+
+        return Image.fromarray((image * 255).round().astype("uint8"))
+
+    def set_version(self, version: int):
+        """Set the current weight version tag."""
+        self._version = version
+
+    def get_version(self) -> int:
+        """Return the current weight version tag."""
+        return self._version
+
+    def save(self, path: str):
+        """Save the LoRA adapter weights to ``path``."""
+        if self.unet is None:
+            raise RuntimeError("Engine not initialized.")
+        self.unet.save_pretrained(path)
+        logger.info(f"Saved LoRA adapter to {path}")
+
+    def load(self, path: str):
+        """Load LoRA adapter weights from ``path``."""
+        if self.unet is None:
+            raise RuntimeError("Engine not initialized.")
+        self.unet.load_adapter(path)
+        logger.info(f"Loaded LoRA adapter from {path}")

--- a/areal/experimental/diffusion/diffusion_loss.py
+++ b/areal/experimental/diffusion/diffusion_loss.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GRPO advantage and step-level policy loss for diffusion RL.
+
+Two pieces live here:
+
+1. ``compute_group_advantages`` -- group-relative advantage normalization. This
+   is modality-agnostic (it operates on scalar rewards), so it reuses the same
+   normalization primitive (:func:`areal.utils.functional.masked_normalization`)
+   that the LLM GRPO path uses.
+
+2. ``diffusion_grpo_loss_fn`` -- the diffusion-specific policy loss. Unlike the
+   LLM case (token-level ``logprob * advantage``), the diffusion trajectory is a
+   sequence of *denoising steps*; each UNet prediction yields one step log-prob.
+   The whole trajectory shares a single terminal advantage (the reward can only
+   be computed from the final image). When ``old_logprobs`` is supplied we use a
+   PPO-style clipped ratio surrogate ``min(r*A, clip(r)*A)`` with
+   ``r = exp(new_logprob - old_logprob)``; when it is ``None`` we fall back to
+   the plain REINFORCE surrogate ``- mean_t(logprob_t) * advantage``. Both
+   mirror the ddpo-pytorch / TRL ``DDPOTrainer`` formulation. The PPO form is
+   what enables off-policy reuse in Phase 2; in Phase 1 the single on-policy
+   step has ``new == old`` so the ratio is ~1 and the two forms coincide.
+
+The loss callable is shaped to be consumed by
+``TrainEngine.train_batch(input_, loss_fn, loss_weight_fn)``: it accepts the
+model output and the input dict, and returns a scalar loss.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from areal.utils import logging
+from areal.utils.functional import masked_normalization
+
+logger = logging.getLogger("DiffusionGRPOLoss")
+
+
+def compute_group_advantages(
+    rewards: torch.Tensor,
+    group_size: int,
+    eps: float = 1e-5,
+) -> torch.Tensor:
+    """Group-relative advantage: normalize rewards within each prompt group.
+
+    Args:
+        rewards: 1-D tensor of scalar rewards, shape ``[num_prompts * group_size]``,
+            laid out group-contiguously (all samples of prompt 0, then prompt 1, ...).
+        group_size: Number of samples per prompt group.
+        eps: Numerical stabilizer for the per-group std.
+
+    Returns:
+        Advantages with the same shape as ``rewards``, normalized within each
+        group (zero mean, unit variance per group).
+    """
+    if rewards.ndim != 1:
+        raise ValueError(f"rewards must be 1-D, got shape {tuple(rewards.shape)}")
+    if rewards.numel() % group_size != 0:
+        raise ValueError(
+            f"rewards length {rewards.numel()} not divisible by group_size {group_size}"
+        )
+
+    grouped = rewards.view(-1, group_size)
+    # Per-group normalization; disable distributed all-reduce because grouping is
+    # local to the rollout buffer in Phase 1 (single process). ``dim`` must be a
+    # tuple: masked_normalization iterates over it.
+    normalized = masked_normalization(grouped, dim=(1,), eps=eps, all_reduce=False)
+    return normalized.reshape(-1)
+
+
+def diffusion_grpo_loss_fn(
+    step_logprobs: torch.Tensor,
+    advantages: torch.Tensor,
+    loss_mask: torch.Tensor | None = None,
+    old_logprobs: torch.Tensor | None = None,
+    clip_eps: float = 0.2,
+) -> torch.Tensor:
+    """Step-level GRPO policy loss for a batch of diffusion trajectories.
+
+    Args:
+        step_logprobs: Per-step log-probs, shape ``[batch, num_steps]``. These
+            must be *differentiable* (recomputed under grad during training,
+            not the detached rollout-time values).
+        advantages: Per-trajectory advantages, shape ``[batch]``. Broadcast
+            across all steps of a trajectory.
+        loss_mask: Optional ``[batch, num_steps]`` mask for variable-length
+            trajectories. ``None`` means all steps are valid.
+        old_logprobs: Optional detached rollout-time per-step log-probs, same
+            shape as ``step_logprobs``. When provided, a PPO-style clipped ratio
+            surrogate is used; when ``None``, plain REINFORCE is used.
+        clip_eps: PPO clip range (only used when ``old_logprobs`` is provided).
+
+    Returns:
+        Scalar policy loss (to be minimized).
+    """
+    if step_logprobs.ndim != 2:
+        raise ValueError(
+            f"step_logprobs must be [batch, num_steps], got "
+            f"{tuple(step_logprobs.shape)}"
+        )
+    if advantages.ndim != 1 or advantages.shape[0] != step_logprobs.shape[0]:
+        raise ValueError(
+            f"advantages must be [batch] matching step_logprobs batch dim; "
+            f"got advantages {tuple(advantages.shape)} vs "
+            f"step_logprobs {tuple(step_logprobs.shape)}"
+        )
+    if old_logprobs is not None and old_logprobs.shape != step_logprobs.shape:
+        raise ValueError(
+            f"old_logprobs must match step_logprobs shape; got "
+            f"{tuple(old_logprobs.shape)} vs {tuple(step_logprobs.shape)}"
+        )
+
+    # Mean log-prob per trajectory over its denoising steps.
+    if loss_mask is None:
+        traj_logprob = step_logprobs.mean(dim=1)
+    else:
+        denom = loss_mask.sum(dim=1).clamp_min(1.0)
+        traj_logprob = (step_logprobs * loss_mask).sum(dim=1) / denom
+
+    if old_logprobs is None:
+        # Plain REINFORCE surrogate: maximize advantage-weighted log-prob.
+        loss = -(traj_logprob * advantages).mean()
+        return loss
+
+    # PPO-style clipped ratio surrogate. old_logprobs are the detached
+    # rollout-time values; the ratio is per-trajectory (mean over steps).
+    if loss_mask is None:
+        old_traj_logprob = old_logprobs.mean(dim=1)
+    else:
+        denom = loss_mask.sum(dim=1).clamp_min(1.0)
+        old_traj_logprob = (old_logprobs * loss_mask).sum(dim=1) / denom
+    old_traj_logprob = old_traj_logprob.detach()
+
+    ratio = torch.exp(traj_logprob - old_traj_logprob)
+    surr1 = ratio * advantages
+    surr2 = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * advantages
+    loss = -torch.minimum(surr1, surr2).mean()
+    return loss

--- a/areal/experimental/diffusion/diffusion_workflow.py
+++ b/areal/experimental/diffusion/diffusion_workflow.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rollout workflow for diffusion RL post-training.
+
+This subclasses :class:`areal.api.workflow_api.RolloutWorkflow`, whose
+``arun_episode`` returns a loose ``dict[str, Any] | None``. That looseness is
+the key enabler for a non-invasive design: we pack the diffusion trajectory
+(latents / timesteps / step log-probs / rewards / advantages) into the returned
+dict without touching any base-class signature or the token-centric LLM path.
+
+The returned dict is consumed by
+:func:`areal.experimental.diffusion.diffusion_loss.diffusion_grpo_loss_fn`
+during the training step.
+
+Note: the ``engine`` argument is a
+:class:`~areal.experimental.diffusion.diffusion_engine.DiffusionInferenceEngine`,
+which deliberately does NOT inherit ``InferenceEngine`` (see that module's
+docstring). Phase 1 therefore drives this workflow with a synchronous rollout
+loop rather than the async ``engine.submit`` scheduler.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from areal import workflow_context
+from areal.api.workflow_api import RolloutWorkflow
+from areal.experimental.diffusion.diffusion_api import DiffusionModelRequest
+from areal.experimental.diffusion.diffusion_loss import compute_group_advantages
+from areal.utils import logging, stats_tracker
+
+if TYPE_CHECKING:
+    from areal.experimental.diffusion.diffusion_engine import (
+        DiffusionInferenceEngine,
+    )
+
+logger = logging.getLogger("DiffusionRolloutWorkflow")
+
+
+class DiffusionRolloutWorkflow(RolloutWorkflow):
+    """Generate a group of denoising trajectories and score them.
+
+    For each prompt the workflow samples ``group_size`` trajectories, scores the
+    final images with ``reward_fn``, and computes group-relative advantages. The
+    resulting trajectory tensors are returned for the training step.
+
+    Args:
+        reward_fn: Callable ``(prompt, image, **kwargs) -> float``. In Phase 1
+            this is invoked synchronously in the main process (see
+            ``aesthetic_reward`` for the rationale).
+        group_size: Number of samples per prompt (the GRPO group).
+        num_inference_steps: Denoising steps per trajectory.
+        guidance_scale: Classifier-free guidance scale.
+        eta: DDIM stochasticity coefficient (must be > 0 for usable log-probs).
+        height: Output image height.
+        width: Output image width.
+    """
+
+    def __init__(
+        self,
+        reward_fn: Callable[..., float],
+        group_size: int = 8,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 7.5,
+        eta: float = 1.0,
+        height: int = 512,
+        width: int = 512,
+    ):
+        if eta <= 0:
+            raise ValueError(
+                f"eta must be > 0 for policy-gradient training (no log-prob "
+                f"signal otherwise); got {eta}"
+            )
+        self.reward_fn = reward_fn
+        self.group_size = group_size
+        self.num_inference_steps = num_inference_steps
+        self.guidance_scale = guidance_scale
+        self.eta = eta
+        self.height = height
+        self.width = width
+
+    async def arun_episode(
+        self, engine: DiffusionInferenceEngine, data: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Sample a GRPO group for one prompt and return its trajectory tensors.
+
+        Args:
+            engine: The diffusion inference engine.
+            data: A data item containing at least a ``"prompt"`` field.
+
+        Returns:
+            A dict carrying the batched trajectory:
+            ``old_step_logprobs`` ``[group_size, num_steps]`` (rollout-time,
+            detached -- the PPO "old" policy log-probs),
+            ``advantages`` ``[group_size]``, ``rewards`` ``[group_size]``,
+            ``latents`` (list of per-sample latent trajectories), ``timesteps``,
+            and ``prompts``. The training step recomputes differentiable
+            log-probs from ``latents``/``timesteps`` via
+            ``engine.recompute_step_logprobs`` (the rollout-time values are
+            detached and cannot backprop). Returns ``None`` if the prompt is
+            missing.
+        """
+        prompt = data.get("prompt")
+        if prompt is None:
+            logger.warning("Data item missing 'prompt'; skipping episode.")
+            return None
+
+        responses = []
+        for _ in range(self.group_size):
+            req = DiffusionModelRequest(
+                rid=str(uuid.uuid4()),
+                prompt=prompt,
+                num_inference_steps=self.num_inference_steps,
+                guidance_scale=self.guidance_scale,
+                eta=self.eta,
+                height=self.height,
+                width=self.width,
+            )
+            resp = await engine.agenerate(req)
+            responses.append(resp)
+
+        # ---- Reward scoring (synchronous, main process) ----
+        rewards = torch.tensor(
+            [float(self.reward_fn(prompt=prompt, image=r.image)) for r in responses],
+            dtype=torch.float32,
+        )
+
+        # ---- Group-relative advantages ----
+        advantages = compute_group_advantages(rewards, group_size=self.group_size)
+
+        # ---- Stack per-step log-probs into [group_size, num_steps] ----
+        step_logprobs = torch.stack(
+            [torch.stack(r.step_logprobs).reshape(-1) for r in responses], dim=0
+        )
+
+        stats_tracker.get(workflow_context.stat_scope()).scalar(
+            diffusion_reward_mean=float(rewards.mean()),
+            diffusion_reward_std=float(rewards.std()),
+        )
+
+        return {
+            "prompts": [prompt] * self.group_size,
+            # Rollout-time (detached) log-probs: the PPO "old" policy. The
+            # training step recomputes the differentiable "new" log-probs from
+            # the recorded latents/timesteps via recompute_step_logprobs.
+            "old_step_logprobs": step_logprobs,
+            "advantages": advantages,
+            "rewards": rewards,
+            "latents": [r.latents for r in responses],
+            "timesteps": [r.timesteps for r in responses],
+        }

--- a/examples/diffusion/prepare_assets.sh
+++ b/examples/diffusion/prepare_assets.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download the model + reward assets needed for the Phase 1 SD1.5 GRPO PoC:
+#   1. SD1.5 base pipeline          (AI-ModelScope/stable-diffusion-v1-5)
+#   2. CLIP ViT-L/14 image encoder  (openai/clip-vit-large-patch14)
+#   3. LAION aesthetic predictor    (sac+logos+ava1-l14-linearMSE.pth)
+#
+# Source selection (SD15_SOURCE):
+#   - "modelscope" (default): pull SD1.5 from ModelScope via its Python SDK.
+#       The original `runwayml/stable-diffusion-v1-5` HF repo was removed by
+#       RunwayML, and the HF community mirror is heavily rate-limited / blocked
+#       from many regions (notably mainland China, where SD1.5 large files crawl
+#       at ~50KB/s). ModelScope's CDN is fast and unmetered for these weights,
+#       so it is the default. Note: the ModelScope repo ships fp32 safetensors
+#       only (no .fp16 variants); loading with torch_dtype=float16 still works
+#       and uses fp16 memory -- it just takes 2x disk.
+#   - "hf": pull SD1.5 from the HuggingFace community mirror
+#       (stable-diffusion-v1-5/stable-diffusion-v1-5) via huggingface-cli.
+#
+# Override the exact repos via SD15_REPO / CLIP_REPO if you have your own copies.
+#
+# Idempotent: existing files are skipped. Nothing here requires sudo or a GPU.
+#
+# Usage:
+#   bash examples/diffusion/prepare_assets.sh [ASSET_DIR]
+#   SD15_SOURCE=hf bash examples/diffusion/prepare_assets.sh [ASSET_DIR]
+#
+# ASSET_DIR defaults to ./assets/diffusion. After running, train with:
+#   python examples/diffusion/sd15_grpo.py \
+#       --model_path  "$ASSET_DIR/stable-diffusion-v1-5" \
+#       --clip_model  "$ASSET_DIR/clip-vit-large-patch14" \
+#       --aesthetic_weights "$ASSET_DIR/sac+logos+ava1-l14-linearMSE.pth" \
+#       --prompt_file examples/diffusion/prompts/aesthetic_prompts.txt
+# (these are also the script defaults, so a bare run picks up the local copies).
+
+set -euo pipefail
+
+ASSET_DIR="${1:-./assets/diffusion}"
+SD15_SOURCE="${SD15_SOURCE:-modelscope}"
+CLIP_REPO="${CLIP_REPO:-openai/clip-vit-large-patch14}"
+AESTHETIC_URL="https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/main/sac+logos+ava1-l14-linearMSE.pth"
+AESTHETIC_FILE="$ASSET_DIR/sac+logos+ava1-l14-linearMSE.pth"
+
+SD15_DEST="$ASSET_DIR/stable-diffusion-v1-5"
+CLIP_DEST="$ASSET_DIR/clip-vit-large-patch14"
+
+mkdir -p "$ASSET_DIR"
+echo "[prepare_assets] target dir: $ASSET_DIR"
+echo "[prepare_assets] SD1.5 source: $SD15_SOURCE"
+
+dir_has_files() {
+  local d="$1"
+  [ -d "$d" ] && [ -n "$(ls -A "$d" 2>/dev/null || true)" ]
+}
+
+# ---- 1: SD1.5 pipeline ----
+if dir_has_files "$SD15_DEST"; then
+  echo "[prepare_assets] skip SD1.5 (already at $SD15_DEST)"
+elif [ "$SD15_SOURCE" = "modelscope" ]; then
+  SD15_REPO="${SD15_REPO:-AI-ModelScope/stable-diffusion-v1-5}"
+  if ! python -c "import modelscope" >/dev/null 2>&1; then
+    echo "[prepare_assets] ERROR: modelscope SDK not found." >&2
+    echo "  Install it with:  uv pip install modelscope" >&2
+    echo "  (or)              pip install modelscope" >&2
+    echo "  Or use the HF mirror instead:  SD15_SOURCE=hf bash $0 $ASSET_DIR" >&2
+    exit 1
+  fi
+  echo "[prepare_assets] downloading $SD15_REPO (ModelScope) -> $SD15_DEST"
+  python - "$SD15_REPO" "$SD15_DEST" <<'PY'
+import sys
+from modelscope import snapshot_download
+
+repo, dest = sys.argv[1], sys.argv[2]
+snapshot_download(repo, local_dir=dest)
+PY
+elif [ "$SD15_SOURCE" = "hf" ]; then
+  SD15_REPO="${SD15_REPO:-stable-diffusion-v1-5/stable-diffusion-v1-5}"
+  if ! command -v huggingface-cli >/dev/null 2>&1; then
+    echo "[prepare_assets] ERROR: huggingface-cli not found." >&2
+    echo "  Install it with:  uv pip install 'huggingface_hub[cli]'" >&2
+    exit 1
+  fi
+  echo "[prepare_assets] downloading $SD15_REPO (HuggingFace) -> $SD15_DEST"
+  huggingface-cli download "$SD15_REPO" --local-dir "$SD15_DEST"
+else
+  echo "[prepare_assets] ERROR: unknown SD15_SOURCE='$SD15_SOURCE' (use 'modelscope' or 'hf')." >&2
+  exit 1
+fi
+
+# ---- 2: CLIP ViT-L/14 (HuggingFace) ----
+if dir_has_files "$CLIP_DEST"; then
+  echo "[prepare_assets] skip CLIP (already at $CLIP_DEST)"
+else
+  if ! command -v huggingface-cli >/dev/null 2>&1; then
+    echo "[prepare_assets] ERROR: huggingface-cli not found (needed for CLIP)." >&2
+    echo "  Install it with:  uv pip install 'huggingface_hub[cli]'" >&2
+    exit 1
+  fi
+  echo "[prepare_assets] downloading $CLIP_REPO (HuggingFace) -> $CLIP_DEST"
+  huggingface-cli download "$CLIP_REPO" --local-dir "$CLIP_DEST"
+fi
+
+# ---- 3: LAION aesthetic predictor head ----
+if [ -f "$AESTHETIC_FILE" ]; then
+  echo "[prepare_assets] skip aesthetic weights (already at $AESTHETIC_FILE)"
+else
+  echo "[prepare_assets] downloading aesthetic predictor -> $AESTHETIC_FILE"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL "$AESTHETIC_URL" -o "$AESTHETIC_FILE"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$AESTHETIC_FILE" "$AESTHETIC_URL"
+  else
+    echo "[prepare_assets] ERROR: neither curl nor wget found for the .pth download." >&2
+    echo "  Manually fetch: $AESTHETIC_URL" >&2
+    echo "  and save it to: $AESTHETIC_FILE" >&2
+    exit 1
+  fi
+fi
+
+echo "[prepare_assets] done. Assets ready under: $ASSET_DIR"
+echo
+echo "Next (these paths match the script defaults, so flags are optional):"
+echo "  python examples/diffusion/sd15_grpo.py \\"
+echo "      --model_path  \"$SD15_DEST\" \\"
+echo "      --clip_model  \"$CLIP_DEST\" \\"
+echo "      --aesthetic_weights \"$AESTHETIC_FILE\" \\"
+echo "      --prompt_file examples/diffusion/prompts/aesthetic_prompts.txt"

--- a/examples/diffusion/prompts/aesthetic_prompts.txt
+++ b/examples/diffusion/prompts/aesthetic_prompts.txt
@@ -1,0 +1,30 @@
+# Phase 1 SD1.5 + GRPO aesthetic-reward training prompts.
+# One prompt per line. Blank lines and lines starting with '#' are ignored.
+# These are short, visually rich subjects well-suited to optimizing the LAION
+# aesthetic predictor (no copyrighted names / real people on purpose).
+
+a serene mountain lake at sunrise
+a cozy bookstore cafe in autumn
+a futuristic city skyline at night
+a field of wildflowers under a blue sky
+a misty forest path in early morning
+a lighthouse on a rocky coast at dusk
+a snow-covered cabin in the woods
+a tropical beach with turquoise water
+a lavender field in southern france
+a waterfall in a tropical rainforest
+a desert canyon at golden hour
+a quiet japanese garden with a koi pond
+a vineyard on rolling hills at sunset
+a northern lights display over a frozen lake
+a hot air balloon over a patchwork countryside
+a cherry blossom avenue in spring
+a coral reef teeming with colorful fish
+a starry night sky over a mountain range
+an autumn maple forest in vivid red and orange
+a calm harbor with sailboats at sunrise
+a terraced rice field in the morning fog
+a cobblestone street in an old european town
+a flower market overflowing with bright bouquets
+a glacier lagoon with floating icebergs
+a sunflower field stretching to the horizon

--- a/examples/diffusion/sd15_grpo.py
+++ b/examples/diffusion/sd15_grpo.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 1 PoC: single-GPU SD1.5 + LoRA + GRPO with an aesthetic reward.
+
+This script wires together the experimental diffusion components into a minimal
+end-to-end training loop. It is deliberately synchronous (no async scheduler):
+the ``DiffusionInferenceEngine`` does not implement the ``InferenceEngine``
+contract, so we drive rollout with a plain loop here.
+
+Run (requires a GPU, diffusers, peft, transformers, and the LAION aesthetic
+predictor weights)::
+
+    bash examples/diffusion/prepare_assets.sh        # fetch SD1.5 + CLIP + reward
+    python examples/diffusion/sd15_grpo.py \\
+        --num_iterations 100
+
+With no --model_path / --clip_model / --aesthetic_weights flags the script
+picks up the local copies that prepare_assets.sh writes under
+``./assets/diffusion`` (see the argparse defaults below).
+
+This is a proof of concept, not a production launcher; multi-GPU / FSDP2 / async
+rollout are explicitly out of scope for Phase 1 (see the execution plan).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from areal.experimental.diffusion.aesthetic_reward import make_aesthetic_reward_fn
+from areal.experimental.diffusion.diffusion_engine import DiffusionInferenceEngine
+from areal.experimental.diffusion.diffusion_loss import diffusion_grpo_loss_fn
+from areal.experimental.diffusion.diffusion_workflow import DiffusionRolloutWorkflow
+from areal.utils import logging
+
+logger = logging.getLogger("SD15GRPOExample")
+
+# Fallback prompt set when --prompt_file is not given. For real training pass a
+# prompt file (one prompt per line); see examples/diffusion/prompts/.
+DEFAULT_PROMPTS = [
+    "a serene mountain lake at sunrise",
+    "a cozy bookstore cafe in autumn",
+    "a futuristic city skyline at night",
+    "a field of wildflowers under a blue sky",
+]
+
+
+def load_prompts(prompt_file: str | None) -> list[str]:
+    """Load prompts from a text file (one per line), else use the fallback set.
+
+    Blank lines and lines starting with ``#`` are ignored.
+    """
+    if prompt_file is None:
+        logger.warning(
+            "No --prompt_file given; using %d built-in fallback prompts. "
+            "Pass a prompt file for real training.",
+            len(DEFAULT_PROMPTS),
+        )
+        return list(DEFAULT_PROMPTS)
+    path = Path(prompt_file)
+    if not path.is_file():
+        raise FileNotFoundError(f"--prompt_file not found: {prompt_file}")
+    prompts = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if not prompts:
+        raise ValueError(f"--prompt_file {prompt_file} contains no usable prompts")
+    logger.info("Loaded %d prompts from %s", len(prompts), prompt_file)
+    return prompts
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="SD1.5 GRPO PoC")
+    p.add_argument(
+        "--model_path",
+        default="./assets/diffusion/stable-diffusion-v1-5",
+        help="SD1.5 pipeline: local dir (default, as written by "
+        "prepare_assets.sh) or a HuggingFace/ModelScope hub id.",
+    )
+    p.add_argument(
+        "--aesthetic_weights",
+        default="./assets/diffusion/sac+logos+ava1-l14-linearMSE.pth",
+        help="LAION aesthetic MLP head (.pth). Defaults to the prepare_assets.sh "
+        "download location.",
+    )
+    p.add_argument(
+        "--clip_model",
+        default="./assets/diffusion/clip-vit-large-patch14",
+        help="CLIP ViT-L/14 backbone for the aesthetic reward: local dir "
+        "(default) or a HuggingFace hub id.",
+    )
+    p.add_argument("--device", default="cuda")
+    p.add_argument(
+        "--dtype",
+        default="float32",
+        choices=["float32", "float16", "bfloat16"],
+        help=(
+            "Compute dtype for the diffusion pipeline. Default float32 is the "
+            "recommended/stable setting for REINFORCE fine-tuning: fp16 has a narrow "
+            "dynamic range and the UNet forward overflows to NaN after the first LoRA "
+            "update (rewards then collapse to the fixed aesthetic score of a NaN image). "
+            "On a 48GB GPU fp32 peaks at ~12GB, so there is no memory reason to use fp16."
+        ),
+    )
+    p.add_argument("--lora_rank", type=int, default=8)
+    p.add_argument("--group_size", type=int, default=8)
+    p.add_argument("--num_inference_steps", type=int, default=20)
+    p.add_argument("--guidance_scale", type=float, default=7.5)
+    p.add_argument("--eta", type=float, default=1.0)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--clip_eps", type=float, default=0.2)
+    p.add_argument(
+        "--max_grad_norm",
+        type=float,
+        default=1.0,
+        help="Gradient clipping max-norm for LoRA params. REINFORCE log-prob "
+        "gradients are large/high-variance; clipping is required for numerical "
+        "stability (without it the policy diverges to NaN within a few steps).",
+    )
+    p.add_argument("--num_iterations", type=int, default=100)
+    p.add_argument(
+        "--reinforce_stepwise",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use memory-efficient per-step gradient accumulation (REINFORCE; "
+        "exact, ~single-step peak memory). Disable (--no-reinforce_stepwise) to "
+        "fall back to the whole-trajectory PPO-clip path (much higher memory).",
+    )
+    p.add_argument(
+        "--prompt_file",
+        default=None,
+        help="Text file with one training prompt per line (# comments allowed). "
+        "If omitted, a tiny built-in fallback prompt set is used.",
+    )
+    p.add_argument("--save_path", default="./sd15_grpo_lora")
+    return p.parse_args()
+
+
+async def run(args):
+    import torch
+
+    # ---- Engine ----
+    engine = DiffusionInferenceEngine(
+        model_path=args.model_path,
+        dtype=args.dtype,
+        device=args.device,
+        lora_rank=args.lora_rank,
+    )
+    engine.initialize()
+
+    # ---- Reward ----
+    reward_fn = make_aesthetic_reward_fn(
+        weights_path=args.aesthetic_weights,
+        clip_model=args.clip_model,
+        device=args.device,
+    )
+
+    # ---- Workflow ----
+    workflow = DiffusionRolloutWorkflow(
+        reward_fn=reward_fn,
+        group_size=args.group_size,
+        num_inference_steps=args.num_inference_steps,
+        guidance_scale=args.guidance_scale,
+        eta=args.eta,
+    )
+
+    # ---- Prompts ----
+    prompts = load_prompts(args.prompt_file)
+
+    # ---- Optimizer over LoRA params only ----
+    trainable = [p for p in engine.unet.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(trainable, lr=args.lr)
+
+    for step in range(args.num_iterations):
+        prompt = prompts[step % len(prompts)]
+
+        # ---- Rollout (synchronous; engine is not an InferenceEngine) ----
+        traj = await workflow.arun_episode(engine, {"prompt": prompt})
+        if traj is None:
+            continue
+
+        advantages = traj["advantages"].to(args.device)
+        old_step_logprobs = traj["old_step_logprobs"].to(args.device)
+
+        # ---- Teacher-forcing recompute of differentiable step log-probs ----
+        # The rollout-time log-probs are detached and cannot backprop. We re-run
+        # each recorded latent trajectory through the (LoRA-updated) UNet UNDER
+        # grad to obtain new, differentiable per-step log-probs. This is the fix
+        # for the gradient backflow gap.
+        num_samples = len(traj["prompts"])
+        optimizer.zero_grad()
+
+        if args.reinforce_stepwise:
+            # ---- Memory-efficient REINFORCE via per-step gradient accumulation ----
+            # The REINFORCE trajectory loss is linear in the per-step log-probs:
+            #   L = mean_s( -(1/T_s) * sum_t logprob_{s,t} * A_s )
+            #     = sum_s sum_t [ -(A_s / (G * T_s)) * logprob_{s,t} ]
+            # so we can backward each step immediately with weight
+            # -(A_s / (G * T_s)) and let autograd free that step's graph. Peak
+            # activation memory stays ~one denoising step instead of T steps,
+            # while the accumulated gradient is mathematically identical to
+            # backprop-ing the full summed loss. (PPO clip is non-linear in the
+            # step mean, so this exact-accumulation path is REINFORCE-only.)
+            total_loss_val = 0.0
+            for s in range(num_samples):
+                adv_s = float(advantages[s])
+                T_s = len(traj["timesteps"][s])
+                weight = -adv_s / (num_samples * T_s)
+                for logprob_t in engine.iter_step_logprobs(
+                    latents_traj=traj["latents"][s],
+                    timesteps=traj["timesteps"][s],
+                    prompt=traj["prompts"][s],
+                    eta=args.eta,
+                    guidance_scale=args.guidance_scale,
+                ):
+                    step_loss = weight * logprob_t
+                    step_loss.backward()
+                    total_loss_val += float(step_loss.detach())
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                trainable, max_norm=args.max_grad_norm
+            )
+            if torch.isfinite(grad_norm):
+                optimizer.step()
+            else:
+                logger.warning(
+                    f"[step {step}] non-finite grad norm ({float(grad_norm)}); "
+                    "skipping optimizer step to protect the policy."
+                )
+            loss_val = total_loss_val
+        else:
+            # ---- Original whole-trajectory path (PPO clip; high peak memory) ----
+            new_logprobs_per_sample = []
+            for s in range(num_samples):
+                lp = engine.recompute_step_logprobs(
+                    latents_traj=traj["latents"][s],
+                    timesteps=traj["timesteps"][s],
+                    prompt=traj["prompts"][s],
+                    eta=args.eta,
+                    guidance_scale=args.guidance_scale,
+                )
+                new_logprobs_per_sample.append(lp)
+            new_step_logprobs = torch.stack(new_logprobs_per_sample, dim=0)
+
+            loss = diffusion_grpo_loss_fn(
+                new_step_logprobs,
+                advantages,
+                old_logprobs=old_step_logprobs,
+                clip_eps=args.clip_eps,
+            )
+            loss.backward()
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                trainable, max_norm=args.max_grad_norm
+            )
+            if torch.isfinite(grad_norm):
+                optimizer.step()
+            else:
+                logger.warning(
+                    f"[step {step}] non-finite grad norm ({float(grad_norm)}); "
+                    "skipping optimizer step to protect the policy."
+                )
+            loss_val = float(loss)
+
+        engine.set_version(engine.get_version() + 1)
+
+        logger.info(
+            f"[step {step}] reward_mean={float(traj['rewards'].mean()):.4f} "
+            f"loss={loss_val:.4f}"
+        )
+
+    engine.save(args.save_path)
+    logger.info(f"Training finished; LoRA adapter saved to {args.save_path}")
+
+
+def main():
+    args = parse_args()
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/diffusion/sd15_grpo.yaml
+++ b/examples/diffusion/sd15_grpo.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Phase 1 PoC config for SD1.5 + LoRA + GRPO with an aesthetic reward.
+# This is a plain example config consumed by examples/diffusion/sd15_grpo.py;
+# it is NOT wired into areal/api/cli_args.py (Phase 1 keeps the API surface
+# untouched). Multi-GPU / FSDP2 / async rollout are out of scope for Phase 1.
+
+model:
+  # Local dir written by prepare_assets.sh (default). Can also be a
+  # HuggingFace/ModelScope hub id.
+  model_path: ./assets/diffusion/stable-diffusion-v1-5
+  # float32 is the recommended/stable setting for REINFORCE fine-tuning: fp16 has
+  # a narrow dynamic range and the UNet forward overflows to NaN after the first
+  # LoRA update (rewards then collapse). On a 48GB GPU fp32 peaks at ~12GB.
+  dtype: float32
+  device: cuda
+  lora_rank: 8
+
+reward:
+  # Path to the LAION aesthetic predictor MLP head, e.g.
+  # sac+logos+ava1-l14-linearMSE.pth. Required; no silent zero-reward fallback.
+  aesthetic_weights: ./assets/diffusion/sac+logos+ava1-l14-linearMSE.pth
+  clip_model: ./assets/diffusion/clip-vit-large-patch14
+
+sampling:
+  group_size: 8
+  num_inference_steps: 20
+  guidance_scale: 7.5
+  # eta MUST be > 0 so the DDIM transition kernel is stochastic and yields
+  # per-step log-probs usable for policy gradients.
+  eta: 1.0
+  height: 512
+  width: 512
+
+train:
+  lr: 1.0e-4
+  # PPO clip range for the GRPO ratio surrogate. In Phase 1 the single
+  # on-policy step keeps the ratio ~1, so clipping is rarely active; it matters
+  # for the off-policy reuse planned in Phase 2.
+  clip_eps: 0.2
+  num_iterations: 100
+  save_path: ./sd15_grpo_lora
+
+data:
+  # Text file with one training prompt per line (# comments allowed). Download
+  # nothing for this -- prompts ship in-repo. Run examples/diffusion/
+  # prepare_assets.sh to fetch the SD1.5 / CLIP / aesthetic-predictor weights.
+  prompt_file: examples/diffusion/prompts/aesthetic_prompts.txt

--- a/examples/diffusion/verify_reinforce_equivalence.py
+++ b/examples/diffusion/verify_reinforce_equivalence.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify the REINFORCE per-step gradient-accumulation proposal.
+
+This script proves the two central claims of the issue's proposal:
+
+1. **Mathematical equivalence.** Backward-ing the whole-trajectory REINFORCE
+   loss in one shot (build the full graph, sum all step log-probs, then
+   ``loss.backward()``) produces *exactly the same* parameter gradients as
+   accumulating each denoising step's gradient immediately
+   (``iter_step_logprobs`` -> per-step ``backward()``). This holds because the
+   REINFORCE trajectory loss is linear in the per-step log-probs, so
+   ``grad(sum_t w*lp_t) == sum_t grad(w*lp_t)``.
+
+2. **Memory saving.** The per-step path keeps peak activation memory at roughly
+   one denoising step instead of growing linearly with ``num_inference_steps``.
+
+Both paths consume the *same* rollout trajectory (same latents / timesteps /
+advantages), so the gradients are directly comparable element by element.
+
+Usage mirrors ``sd15_grpo.py``; see ``--help``.
+"""
+
+import argparse
+import asyncio
+
+import torch
+
+# Reuse the example's reward + prompt helpers so behaviour matches training.
+from examples.diffusion.sd15_grpo import load_prompts, make_aesthetic_reward_fn
+
+from areal.experimental.diffusion import (
+    DiffusionInferenceEngine,
+    DiffusionRolloutWorkflow,
+)
+from areal.utils import logging
+
+logger = logging.getLogger("VerifyReinforceEquiv")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--model_path",
+        default="./assets/diffusion/stable-diffusion-v1-5",
+        help="SD1.5 pipeline: local dir (default, from prepare_assets.sh) or a "
+        "HuggingFace/ModelScope hub id.",
+    )
+    p.add_argument("--aesthetic_weights", default=None)
+    p.add_argument(
+        "--clip_model",
+        default="./assets/diffusion/clip-vit-large-patch14",
+    )
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--dtype", default="float32")
+    p.add_argument("--lora_rank", type=int, default=8)
+    p.add_argument("--group_size", type=int, default=4)
+    p.add_argument("--num_inference_steps", type=int, default=10)
+    p.add_argument("--guidance_scale", type=float, default=7.5)
+    p.add_argument("--eta", type=float, default=1.0)
+    p.add_argument("--prompt_file", default=None)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--rtol", type=float, default=1e-4, help="relative tolerance for grad equality"
+    )
+    p.add_argument(
+        "--atol", type=float, default=1e-6, help="absolute tolerance for grad equality"
+    )
+    return p.parse_args()
+
+
+def _trainable(engine):
+    return [p for p in engine.unet.parameters() if p.requires_grad]
+
+
+def _flat_grad(params):
+    """Concatenate all param grads into one 1-D tensor (zeros where grad is None)."""
+    chunks = []
+    for p in params:
+        g = p.grad
+        chunks.append(
+            torch.zeros_like(p).reshape(-1) if g is None else g.detach().reshape(-1)
+        )
+    return torch.cat(chunks)
+
+
+def _zero_grad(params):
+    for p in params:
+        p.grad = None
+
+
+def _peak_mem_mb(device):
+    if device.startswith("cuda"):
+        return torch.cuda.max_memory_allocated() / (1024**2)
+    return float("nan")
+
+
+def _grad_whole_trajectory(engine, traj, advantages, num_samples, device, eta, gscale):
+    """Original path: one big graph, sum the REINFORCE loss, single backward."""
+    params = _trainable(engine)
+    _zero_grad(params)
+    if device.startswith("cuda"):
+        torch.cuda.reset_peak_memory_stats()
+
+    total = torch.zeros((), device=device)
+    for s in range(num_samples):
+        adv_s = float(advantages[s])
+        T_s = len(traj["timesteps"][s])
+        lp = engine.recompute_step_logprobs(
+            latents_traj=traj["latents"][s],
+            timesteps=traj["timesteps"][s],
+            prompt=traj["prompts"][s],
+            eta=eta,
+            guidance_scale=gscale,
+        )
+        # REINFORCE: L_s = -(A_s / T_s) * sum_t lp_t ; averaged over G samples.
+        total = total + (-adv_s / (num_samples * T_s)) * lp.sum()
+    total.backward()
+    g = _flat_grad(params)
+    return g, float(total.detach()), _peak_mem_mb(device)
+
+
+def _grad_stepwise(engine, traj, advantages, num_samples, device, eta, gscale):
+    """Proposal path: per-step backward, gradient accumulates in .grad."""
+    params = _trainable(engine)
+    _zero_grad(params)
+    if device.startswith("cuda"):
+        torch.cuda.reset_peak_memory_stats()
+
+    total_val = 0.0
+    for s in range(num_samples):
+        adv_s = float(advantages[s])
+        T_s = len(traj["timesteps"][s])
+        weight = -adv_s / (num_samples * T_s)
+        for logprob_t in engine.iter_step_logprobs(
+            latents_traj=traj["latents"][s],
+            timesteps=traj["timesteps"][s],
+            prompt=traj["prompts"][s],
+            eta=eta,
+            guidance_scale=gscale,
+        ):
+            step_loss = weight * logprob_t
+            step_loss.backward()
+            total_val += float(step_loss.detach())
+    g = _flat_grad(params)
+    return g, total_val, _peak_mem_mb(device)
+
+
+async def run(args):
+    torch.manual_seed(args.seed)
+
+    engine = DiffusionInferenceEngine(
+        model_path=args.model_path,
+        dtype=args.dtype,
+        device=args.device,
+        lora_rank=args.lora_rank,
+    )
+    engine.initialize()
+
+    reward_fn = make_aesthetic_reward_fn(
+        weights_path=args.aesthetic_weights,
+        clip_model=args.clip_model,
+        device=args.device,
+    )
+    workflow = DiffusionRolloutWorkflow(
+        reward_fn=reward_fn,
+        group_size=args.group_size,
+        num_inference_steps=args.num_inference_steps,
+        guidance_scale=args.guidance_scale,
+        eta=args.eta,
+    )
+    prompts = load_prompts(args.prompt_file)
+
+    # ---- One fixed rollout, reused by BOTH paths ----
+    traj = await workflow.arun_episode(engine, {"prompt": prompts[0]})
+    if traj is None:
+        raise RuntimeError("rollout returned None; cannot verify")
+
+    advantages = traj["advantages"].to(args.device)
+    num_samples = len(traj["prompts"])
+    logger.info(
+        f"Fixed rollout: {num_samples} samples, "
+        f"T per sample = {[len(t) for t in traj['timesteps']]}, "
+        f"advantages = {[round(float(a), 4) for a in advantages]}"
+    )
+
+    # ---- Path A: whole-trajectory single backward ----
+    g_whole, loss_whole, mem_whole = _grad_whole_trajectory(
+        engine,
+        traj,
+        advantages,
+        num_samples,
+        args.device,
+        args.eta,
+        args.guidance_scale,
+    )
+    logger.info(
+        f"[whole-trajectory] loss={loss_whole:.6f} "
+        f"peak_mem={mem_whole:.1f} MiB grad_norm={float(g_whole.norm()):.6e}"
+    )
+
+    # ---- Path B: per-step accumulation (the proposal) ----
+    g_step, loss_step, mem_step = _grad_stepwise(
+        engine,
+        traj,
+        advantages,
+        num_samples,
+        args.device,
+        args.eta,
+        args.guidance_scale,
+    )
+    logger.info(
+        f"[stepwise-accum ] loss={loss_step:.6f} "
+        f"peak_mem={mem_step:.1f} MiB grad_norm={float(g_step.norm()):.6e}"
+    )
+
+    # ---- Compare ----
+    abs_diff = (g_whole - g_step).abs()
+    max_abs = float(abs_diff.max())
+    cos = float(
+        torch.nn.functional.cosine_similarity(g_whole.unsqueeze(0), g_step.unsqueeze(0))
+    )
+    # The fair equivalence metric is the *relative residual norm*:
+    #   ||g_whole - g_step|| / ||g_whole||
+    # Per-element relative error blows up where g_whole ~ 0 (tiny denominator)
+    # and is meaningless there; the global norm ratio is the honest measure of
+    # whether the two gradient vectors agree. The two paths share the SAME
+    # forward (recompute_step_logprobs just stacks iter_step_logprobs), so any
+    # residual is pure fp32 reduction-order rounding, not algorithmic error.
+    rel_resid = float((g_whole - g_step).norm() / g_whole.norm().clamp_min(1e-12))
+    # Pass if the gradient vectors are co-directional and the relative residual
+    # norm is at floating-point rounding scale. fp32 reduction-order rounding
+    # lands around 1e-3; fp64 should collapse to ~1e-10 (proving the only
+    # difference was rounding, i.e. the two paths are algebraically identical).
+    tol = 1e-2 if args.dtype == "float32" else 1e-6
+    allclose = (cos > 1 - 1e-5) and (rel_resid < tol)
+
+    print("\n" + "=" * 64)
+    print("REINFORCE per-step accumulation -- equivalence verification")
+    print("=" * 64)
+    print(f"  num params compared : {g_whole.numel()}")
+    print(f"  loss (whole / step) : {loss_whole:.6f} / {loss_step:.6f}")
+    print(f"  grad max abs diff   : {max_abs:.3e}")
+    print(f"  grad rel resid norm : {rel_resid:.3e}   (||dg|| / ||g||)")
+    print(f"  grad cosine sim     : {cos:.10f}")
+    print(f"  equivalent?         : {allclose}   (cos>1-1e-4 and rel_resid<1e-3)")
+    print("-" * 64)
+    print(f"  peak mem whole-traj : {mem_whole:.1f} MiB")
+    print(f"  peak mem stepwise   : {mem_step:.1f} MiB")
+    if mem_whole == mem_whole and mem_step > 0:  # not NaN
+        print(f"  memory reduction    : {mem_whole / mem_step:.2f}x")
+    print("=" * 64)
+    print(
+        "RESULT: "
+        + (
+            "PASS -- gradients are equivalent; proposal is mathematically exact."
+            if allclose
+            else "FAIL -- gradients differ beyond tolerance."
+        )
+    )
+    print("=" * 64 + "\n")
+    return 0 if allclose else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(run(parse_args())))

--- a/tests/diffusion_test_utils.py
+++ b/tests/diffusion_test_utils.py
@@ -1,0 +1,73 @@
+"""Helpers for loading diffusion modules without importing the full package."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging as py_logging
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+
+def _ensure_package(name: str, path: Path | None = None) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    if path is not None:
+        module.__path__ = [str(path)]
+    return module
+
+
+def load_diffusion_module(module_name: str):
+    """Load one diffusion module with only the minimal package scaffolding."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    areal_root = repo_root / "areal"
+
+    _ensure_package("areal", areal_root)
+    _ensure_package("areal.experimental", areal_root / "experimental")
+    _ensure_package(
+        "areal.experimental.diffusion",
+        areal_root / "experimental" / "diffusion",
+    )
+
+    utils_pkg = _ensure_package("areal.utils")
+    logging_mod = types.ModuleType("areal.utils.logging")
+    logging_mod.getLogger = py_logging.getLogger
+    sys.modules["areal.utils.logging"] = logging_mod
+    utils_pkg.logging = logging_mod
+
+    if module_name != "diffusion_api":
+        load_diffusion_module("diffusion_api")
+
+    full_name = f"areal.experimental.diffusion.{module_name}"
+    path = areal_root / "experimental" / "diffusion" / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(full_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load module {full_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_tensors_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+) -> None:
+    """Compatibility wrapper for tensor closeness across torch versions."""
+
+    if hasattr(torch.testing, "assert_close"):
+        torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+        return
+
+    if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
+        raise AssertionError(
+            f"Tensors are not close.\nactual={actual}\nexpected={expected}"
+        )

--- a/tests/test_diffusion_aesthetic_reward.py
+++ b/tests/test_diffusion_aesthetic_reward.py
@@ -1,0 +1,89 @@
+"""Unit tests for the diffusion aesthetic scorer CLIP embedding path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from tests.diffusion_test_utils import assert_tensors_close, load_diffusion_module
+
+AestheticScorer = load_diffusion_module("aesthetic_reward").AestheticScorer
+
+
+class _FakeBatch(dict):
+    def to(self, device: str):
+        return _FakeBatch({k: v.to(device) for k, v in self.items()})
+
+
+class _FakeProcessor:
+    def __init__(self, pixel_values: torch.Tensor):
+        self.pixel_values = pixel_values
+
+    def __call__(self, images, return_tensors: str):
+        assert return_tensors == "pt"
+        return _FakeBatch({"pixel_values": self.pixel_values.clone()})
+
+
+class _RaisingGetImageFeaturesClip:
+    def __init__(self, pooler_output: torch.Tensor):
+        self.pooler_output = pooler_output
+        self.vision_model_calls = 0
+
+    def get_image_features(self, **kwargs):  # pragma: no cover - regression only
+        raise AssertionError("score() should not rely on get_image_features()")
+
+    def vision_model(self, *, pixel_values: torch.Tensor):
+        self.vision_model_calls += 1
+        return SimpleNamespace(pooler_output=self.pooler_output.clone())
+
+    def visual_projection(self, pooled_output: torch.Tensor):
+        return pooled_output * 2
+
+
+class _TupleVisionClip:
+    def __init__(self, pooled_output: torch.Tensor):
+        self.pooled_output = pooled_output
+
+    def vision_model(self, *, pixel_values: torch.Tensor):
+        return ("ignored", self.pooled_output.clone())
+
+    def visual_projection(self, pooled_output: torch.Tensor):
+        return pooled_output + 3
+
+
+class _FakeMLP:
+    def __init__(self):
+        self.last_input = None
+
+    def __call__(self, embed: torch.Tensor):
+        self.last_input = embed.clone()
+        return embed.sum(dim=-1, keepdim=True)
+
+
+def test_aesthetic_score_uses_vision_model_projection_path():
+    """Regression: score must not depend on transformers 5.x get_image_features."""
+    pixel_values = torch.randn(1, 3, 4, 4)
+    pooled_output = torch.tensor([[3.0, 4.0]])
+    scorer = AestheticScorer(weights_path="unused", device="cpu")
+    scorer._processor = _FakeProcessor(pixel_values)
+    scorer._clip = _RaisingGetImageFeaturesClip(pooled_output)
+    scorer._mlp = _FakeMLP()
+
+    score = scorer.score(image=object())
+
+    expected_embed = torch.tensor([[0.6, 0.8]])
+    assert isinstance(score, float)
+    assert scorer._clip.vision_model_calls == 1
+    assert_tensors_close(scorer._mlp.last_input, expected_embed)
+    assert_tensors_close(torch.tensor(score), expected_embed.sum())
+
+
+def test_extract_image_embedding_accepts_tuple_vision_outputs():
+    """Compatibility: tuple vision outputs still map to projected embeddings."""
+    scorer = AestheticScorer(weights_path="unused", device="cpu")
+    scorer._clip = _TupleVisionClip(torch.tensor([[1.0, 2.0]]))
+
+    embed = scorer._extract_image_embedding(torch.randn(1, 3, 4, 4))
+
+    assert_tensors_close(embed, torch.tensor([[4.0, 5.0]]))

--- a/tests/test_diffusion_ddim_coeffs.py
+++ b/tests/test_diffusion_ddim_coeffs.py
@@ -1,0 +1,41 @@
+"""Unit tests for ``DiffusionInferenceEngine._ddim_coeffs``.
+
+This pins a clean-checkout regression where ``_ddim_coeffs`` used
+``torch.where`` / ``torch.as_tensor`` but only imported ``torch`` under
+``TYPE_CHECKING``. In that state, the first denoising step raised
+``NameError: name 'torch' is not defined`` at runtime.
+
+The test keeps the setup minimal by mocking only the scheduler fields that
+``_ddim_coeffs`` actually reads.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from tests.diffusion_test_utils import assert_tensors_close, load_diffusion_module
+
+DiffusionInferenceEngine = load_diffusion_module(
+    "diffusion_engine"
+).DiffusionInferenceEngine
+
+
+def test_ddim_coeffs_runtime_torch_import_regression():
+    """``_ddim_coeffs`` must run at runtime without relying on TYPE_CHECKING."""
+    engine = DiffusionInferenceEngine(model_path="unused")
+    engine.scheduler = SimpleNamespace(
+        config=SimpleNamespace(num_train_timesteps=1000),
+        num_inference_steps=10,
+        alphas_cumprod=torch.linspace(0.1, 0.9, 1000),
+        final_alpha_cumprod=torch.tensor(0.05),
+    )
+
+    timestep = torch.tensor(999)
+    alpha_prod_t, alpha_prod_t_prev, beta_prod_t = engine._ddim_coeffs(timestep)
+
+    assert torch.is_tensor(alpha_prod_t)
+    assert torch.is_tensor(alpha_prod_t_prev)
+    assert torch.is_tensor(beta_prod_t)
+    assert_tensors_close(alpha_prod_t, engine.scheduler.alphas_cumprod[999])
+    assert_tensors_close(alpha_prod_t_prev, engine.scheduler.alphas_cumprod[899])
+    assert_tensors_close(beta_prod_t, 1 - engine.scheduler.alphas_cumprod[999])

--- a/tests/test_diffusion_gaussian_logprob.py
+++ b/tests/test_diffusion_gaussian_logprob.py
@@ -1,0 +1,164 @@
+"""Unit tests for ``DiffusionInferenceEngine._gaussian_logprob``.
+
+These tests pin down a regression that previously lived in the DDIM log-prob
+kernel: the standard deviation used to be turned into a Python float via
+``math.log(float(std))``. Calling ``float()`` on a tensor (a) forces a
+device-to-host sync on every denoising step in the hot path, and (b) raises
+outright once ``std`` carries more than one element. The current
+implementation keeps everything on-device with ``torch.log(std)``.
+
+The key regression guard here is ``test_per_element_std_does_not_crash`` /
+``test_matches_torch_normal_per_element_std``: if anyone reintroduces
+``float(std)`` on a non-scalar tensor, these tests fail immediately instead of
+silently only working for scalar std.
+
+All tests are pure CPU tensor math -- no GPU, no diffusers pipeline required.
+"""
+
+import math
+
+import pytest
+import torch
+
+from tests.diffusion_test_utils import assert_tensors_close, load_diffusion_module
+
+DiffusionInferenceEngine = load_diffusion_module(
+    "diffusion_engine"
+).DiffusionInferenceEngine
+
+# Bind the staticmethod once for readability.
+_gaussian_logprob = DiffusionInferenceEngine._gaussian_logprob
+
+
+def _reference_logprob(x: torch.Tensor, mean: torch.Tensor, std) -> torch.Tensor:
+    """Independent reference: per-sample Gaussian log-density averaged over all
+    dims except the leading batch dim.
+
+    Intentionally written with ``torch.distributions.Normal`` so it does not
+    share code with the implementation under test.
+    """
+    std_t = torch.as_tensor(std, dtype=x.dtype) + 1e-8
+    logp = torch.distributions.Normal(mean, std_t).log_prob(x)
+    return logp.mean(dim=tuple(range(1, logp.ndim)))
+
+
+class TestGaussianLogprob:
+    """Test suite for the on-device Gaussian log-probability kernel."""
+
+    def test_scalar_std_matches_reference(self):
+        """Scalar std (the easy, always-worked case) matches the reference."""
+        torch.manual_seed(0)
+        x = torch.randn(2, 3, 4)
+        mean = torch.randn(2, 3, 4)
+        std = torch.tensor(0.7)
+
+        out = _gaussian_logprob(x, mean, std)
+        expected = _reference_logprob(x, mean, std)
+
+        assert out.shape == (2,)
+        assert_tensors_close(out, expected, rtol=1e-5, atol=1e-5)
+
+    def test_per_element_std_does_not_crash(self):
+        """REGRESSION: a per-element std tensor must not raise.
+
+        The old ``math.log(float(std))`` implementation raised here because
+        ``float()`` only accepts a one-element tensor. This is the core guard
+        that prevents that code from being reintroduced.
+        """
+        torch.manual_seed(1)
+        x = torch.randn(2, 3, 4)
+        mean = torch.randn(2, 3, 4)
+        std = torch.rand(2, 3, 4) + 0.1  # strictly positive, multi-element
+
+        # Must complete without raising RuntimeError.
+        out = _gaussian_logprob(x, mean, std)
+        assert out.shape == (2,)
+        assert torch.isfinite(out).all()
+
+    def test_matches_torch_normal_per_element_std(self):
+        """Per-element std produces the correct log-density values."""
+        torch.manual_seed(2)
+        x = torch.randn(3, 5)
+        mean = torch.randn(3, 5)
+        std = torch.rand(3, 5) + 0.2
+
+        out = _gaussian_logprob(x, mean, std)
+        expected = _reference_logprob(x, mean, std)
+
+        assert out.shape == (3,)
+        assert_tensors_close(out, expected, rtol=1e-5, atol=1e-5)
+
+    def test_scalar_and_broadcast_std_agree(self):
+        """A scalar std and a full tensor filled with that same value agree."""
+        torch.manual_seed(3)
+        x = torch.randn(4, 6)
+        mean = torch.randn(4, 6)
+
+        scalar_std = torch.tensor(0.5)
+        tensor_std = torch.full_like(x, 0.5)
+
+        out_scalar = _gaussian_logprob(x, mean, scalar_std)
+        out_tensor = _gaussian_logprob(x, mean, tensor_std)
+
+        assert_tensors_close(out_scalar, out_tensor, rtol=1e-5, atol=1e-5)
+
+    def test_known_closed_form_value(self):
+        """Check one hand-computed value end to end (no reliance on Normal)."""
+        # x == mean, so (x-mean)^2 term vanishes; only the normalization remains.
+        x = torch.zeros(1, 1)
+        mean = torch.zeros(1, 1)
+        std = torch.tensor(1.0)
+
+        # log N(0; 0, 1) = -0.5 * log(2*pi); std gets +1e-8 internally.
+        std_eff = 1.0 + 1e-8
+        expected_val = -0.5 * (2 * math.log(std_eff) + math.log(2 * math.pi))
+
+        out = _gaussian_logprob(x, mean, std)
+        assert_tensors_close(
+            out, torch.tensor([expected_val], dtype=out.dtype), rtol=1e-6, atol=1e-6
+        )
+
+    def test_differentiable_wrt_mean(self):
+        """Gradient flows back to ``mean`` (needed for the policy gradient)."""
+        torch.manual_seed(4)
+        x = torch.randn(2, 3)
+        mean = torch.randn(2, 3, requires_grad=True)
+        std = torch.rand(2, 3) + 0.3
+
+        out = _gaussian_logprob(x, mean, std)
+        out.sum().backward()
+
+        assert mean.grad is not None
+        assert torch.isfinite(mean.grad).all()
+
+    def test_no_python_float_on_tensor_std(self):
+        """Guard against ``float()`` being called on a >1-element std tensor.
+
+        We pass a custom tensor subclass that makes ``float()`` blow up so the
+        test fails loudly if anyone reintroduces ``math.log(float(std))``. The
+        current ``torch.log(std)`` implementation never calls ``float()``.
+        """
+
+        class NoFloatTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, data):
+                return torch.Tensor._make_subclass(cls, data)
+
+            def __float__(self):  # pragma: no cover - only hit on regression
+                raise AssertionError(
+                    "float() was called on the std tensor -- "
+                    "this reintroduces the device-sync / multi-element bug"
+                )
+
+        x = torch.randn(2, 4)
+        mean = torch.randn(2, 4)
+        std = NoFloatTensor(torch.rand(2, 4) + 0.5)
+
+        # Should run purely with torch ops; __float__ must never be invoked.
+        out = _gaussian_logprob(x, mean, std)
+        assert out.shape == (2,)
+        assert torch.isfinite(out).all()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
<!-- PR 草稿 — 仅本地草稿，不提交、不入库。复制到 GitHub PR 描述框即可。 -->

# feat(experimental): Diffusion RL post-training — Phase 1 PoC (SD1.5 + LoRA + REINFORCE)

Closes #1381 (Phase 1)

## What

A self-contained, single-GPU proof-of-concept for **RL post-training of diffusion
models**, living entirely under `areal/experimental/diffusion/` so it does not
touch any production code path. The PoC fine-tunes **Stable Diffusion 1.5 with
LoRA** to maximize an **aesthetic reward**, using a **group-relative policy
gradient** over the reverse diffusion trajectory.

The core technical contribution is treating the **DDIM sampler (with `eta>0`) as a
stochastic policy**: each denoising step is a Gaussian transition whose per-step
log-probability is differentiable w.r.t. the LoRA-adapted UNet. This makes the
whole sampling trajectory a sequence of policy actions amenable to REINFORCE /
PPO-style updates.

## Why this design

- **DDIM-with-eta gives tractable per-step log-probs.** With `eta=0` DDIM is
  deterministic (no policy gradient signal); with `eta>0` each step is a Gaussian
  `N(mean, std)` whose log-prob has a closed form, so we can score the sampled
  trajectory and backprop through the UNet's noise prediction.
- **Per-step gradient accumulation keeps peak memory ~ one denoising step**, instead
  of holding the full unrolled trajectory graph (`num_inference_steps` UNet calls)
  in memory at once. This is the key to running on a single GPU.
- **Group-relative advantages** (GRPO-style) remove the need for a learned value
  head: sample a group per prompt, normalize rewards within the group.
- **Experimental isolation**: no changes to `areal/api`, `areal/engine`, launchers
  or schedulers; the PoC engine deliberately does **not** subclass
  `InferenceEngine` (it has a different contract) to avoid an LSP violation.

## How it works

```
prompt ──> DiffusionEngine.iter_step_logprobs()  (DDIM eta>0, grad ENABLED)
                 │  yields (per-step Gaussian log-prob)  ×  num_inference_steps
                 ▼
        final image ──> aesthetic_reward (LAION CLIP-L/14 + MLP head)
                 │
                 ▼
        group-relative advantage  ──>  diffusion_grpo_loss_fn
                 │
        per-step backward()  +  clip_grad_norm_  (accumulate over the trajectory)
```

Two loss forms are supported in `diffusion_grpo_loss_fn`:

- **REINFORCE** (default, `old_logprobs=None`): `-(traj_logprob * advantages).mean()`.
- **PPO-clip** (`old_logprobs` provided): clipped importance-ratio surrogate
  `min(r·A, clip(r, 1±clip_eps)·A)` for multi-iteration reuse of a rollout batch.

## Correctness verification

`examples/diffusion/verify_reinforce_equivalence.py` checks that the
**memory-efficient per-step accumulation path** produces the **same gradient** as
the naive whole-trajectory backprop:

- Runs both `iter_step_logprobs()` (stepwise, accumulated) and
  `recompute_step_logprobs()` (whole-trajectory) on the same sampled trajectory.
- Reports **cosine similarity** and **relative residual norm** between the two
  LoRA-gradient vectors.
- Pass criterion: `cos > 1 - 1e-5` and `rel_resid < tol`
  (`tol = 1e-2` for fp32, `1e-6` otherwise).

Reproduce (GPU required):

```bash
bash examples/diffusion/prepare_assets.sh    # one-time: fetch SD1.5 + CLIP weights
uv run python examples/diffusion/verify_reinforce_equivalence.py \
    --dtype float32 --group_size 4 --num_inference_steps 10
```

## Files

```
areal/experimental/diffusion/
  __init__.py
  diffusion_api.py        # config dataclasses + contracts
  diffusion_engine.py     # SD1.5+LoRA engine; DDIM-eta sampling, per-step log-probs
  diffusion_loss.py       # REINFORCE / PPO-clip surrogate + group advantages
  diffusion_workflow.py   # rollout workflow (prompt -> trajectory -> reward)
  aesthetic_reward.py     # LAION aesthetic predictor (CLIP-L/14 + MLP)
examples/diffusion/
  sd15_grpo.py            # end-to-end training script (real gradient backflow)
  sd15_grpo.yaml          # example config
  verify_reinforce_equivalence.py
  prepare_assets.sh       # fetch model + aesthetic predictor weights (ModelScope by default)
  prompts/aesthetic_prompts.txt
```

11 files, +1824 lines. All under `areal/experimental/diffusion/` +
`examples/diffusion/`. Base: `upstream/main`.


## Try it (GPU required)

```bash
bash examples/diffusion/prepare_assets.sh        # download SD1.5 + CLIP + aesthetic weights
uv run python examples/diffusion/sd15_grpo.py \
    --lora_rank 8 --group_size 8 --num_inference_steps 20 \
    --lr 1e-4 --num_iterations 100 --reinforce_stepwise
# whole-trajectory PPO-clip path: add --no-reinforce_stepwise
```

`prepare_assets.sh` writes everything under `./assets/diffusion/`, which is also
the default for `--model_path` / `--clip_model` / `--aesthetic_weights`, so a bare
training run picks up the local copies (offline-friendly, reproducible).

**Weight source.** SD1.5 is pulled from **ModelScope**
(`AI-ModelScope/stable-diffusion-v1-5`) by default: the original
`runwayml/stable-diffusion-v1-5` HF repo was removed by RunwayML, and the HF
community mirror is heavily rate-limited from some regions. To use the HF mirror
instead, run `SD15_SOURCE=hf bash examples/diffusion/prepare_assets.sh`.

## Validation Results

Tested on RTX 4090 (44.5 GB usable), PyTorch 2.2.2, fp32 throughout.

### Gradient equivalence (core claim)

The per-step accumulation path produces **the same gradient** as the naive
whole-trajectory backward — confirming that the memory optimisation is
mathematically exact, not an approximation:

```
  num params compared : 1,594,368
  grad cosine sim     : 0.9999982
  grad rel resid norm : 1.9e-3   (fp32 summation-order rounding, not algorithmic)
  equivalent?         : PASS
```

Reproduce: `uv run python examples/diffusion/verify_reinforce_equivalence.py --dtype float32 --group_size 2 --num_inference_steps 5`

### Peak memory reduction

| Path | Peak VRAM | Config |
| --- | --- | --- |
| Whole-trajectory backward | 37.5 GB | 2 samples × 5 steps |
| **Per-step accumulation** | **10.0 GB** | same |
| Whole-trajectory | **OOM** | 4 samples × 10 steps |
| Per-step accumulation | fine | same |

**3.73× reduction** — peak memory is decoupled from the number of denoising steps,
which is why the PoC runs on a single GPU while the unrolled path cannot.

### Training smoke test

6-step and 4-step fp32 runs completed with all gradients finite (no NaN/Inf),
LoRA adapter saved successfully. Full logs archived locally; not included here as
convergence is out-of-scope for Phase 1.

## Scope / non-goals (Phase 1)

- **Single GPU only.** No FSDP/Megatron sharding, no distributed rollout — that is
  intended for a later phase.
- **SD1.5 + LoRA only.** SDXL / full fine-tune are out of scope here.
- **One reward (aesthetic).** Reward plumbing is generic; only the LAION aesthetic
  predictor is wired in for this PoC.
- Lives under `experimental/`; APIs may change and are not covered by backward-compat
  guarantees yet.

## Checklist

- [x] No changes to `areal/api`, `areal/engine`, launchers, or schedulers
- [x] Experimental engine does **not** subclass `InferenceEngine` (avoids LSP break)
- [x] `pre-commit` clean on touched files (ruff check + format, check-yaml, SPDX
  header, end-of-files, trailing-whitespace, detect-private-keys)
- [x] No wildcard imports, no hardcoded secrets/paths/endpoints
- [x] Per-step ⇄ whole-trajectory gradient equivalence is scriptable/reproducible
- [ ] Multi-node / GPU integration tests **skipped** — Phase 1 is single-GPU by design
