### PR TITLE
fix(ppo): derive group norm size from n_samples

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -3179,11 +3179,7 @@ class PPOConfig(BaseExperimentConfig):
         if self.rollout.use_lora and not self.rollout.lora_name:
             self.rollout.lora_name = self.gconfig.lora_name
 
-        # Group-level reward/advantage normalization groups the n_samples
-        # responses of one prompt, so its group_size is, by definition,
-        # gconfig.n_samples. YAML may keep `group_size: ${gconfig.n_samples}` as
-        # a visible reference, but runtime still enforces n_samples as the source
-        # of truth so mismatched literals cannot silently take effect.
+        # Runtime source of truth for prompt-group normalization.
         for _name, _norm in (
             ("reward_norm", self.actor.reward_norm),
             ("adv_norm", self.actor.adv_norm),
@@ -3192,8 +3188,6 @@ class PPOConfig(BaseExperimentConfig):
                 continue
             if _norm.mean_level != "group" and _norm.std_level != "group":
                 continue
-            # group_size=1 is the field default (unset), so deriving it silently is
-            # expected; only warn when a user set a different value out of sync.
             if _norm.group_size not in (1, self.gconfig.n_samples):
                 logger.warning(
                     "actor.%s.group_size=%d disagrees with gconfig.n_samples=%d; "

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -77,8 +77,8 @@ class NormConfig:
         default=1,
         metadata={
             "help": "Group size for group-level normalization. For the actor's "
-            "reward_norm/adv_norm this is auto-derived from gconfig.n_samples; "
-            "setting it by hand is unnecessary and a mismatched value is overridden."
+            "reward_norm/adv_norm this is derived from gconfig.n_samples; "
+            "mismatched values are overridden."
         },
     )
 
@@ -3181,10 +3181,9 @@ class PPOConfig(BaseExperimentConfig):
 
         # Group-level reward/advantage normalization groups the n_samples
         # responses of one prompt, so its group_size is, by definition,
-        # gconfig.n_samples. Make that the single source of truth instead of
-        # asking every config to repeat `group_size: ${gconfig.n_samples}` (a
-        # literal a user can mis-set out of sync with n_samples). Only touch a
-        # norm that actually uses group level.
+        # gconfig.n_samples. YAML may keep `group_size: ${gconfig.n_samples}` as
+        # a visible reference, but runtime still enforces n_samples as the source
+        # of truth so mismatched literals cannot silently take effect.
         for _name, _norm in (
             ("reward_norm", self.actor.reward_norm),
             ("adv_norm", self.actor.adv_norm),

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -74,7 +74,12 @@ class NormConfig:
         },
     )
     group_size: int = field(
-        default=1, metadata={"help": "Group size for group-level normalization"}
+        default=1,
+        metadata={
+            "help": "Group size for group-level normalization. For the actor's "
+            "reward_norm/adv_norm this is auto-derived from gconfig.n_samples; "
+            "setting it by hand is unnecessary and a mismatched value is overridden."
+        },
     )
 
     def __post_init__(self):
@@ -3173,6 +3178,33 @@ class PPOConfig(BaseExperimentConfig):
         # the engine config. Single source of truth: gconfig.lora_name.
         if self.rollout.use_lora and not self.rollout.lora_name:
             self.rollout.lora_name = self.gconfig.lora_name
+
+        # Group-level reward/advantage normalization groups the n_samples
+        # responses of one prompt, so its group_size is, by definition,
+        # gconfig.n_samples. Make that the single source of truth instead of
+        # asking every config to repeat `group_size: ${gconfig.n_samples}` (a
+        # literal a user can mis-set out of sync with n_samples). Only touch a
+        # norm that actually uses group level.
+        for _name, _norm in (
+            ("reward_norm", self.actor.reward_norm),
+            ("adv_norm", self.actor.adv_norm),
+        ):
+            if _norm is None:
+                continue
+            if _norm.mean_level != "group" and _norm.std_level != "group":
+                continue
+            # group_size=1 is the field default (unset), so deriving it silently is
+            # expected; only warn when a user set a different value out of sync.
+            if _norm.group_size not in (1, self.gconfig.n_samples):
+                logger.warning(
+                    "actor.%s.group_size=%d disagrees with gconfig.n_samples=%d; "
+                    "overriding with n_samples (the prompt-group size).",
+                    _name,
+                    _norm.group_size,
+                    self.gconfig.n_samples,
+                )
+            _norm.group_size = self.gconfig.n_samples
+
         super().__post_init__()
 
 

--- a/docs/en/algorithms/grpo_series.md
+++ b/docs/en/algorithms/grpo_series.md
@@ -88,13 +88,15 @@ The `NormConfig` dataclass controls how rewards and advantages are normalized:
 | `mean_leave1out` | bool        | `true`, `false`              | Use leave-one-out average (exclude current sample)         |
 | `std_unbiased`   | bool        | `true`, `false`              | Use unbiased std computation (default: `true`)             |
 | `eps`            | float       | -                            | Small constant to avoid division by zero (default: `1e-5`) |
-| `group_size`     | int         | -                            | Group size for group-level normalization                   |
+| `group_size`     | int         | -                            | Prompt-group size for group-level normalization            |
 
 "Batch" level computes the mean/std across the global batch, while "group" level
-computes them within groups (e.g., trajectories sharing the same prompt). For
-group-level normalization, `group_size` must be specified. Setting `mean_level` or
-`std_level` to `None` skips mean subtraction or standard deviation scaling,
-respectively.
+computes them within groups (e.g., trajectories sharing the same prompt). In PPO/GRPO
+actor reward/advantage normalization, `group_size` is derived from
+`gconfig.n_samples`, because that is the number of sampled responses for one prompt.
+YAML examples keep `group_size: ${gconfig.n_samples}` as a visible reference; a
+mismatched literal is overridden with a warning. Setting `mean_level` or `std_level` to
+`None` skips mean subtraction or standard deviation scaling, respectively.
 
 If the entire field is omitted (e.g., `adv_norm: null` in YAML), no normalization is
 performed.

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -309,14 +309,14 @@ Specification for splitting micro-batches during training.
 
 Configuration for reward/advantage normalization.
 
-| Parameter        | Type           | Default   | Description                                                                                                                                                                                         |
-| ---------------- | -------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`                                                                                                 |
-| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                                                                                                               |
-| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None`                                                                                    |
-| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).                                                                                            |
-| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                                                                                                              |
-| `group_size`     | integer        | `1`       | Group size for group-level normalization. For the actor's reward_norm/adv_norm this is auto-derived from gconfig.n_samples; setting it by hand is unnecessary and a mismatched value is overridden. |
+| Parameter        | Type           | Default   | Description                                                                                                                                              |
+| ---------------- | -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`                                                      |
+| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                                                                    |
+| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None`                                         |
+| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).                                                 |
+| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                                                                   |
+| `group_size`     | integer        | `1`       | Group size for group-level normalization. For the actor's reward_norm/adv_norm this is derived from gconfig.n_samples; mismatched values are overridden. |
 
 (section-optimizer)=
 

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -309,14 +309,14 @@ Specification for splitting micro-batches during training.
 
 Configuration for reward/advantage normalization.
 
-| Parameter        | Type           | Default   | Description                                                                                                      |
-| ---------------- | -------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
-| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`              |
-| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                            |
-| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None` |
-| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).         |
-| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                           |
-| `group_size`     | integer        | `1`       | Group size for group-level normalization                                                                         |
+| Parameter        | Type           | Default   | Description                                                                                                                                                                                         |
+| ---------------- | -------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`                                                                                                 |
+| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                                                                                                               |
+| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None`                                                                                    |
+| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).                                                                                            |
+| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                                                                                                              |
+| `group_size`     | integer        | `1`       | Group size for group-level normalization. For the actor's reward_norm/adv_norm this is auto-derived from gconfig.n_samples; setting it by hand is unnecessary and a mismatched value is overridden. |
 
 (section-optimizer)=
 

--- a/docs/zh/algorithms/grpo_series.md
+++ b/docs/zh/algorithms/grpo_series.md
@@ -82,10 +82,13 @@ python3 examples/math/gsm8k_rl.py \
 | `mean_leave1out` | bool        | `true`、`false`              | 使用留一法平均值（排除当前样本）   |
 | `std_unbiased`   | bool        | `true`、`false`              | 使用无偏标准差计算（默认：`true`） |
 | `eps`            | float       | -                            | 避免除零的小常数（默认：`1e-5`）   |
-| `group_size`     | int         | -                            | 分组级归一化的组大小               |
+| `group_size`     | int         | -                            | 分组级归一化的 prompt 组大小       |
 
-"Batch"级在整个全局批次上计算均值/标准差，而"group"级在组内计算（例如，共享相同提示的轨迹）。对于分组级归一化，必须指定 `group_size`。将
-`mean_level` 或 `std_level` 设为 `None` 分别跳过均值减法或标准差缩放。
+"Batch"级在整个全局批次上计算均值/标准差，而"group"级在组内计算（例如，共享相同提示的轨迹）。在 PPO/GRPO actor 的奖励/优势归一化中，`group_size`
+会从 `gconfig.n_samples` 派生，因为它就是同一 prompt 的采样响应数。YAML 示例保留
+`group_size: ${gconfig.n_samples}` 作为显式参考；如果手写的字面值与
+`gconfig.n_samples` 不一致，运行时会发出警告并覆盖该值。将 `mean_level` 或
+`std_level` 设为 `None` 分别跳过均值减法或标准差缩放。
 
 如果整个字段被省略（例如YAML中的 `adv_norm: null`），则不执行归一化。
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -307,14 +307,14 @@ Specification for splitting micro-batches during training.
 
 Configuration for reward/advantage normalization.
 
-| Parameter        | Type           | Default   | Description                                                                                                                                                                                         |
-| ---------------- | -------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`                                                                                                 |
-| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                                                                                                               |
-| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None`                                                                                    |
-| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).                                                                                            |
-| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                                                                                                              |
-| `group_size`     | integer        | `1`       | Group size for group-level normalization. For the actor's reward_norm/adv_norm this is auto-derived from gconfig.n_samples; setting it by hand is unnecessary and a mismatched value is overridden. |
+| Parameter        | Type           | Default   | Description                                                                                                                                              |
+| ---------------- | -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`                                                      |
+| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                                                                    |
+| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None`                                         |
+| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).                                                 |
+| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                                                                   |
+| `group_size`     | integer        | `1`       | Group size for group-level normalization. For the actor's reward_norm/adv_norm this is derived from gconfig.n_samples; mismatched values are overridden. |
 
 (section-optimizer)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -307,14 +307,14 @@ Specification for splitting micro-batches during training.
 
 Configuration for reward/advantage normalization.
 
-| Parameter        | Type           | Default   | Description                                                                                                      |
-| ---------------- | -------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
-| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`              |
-| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                            |
-| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None` |
-| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).         |
-| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                           |
-| `group_size`     | integer        | `1`       | Group size for group-level normalization                                                                         |
+| Parameter        | Type           | Default   | Description                                                                                                                                                                                         |
+| ---------------- | -------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mean_level`     | string \| None | `"batch"` | Mean level for normalization. None for no mean normalization. **Choices:** `batch`, `group`, `None`                                                                                                 |
+| `mean_leave1out` | boolean        | `False`   | Whether to use leave-one-out average.                                                                                                                                                               |
+| `std_level`      | string \| None | `"batch"` | Standard deviation level for normalization. None for no std normalization. **Choices:** `batch`, `group`, `None`                                                                                    |
+| `std_unbiased`   | boolean        | `True`    | Whether to use unbiased standard deviation computation. Defaults to True (changed from False in v0.3.4).                                                                                            |
+| `eps`            | float          | `1e-05`   | The eps when dividing by standard deviation to avoid numerical issues.                                                                                                                              |
+| `group_size`     | integer        | `1`       | Group size for group-level normalization. For the actor's reward_norm/adv_norm this is auto-derived from gconfig.n_samples; setting it by hand is unnecessary and a mismatched value is overridden. |
 
 (section-optimizer)=
 

--- a/examples/math/gsm8k_grpo.yaml
+++ b/examples/math/gsm8k_grpo.yaml
@@ -80,7 +80,7 @@ actor:
   reward_norm:
     mean_level: group
     std_level: group
-    # group_size is auto-derived from gconfig.n_samples (the prompt-group size).
+    group_size: ${gconfig.n_samples}
   adv_norm:
     mean_level: batch
     std_level: batch

--- a/examples/math/gsm8k_grpo.yaml
+++ b/examples/math/gsm8k_grpo.yaml
@@ -80,7 +80,7 @@ actor:
   reward_norm:
     mean_level: group
     std_level: group
-    group_size: ${gconfig.n_samples}
+    # group_size is auto-derived from gconfig.n_samples (the prompt-group size).
   adv_norm:
     mean_level: batch
     std_level: batch

--- a/tests/test_norm_group_size_derivation.py
+++ b/tests/test_norm_group_size_derivation.py
@@ -1,12 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Group-level reward/advantage normalization derives group_size from n_samples.
-
-The prompt-group that group-level reward_norm/adv_norm centers over *is* the
-rollout's n_samples responses, so PPOConfig.__post_init__ makes gconfig.n_samples
-the runtime source of truth even when YAML keeps `group_size: ${gconfig.n_samples}`
-as a visible reference for users.
-"""
-
 from areal.api.cli_args import (
     GenerationHyperparameters,
     GRPOConfig,
@@ -26,8 +18,6 @@ def test_group_norm_group_size_derived_from_n_samples():
 
 
 def test_mismatched_group_size_is_overridden():
-    # A hand-set group_size out of sync with n_samples cannot silently take
-    # effect: it is overridden with n_samples (the prompt-group size).
     cfg = GRPOConfig(
         gconfig=GenerationHyperparameters(n_samples=4),
         actor=PPOActorConfig(
@@ -38,7 +28,6 @@ def test_mismatched_group_size_is_overridden():
 
 
 def test_batch_level_norm_group_size_untouched():
-    # A norm that does not use group level never has its group_size rewritten.
     cfg = GRPOConfig(
         gconfig=GenerationHyperparameters(n_samples=4),
         actor=PPOActorConfig(

--- a/tests/test_norm_group_size_derivation.py
+++ b/tests/test_norm_group_size_derivation.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Group-level reward/advantage normalization derives group_size from n_samples.
+
+The prompt-group that group-level reward_norm/adv_norm centers over *is* the
+rollout's n_samples responses, so PPOConfig.__post_init__ makes gconfig.n_samples
+the single source of truth instead of a per-config `group_size: ${gconfig.n_samples}`
+literal a user can mis-set out of sync.
+"""
+
+from areal.api.cli_args import (
+    GenerationHyperparameters,
+    GRPOConfig,
+    NormConfig,
+    PPOActorConfig,
+)
+
+
+def test_group_norm_group_size_derived_from_n_samples():
+    cfg = GRPOConfig(
+        gconfig=GenerationHyperparameters(n_samples=8),
+        actor=PPOActorConfig(
+            reward_norm=NormConfig(mean_level="group", std_level="group"),
+        ),
+    )
+    assert cfg.actor.reward_norm.group_size == 8
+
+
+def test_mismatched_group_size_is_overridden():
+    # A hand-set group_size out of sync with n_samples cannot silently take
+    # effect: it is overridden with n_samples (the prompt-group size).
+    cfg = GRPOConfig(
+        gconfig=GenerationHyperparameters(n_samples=4),
+        actor=PPOActorConfig(
+            reward_norm=NormConfig(mean_level="group", group_size=7),
+        ),
+    )
+    assert cfg.actor.reward_norm.group_size == 4
+
+
+def test_batch_level_norm_group_size_untouched():
+    # A norm that does not use group level never has its group_size rewritten.
+    cfg = GRPOConfig(
+        gconfig=GenerationHyperparameters(n_samples=4),
+        actor=PPOActorConfig(
+            adv_norm=NormConfig(mean_level="batch", std_level="batch", group_size=3),
+        ),
+    )
+    assert cfg.actor.adv_norm.group_size == 3
+
+
+def test_none_norm_is_safe():
+    cfg = GRPOConfig(
+        gconfig=GenerationHyperparameters(n_samples=4),
+        actor=PPOActorConfig(reward_norm=None, adv_norm=None),
+    )
+    assert cfg.actor.reward_norm is None
+    assert cfg.actor.adv_norm is None

--- a/tests/test_norm_group_size_derivation.py
+++ b/tests/test_norm_group_size_derivation.py
@@ -3,8 +3,8 @@
 
 The prompt-group that group-level reward_norm/adv_norm centers over *is* the
 rollout's n_samples responses, so PPOConfig.__post_init__ makes gconfig.n_samples
-the single source of truth instead of a per-config `group_size: ${gconfig.n_samples}`
-literal a user can mis-set out of sync.
+the runtime source of truth even when YAML keeps `group_size: ${gconfig.n_samples}`
+as a visible reference for users.
 """
 
 from areal.api.cli_args import (


### PR DESCRIPTION
## Description

For group-level reward or advantage normalization, the group is the `gconfig.n_samples` responses sampled for one prompt. A separate hand-set `reward_norm.group_size` / `adv_norm.group_size` could drift from `gconfig.n_samples` and silently normalize against the wrong rows.

This PR makes `gconfig.n_samples` the runtime source of truth whenever actor reward/advantage normalization uses `mean_level: group` or `std_level: group`:

- derive `reward_norm.group_size` / `adv_norm.group_size` in `PPOConfig.__post_init__`
- warn and override mismatched explicit values instead of silently honoring them
- leave batch-level norms and `None` norms untouched
- keep the example YAML reference `group_size: ${gconfig.n_samples}` visible for users
- update English/Chinese GRPO docs and generated CLI references

## Validation

- `uv run pytest -q tests/test_norm_group_size_derivation.py`
- `uv run ruff check areal/api/cli_args.py tests/test_norm_group_size_derivation.py`
- `uv run ruff format --check areal/api/cli_args.py tests/test_norm_group_size_derivation.py`
- `git diff --check`

## Related Issue

Closes #1422.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Test coverage improvement
