### PR TITLE
fix(ppo): reject implicit partial group normalization

### DIFF
--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1423,6 +1423,11 @@ class Normalization:
                 slices.append(slice(offset, offset + sz))
                 offset += sz
             return slices
+        if bs % self.group_size != 0:
+            raise ValueError(
+                f"batch size ({bs}) must be divisible by group_size "
+                f"({self.group_size}) when group_sizes is not provided"
+            )
         return [
             slice(i * self.group_size, (i + 1) * self.group_size)
             for i in range(bs // self.group_size)

--- a/tests/test_reward_norm_variable_group.py
+++ b/tests/test_reward_norm_variable_group.py
@@ -143,6 +143,15 @@ def test_group_sizes_non_positive_raises():
         norm(x, group_sizes=[4, 0])
 
 
+def test_group_sizes_none_rejects_non_divisible_group_batch():
+    """Implicit fixed-size grouping must not leave a partial tail unnormalized."""
+    norm = Normalization(_group_norm_config())  # group_size=2
+    x = torch.tensor([0.0, 1.0, 2.0], dtype=torch.float32)  # bs=3
+
+    with pytest.raises(ValueError, match="divisible by group_size"):
+        norm(x)
+
+
 def test_adv_norm_style_2d_variable_groups_normalize_per_group():
     """Token-level (2D) advantages normalize per variable-size group on dim 0.
 


### PR DESCRIPTION
## Description

Current `main` already includes variable-size group normalization through #1454. This PR keeps the remaining invariant: when group-level `Normalization` is called without explicit `group_sizes`, it is using fixed-size groups, so the batch size must be divisible by `group_size`.

Before this guard, a direct fixed-stride call with a partial tail could leave tail rows with zero-filled normalization state. The PPO rollout path now passes `TrajBatchMeta.traj_group_sizes`, so this is a small boundary hardening for direct callers and future refactors.

## Superseded Context

The original broader #1415 head was `3e3ab94b257acf1a77dc5a9fdecf7cfea2a6f7f1`. That broader variable-group normalization change was superseded by #1454, merged to `main` as `bbc10f0e95bf350d71169efcb2facb9756f1238b` (PR commit `375cc12a4b91da50614aa9d2211ab9995475c942`). This PR is now only the remaining non-duplicative guard.

## Validation

- `uv run pytest -q tests/test_reward_norm_variable_group.py tests/test_adv_norm_config.py` (`214 passed`)
- `uv run ruff check areal/utils/data.py tests/test_reward_norm_variable_group.py`
- `uv run ruff format --check areal/utils/data.py tests/test_reward_norm_variable_group.py`
- `git diff --check origin/main...HEAD`

## Related Issue

Part of #1419.
