### PR TITLE
fix(reward): bound MathVerifyWorker.verify wall-clock on a hung verification

### DIFF
--- a/areal/reward/__init__.py
+++ b/areal/reward/__init__.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import concurrent.futures
+import multiprocessing as mp
+import queue
+import signal
+import threading
+import time
 
 from math_verify.grader import verify as math_verify_verify
 from math_verify.parser import ExprExtractionConfig, LatexExtractionConfig, parse
@@ -10,25 +14,42 @@ from areal.utils import logging
 logger = logging.getLogger("RewardUtils")
 
 
+class _MathVerifyTimeoutError(TimeoutError):
+    pass
+
+
+def _raise_math_verify_timeout(signum, frame):
+    del signum, frame
+    raise _MathVerifyTimeoutError()
+
+
+def _verify_in_subprocess(
+    worker: "MathVerifyWorker",
+    response: str,
+    ground_truth: str,
+    result_queue: mp.Queue,
+) -> None:
+    try:
+        result_queue.put(("ok", worker._verify_impl(response, ground_truth)))
+    except Exception as exc:
+        result_queue.put(("error", repr(exc)))
+
+
 class MathVerifyWorker:
     """Thin wrapper over math_verify with configurable extraction/precision.
 
     Uses ``parse()`` + ``verify()`` directly instead of ``math_metric()``
     so that signal-based timeouts can be disabled (``parsing_timeout=None``,
-    ``timeout_seconds=None``). This avoids ``signal.alarm()`` which only
-    works in the main thread. A thread-safe timeout is enforced via
-    ``concurrent.futures`` instead.
+    ``timeout_seconds=None``). ``verify()`` owns the timeout around the whole
+    operation.
 
     Args:
         try_extract_without_anchor: When False, only answers with explicit anchors
             (e.g., "answer = 1", "final answer = 1") are matched. When True,
             any numeric string in the text may be extracted.
         precision: Number of significant digits that must match.
-        timeout: Thread-safe timeout in seconds for the entire verify call
-            (parsing + comparison). ``None`` disables the timeout.
-
-    Notes:
-        Tune these knobs based on dataset format and model output style.
+        timeout: Timeout in seconds for parsing + comparison. ``None`` disables
+            the timeout.
     """
 
     def __init__(
@@ -70,20 +91,59 @@ class MathVerifyWorker:
         )
         return 1.0 if result else 0.0
 
+    def _verify_with_signal_timeout(self, response: str, ground_truth: str) -> float:
+        assert self.timeout is not None
+        previous_handler = signal.getsignal(signal.SIGALRM)
+        started = time.monotonic()
+        signal.signal(signal.SIGALRM, _raise_math_verify_timeout)
+        previous_timer = signal.setitimer(signal.ITIMER_REAL, self.timeout)
+        try:
+            return self._verify_impl(response, ground_truth)
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0.0)
+            signal.signal(signal.SIGALRM, previous_handler)
+            if previous_timer[0] > 0 or previous_timer[1] > 0:
+                elapsed = time.monotonic() - started
+                delay = max(previous_timer[0] - elapsed, 1e-6)
+                signal.setitimer(signal.ITIMER_REAL, delay, previous_timer[1])
+
+    def _verify_with_subprocess_timeout(
+        self, response: str, ground_truth: str
+    ) -> float:
+        assert self.timeout is not None
+        ctx = mp.get_context("spawn")
+        result_queue: mp.Queue = ctx.Queue(maxsize=1)
+        proc = ctx.Process(
+            target=_verify_in_subprocess,
+            args=(self, response, ground_truth, result_queue),
+        )
+        proc.start()
+        proc.join(self.timeout)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=1.0)
+            if proc.is_alive():
+                proc.kill()
+                proc.join()
+            raise _MathVerifyTimeoutError()
+        try:
+            status, payload = result_queue.get_nowait()
+        except queue.Empty:
+            return 0.0
+        if status == "ok":
+            return float(payload)
+        raise RuntimeError(payload)
+
     def verify(self, response: str, ground_truth: str) -> float:
-        executor = None
         try:
             if self.timeout is None:
                 return self._verify_impl(response, ground_truth)
-            # Don't use ThreadPoolExecutor as a context manager: _verify_impl runs
-            # with signal-based timeouts disabled, so a runaway call never returns,
-            # and __exit__'s shutdown(wait=True) would block past self.timeout
-            # joining it. Shut down with wait=False so the wall-clock stays bounded;
-            # the orphaned worker exits on its own.
-            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            future = executor.submit(self._verify_impl, response, ground_truth)
-            return future.result(timeout=self.timeout)
-        except concurrent.futures.TimeoutError:
+            if threading.current_thread() is threading.main_thread() and hasattr(
+                signal, "SIGALRM"
+            ):
+                return self._verify_with_signal_timeout(response, ground_truth)
+            return self._verify_with_subprocess_timeout(response, ground_truth)
+        except _MathVerifyTimeoutError:
             logger.warning(
                 f"Timeout ({self.timeout}s) in MathVerifyWorker.verify for "
                 f"response={response!r} and ground_truth={ground_truth!r}",
@@ -95,9 +155,6 @@ class MathVerifyWorker:
                 exc_info=True,
             )
             return 0.0
-        finally:
-            if executor is not None:
-                executor.shutdown(wait=False, cancel_futures=True)
 
 
 _MATH_VERIFY_WORKER: MathVerifyWorker | None = None

--- a/areal/reward/__init__.py
+++ b/areal/reward/__init__.py
@@ -71,12 +71,18 @@ class MathVerifyWorker:
         return 1.0 if result else 0.0
 
     def verify(self, response: str, ground_truth: str) -> float:
+        executor = None
         try:
             if self.timeout is None:
                 return self._verify_impl(response, ground_truth)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(self._verify_impl, response, ground_truth)
-                return future.result(timeout=self.timeout)
+            # Don't use ThreadPoolExecutor as a context manager: _verify_impl runs
+            # with signal-based timeouts disabled, so a runaway call never returns,
+            # and __exit__'s shutdown(wait=True) would block past self.timeout
+            # joining it. Shut down with wait=False so the wall-clock stays bounded;
+            # the orphaned worker exits on its own.
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(self._verify_impl, response, ground_truth)
+            return future.result(timeout=self.timeout)
         except concurrent.futures.TimeoutError:
             logger.warning(
                 f"Timeout ({self.timeout}s) in MathVerifyWorker.verify for "
@@ -89,6 +95,9 @@ class MathVerifyWorker:
                 exc_info=True,
             )
             return 0.0
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=False, cancel_futures=True)
 
 
 _MATH_VERIFY_WORKER: MathVerifyWorker | None = None

--- a/areal/reward/__init__.py
+++ b/areal/reward/__init__.py
@@ -38,10 +38,9 @@ def _verify_in_subprocess(
 class MathVerifyWorker:
     """Thin wrapper over math_verify with configurable extraction/precision.
 
-    Uses ``parse()`` + ``verify()`` directly instead of ``math_metric()``
-    so that signal-based timeouts can be disabled (``parsing_timeout=None``,
-    ``timeout_seconds=None``). ``verify()`` owns the timeout around the whole
-    operation.
+    ``math_verify`` timeouts use ``SIGALRM``, which is invalid in reward
+    worker threads. This wrapper disables those nested timeouts and owns one
+    wall-clock bound around parsing + comparison.
 
     Args:
         try_extract_without_anchor: When False, only answers with explicit anchors

--- a/areal/reward/__init__.py
+++ b/areal/reward/__init__.py
@@ -38,9 +38,12 @@ def _verify_in_subprocess(
 class MathVerifyWorker:
     """Thin wrapper over math_verify with configurable extraction/precision.
 
-    ``math_verify`` timeouts use ``SIGALRM``, which is invalid in reward
-    worker threads. This wrapper disables those nested timeouts and owns one
-    wall-clock bound around parsing + comparison.
+    ``verify()`` normally runs on a worker process's main thread, via
+    ``AsyncRewardWrapper``'s ``ProcessPoolExecutor``, where ``SIGALRM`` is
+    valid and bounds parsing + comparison directly. Off the main thread,
+    where ``SIGALRM`` is invalid, it falls back to a killable subprocess for
+    the same wall-clock bound. ``math_verify``'s own nested timeouts stay
+    disabled either way.
 
     Args:
         try_extract_without_anchor: When False, only answers with explicit anchors

--- a/tests/test_math_verify_reward.py
+++ b/tests/test_math_verify_reward.py
@@ -1,4 +1,3 @@
-import threading
 import time
 
 from areal.reward import (
@@ -771,20 +770,11 @@ class TestMathVerifyWorkerTextWrappedAnswers:
 
 
 class TestMathVerifyWorkerTimeout:
-    """Regression tests: a hung ``_verify_impl`` must not block past ``timeout``.
-
-    ``_verify_impl`` runs with signal-based timeouts disabled, so a runaway
-    call never returns on its own. ``verify`` must still bound the wall-clock
-    by ``self.timeout`` instead of blocking on the worker thread's join.
-    """
-
     def test_verify_returns_within_timeout_on_hang(self, monkeypatch):
         worker = MathVerifyWorker(timeout=0.1)
-        release = threading.Event()
 
         def hung_impl(response, ground_truth):
-            # Simulate a runaway call; the cap lets a regressed run fail fast.
-            release.wait(timeout=2.0)
+            time.sleep(2.0)
             return 1.0
 
         monkeypatch.setattr(worker, "_verify_impl", hung_impl)
@@ -792,7 +782,6 @@ class TestMathVerifyWorkerTimeout:
         start = time.monotonic()
         result = worker.verify("anything", "anything")
         elapsed = time.monotonic() - start
-        release.set()  # with the fix, verify already returned; let the worker exit now
 
-        assert result == 0.0  # the 0.0 default, not the worker's 1.0
-        assert elapsed < 1.0  # bounded by the 0.1s timeout, not the worker join
+        assert result == 0.0
+        assert elapsed < 1.0

--- a/tests/test_math_verify_reward.py
+++ b/tests/test_math_verify_reward.py
@@ -1,3 +1,5 @@
+import queue
+import threading
 import time
 
 from areal.reward import (
@@ -6,6 +8,13 @@ from areal.reward import (
     get_math_verify_worker,
     gsm8k_reward_fn,
 )
+
+
+class _HangingMathVerifyWorker(MathVerifyWorker):
+    def _verify_impl(self, response: str, ground_truth: str) -> float:
+        del response, ground_truth
+        time.sleep(2.0)
+        return 1.0
 
 
 class TestGSM8KRewardFn:
@@ -770,18 +779,29 @@ class TestMathVerifyWorkerTextWrappedAnswers:
 
 
 class TestMathVerifyWorkerTimeout:
-    def test_verify_returns_within_timeout_on_hang(self, monkeypatch):
-        worker = MathVerifyWorker(timeout=0.1)
-
-        def hung_impl(response, ground_truth):
-            time.sleep(2.0)
-            return 1.0
-
-        monkeypatch.setattr(worker, "_verify_impl", hung_impl)
-
+    def test_verify_returns_within_timeout_on_main_thread_hang(self):
+        worker = _HangingMathVerifyWorker(timeout=0.1)
         start = time.monotonic()
         result = worker.verify("anything", "anything")
         elapsed = time.monotonic() - start
 
+        assert result == 0.0
+        assert elapsed < 1.0
+
+    def test_verify_returns_within_timeout_on_worker_thread_hang(self):
+        worker = _HangingMathVerifyWorker(timeout=0.1)
+        results: queue.Queue[tuple[float, float]] = queue.Queue()
+
+        def run_verify():
+            start = time.monotonic()
+            result = worker.verify("anything", "anything")
+            results.put((result, time.monotonic() - start))
+
+        thread = threading.Thread(target=run_verify)
+        thread.start()
+        thread.join(timeout=3.0)
+
+        assert not thread.is_alive()
+        result, elapsed = results.get_nowait()
         assert result == 0.0
         assert elapsed < 1.0

--- a/tests/test_math_verify_reward.py
+++ b/tests/test_math_verify_reward.py
@@ -1,4 +1,12 @@
-from areal.reward import geometry3k_reward_fn, get_math_verify_worker, gsm8k_reward_fn
+import threading
+import time
+
+from areal.reward import (
+    MathVerifyWorker,
+    geometry3k_reward_fn,
+    get_math_verify_worker,
+    gsm8k_reward_fn,
+)
 
 
 class TestGSM8KRewardFn:
@@ -760,3 +768,31 @@ class TestMathVerifyWorkerTextWrappedAnswers:
         pred = "Result: \\boxed{(1/2)^{2} + \\sqrt{9}}"
         gold = "answer is 0.25 + 3"
         assert worker.verify(pred, gold) == 1.0
+
+
+class TestMathVerifyWorkerTimeout:
+    """Regression tests: a hung ``_verify_impl`` must not block past ``timeout``.
+
+    ``_verify_impl`` runs with signal-based timeouts disabled, so a runaway
+    call never returns on its own. ``verify`` must still bound the wall-clock
+    by ``self.timeout`` instead of blocking on the worker thread's join.
+    """
+
+    def test_verify_returns_within_timeout_on_hang(self, monkeypatch):
+        worker = MathVerifyWorker(timeout=0.1)
+        release = threading.Event()
+
+        def hung_impl(response, ground_truth):
+            # Simulate a runaway call; the cap lets a regressed run fail fast.
+            release.wait(timeout=2.0)
+            return 1.0
+
+        monkeypatch.setattr(worker, "_verify_impl", hung_impl)
+
+        start = time.monotonic()
+        result = worker.verify("anything", "anything")
+        elapsed = time.monotonic() - start
+        release.set()  # with the fix, verify already returned; let the worker exit now
+
+        assert result == 0.0  # the 0.0 default, not the worker's 1.0
+        assert elapsed < 1.0  # bounded by the 0.1s timeout, not the worker join


### PR DESCRIPTION
## Description

`MathVerifyWorker.verify()`'s internal timeout only stopped *waiting* on a hung parse/compare — it never stopped the hang itself, and that has a concrete production cost. `verify()` normally runs inside a worker process owned by `AsyncRewardWrapper`'s `ProcessPoolExecutor` (pool sized `max((cpu_count // device_count) // 2, 1)`, default `timeout_seconds=15`, `max_retries=3`). On `main`, a hung verification's `future.result(timeout=self.timeout)` raises promptly, but the `with ThreadPoolExecutor(...)` block's `__exit__` then calls `shutdown(wait=True)`, joining the still-hung worker thread forever — so `verify()` itself never returns, and the process running it never goes back to the pool. `AsyncRewardWrapper`'s own outer timeout stops *waiting* on that call too, but a running `ProcessPoolExecutor` future can't be cancelled or reclaimed, so its retries just consume more workers from the same small pool. One pathological sample can permanently tie up several of the (typically few) reward workers for the rest of the training run.

This PR replaces that with an actual wall-clock bound owned by `MathVerifyWorker.verify()`:

- main thread (the normal path — how `AsyncRewardWrapper` invokes `verify()`): scoped `SIGALRM` / `setitimer` around parse + comparison
- off the main thread, where `SIGALRM` is invalid: a killable subprocess, terminated/killed on timeout
- timeout/error behavior remains `0.0`

`math_verify`'s own nested timeouts stay disabled either way, since they are themselves `SIGALRM`-based and fail off the main thread. No public API or config changes.

## Validation

Refreshed against current `main`, preserving lazy reward imports and the timeout implementation.

- `pytest -q tests/test_math_verify_reward.py`: 71 passed, including signal and subprocess timeout cases.
- `pre-commit run --all-files` and independent integration review passed.

## Related Issue

Direct bug fix; no separate issue.

## Type of Change

- [x] Bug fix
