### PR TITLE
fix(fsdp): cast fp32 master to compute dtype in awex weight sync

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -1295,9 +1295,11 @@ class FSDPEngine(TrainEngine):
         """Cast fp32 master storage to compute dtype for export / rollout sync.
 
         When optimizer_dtype=float32 (the fp32 master weights default), the
-        underlying storage is fp32. HF export and xccl weight sync to rollout
-        engines (SGLang/vLLM) must cast back to compute dtype (typically bf16)
-        so deployment artefacts and broadcast bandwidth stay unchanged.
+        underlying storage is fp32. HF export, xccl weight sync, and the
+        awex FSDP adapter (see areal/v2/weight_update/awex/fsdp_adapter.py)
+        all cast back to compute dtype (typically bf16) so deployment
+        artefacts and broadcast bandwidth stay unchanged and NCCL sees
+        matching byte counts on both ends of the transfer.
         No-op when storage already matches compute dtype.
         """
         compute_dtype = self._compute_dtype()

--- a/areal/v2/weight_update/awex/fsdp_adapter.py
+++ b/areal/v2/weight_update/awex/fsdp_adapter.py
@@ -70,21 +70,30 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
         rank_info = self._build_rank_info()
         metadata: list[ParameterMeta] = []
 
+        # FSDPEngine keeps storage in optimizer_dtype (fp32 by default post
+        # #1369) while forward/backward run in config.dtype (bf16 typically)
+        # via FSDP2's MixedPrecisionPolicy. Rollout engines (SGLang/vLLM)
+        # are loaded in compute dtype, so metadata and the wire must agree
+        # on compute dtype — otherwise NCCL sees train fp32 (4B/elem) vs
+        # rollout bf16 (2B/elem) and hangs. Mirror the xccl-side cast in
+        # FSDPEngine._update_weights_from_distributed.
+        compute_dtype = self._engine._compute_dtype()
+
         for raw_name, param in self._engine.model.named_parameters():
             name = self._to_hf_name(raw_name)
             if self._tie_word_embeddings and name == "lm_head.weight":
                 continue
             tensor = param.data
+            global_shape = tuple(tensor.shape)
+            global_numel = int(tensor.numel())
             if isinstance(tensor, DTensor):
-                shard_meta = self._extract_dtensor_shard_meta(name, tensor, rank_info)
-                global_shape = tuple(tensor.shape)
-                global_numel = int(tensor.numel())
-                dtype = tensor.dtype
+                shard_meta = self._extract_dtensor_shard_meta(
+                    name, tensor, rank_info, compute_dtype
+                )
             else:
-                shard_meta = self._extract_plain_shard_meta(name, tensor, rank_info)
-                global_shape = tuple(tensor.shape)
-                global_numel = int(tensor.numel())
-                dtype = tensor.dtype
+                shard_meta = self._extract_plain_shard_meta(
+                    name, tensor, rank_info, compute_dtype
+                )
 
             replica = ParameterReplicaMeta(shards=[shard_meta])
             metadata.append(
@@ -92,7 +101,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
                     name=name,
                     global_numel=global_numel,
                     global_shape=global_shape,
-                    dtype=dtype,
+                    dtype=compute_dtype,
                     shards=[shard_meta],
                     replicas=[replica],
                 )
@@ -115,9 +124,13 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
 
             tensor = param.data
             if isinstance(tensor, DTensor):
-                local_params[name] = tensor._local_tensor
-            else:
-                local_params[name] = tensor
+                tensor = tensor._local_tensor
+            # Cast fp32 master storage to compute dtype (bf16 typically)
+            # before NCCL send. Must match the dtype reported by
+            # get_weight_metadata so the transfer plan and wire byte counts
+            # agree — see the comment in get_weight_metadata for context.
+            tensor = self._engine._cast_to_compute_dtype(tensor)
+            local_params[name] = tensor
 
         return local_params
 
@@ -292,6 +305,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
         name: str,
         dtensor: DTensor,
         rank_info: RankInfo,
+        dtype: torch.dtype,
     ) -> ParameterShardMeta:
         local_tensor = dtensor._local_tensor
         sharding_dim, num_shards = self._extract_dtensor_sharding(dtensor)
@@ -314,7 +328,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             name=name,
             shape=tuple(local_tensor.shape),
             numel=int(local_tensor.numel()),
-            dtype=local_tensor.dtype,
+            dtype=dtype,
             global_offset=self._compute_dtensor_offset(dtensor),
             sharding_type=sharding_type,
             num_shards=num_shards,
@@ -326,6 +340,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
         name: str,
         tensor: torch.Tensor,
         rank_info: RankInfo,
+        dtype: torch.dtype,
     ) -> ParameterShardMeta:
         return ParameterShardMeta(
             tp_rank=rank_info.tp_rank,
@@ -342,7 +357,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             name=name,
             shape=tuple(tensor.shape),
             numel=int(tensor.numel()),
-            dtype=tensor.dtype,
+            dtype=dtype,
             global_offset=tuple([0] * len(tuple(tensor.shape))),
             sharding_type=ShardingType.NO_SHARDING,
             num_shards=1,

--- a/tests/v2/weight_update/test_awex_fsdp_adapter.py
+++ b/tests/v2/weight_update/test_awex_fsdp_adapter.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :class:`AwexFSDPAdapter` dtype invariants.
+
+Regression guard for the awex-side counterpart of PR #1369's fp32 master
+weight fix. FSDPEngine stores parameters in ``optimizer_dtype`` (fp32 by
+default) but rollout engines expect ``compute_dtype`` (bf16). The awex
+adapter must cast on send and report ``compute_dtype`` in metadata,
+otherwise NCCL sees a byte-count mismatch (train fp32 = 4B/elem vs
+rollout bf16 = 2B/elem) and hangs at first transfer.
+
+These are CPU-only tests: they exercise the metadata / cast wiring on a
+plain ``nn.Module`` with fp32 parameters and assert the adapter reports
+and returns bf16. A full NCCL round-trip requires multi-GPU and is
+covered by the ``torchrun/`` integration tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.nn as nn
+
+# awex depends on megatron at import time; skip cleanly in dev envs that
+# do not ship megatron.
+pytest.importorskip("awex")
+pytest.importorskip("awex.meta.weight_meta")
+
+from areal.v2.weight_update.awex.fsdp_adapter import AwexFSDPAdapter  # noqa: E402
+
+
+class _TinyModel(nn.Module):
+    """Two fp32 parameters, one with a non-trivial name for HF renaming."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(4, 2, dtype=torch.float32))
+        self.bias = nn.Parameter(torch.zeros(4, dtype=torch.float32))
+
+
+def _make_engine(compute_dtype: torch.dtype) -> MagicMock:
+    """Mock FSDPEngine surface used by ``AwexFSDPAdapter``.
+
+    Only the attributes the adapter touches on the plain-tensor (non-DTensor)
+    code path are stubbed. That covers the metadata + cast invariants without
+    pulling in FSDP2 / DeviceMesh setup.
+    """
+    engine = MagicMock()
+    engine.model = _TinyModel()
+
+    # Non-vision model → _to_hf_name is a no-op passthrough.
+    engine.is_vision_model = False
+    engine.model_config.model_type = "llama"
+    engine.model_config.tie_word_embeddings = False
+
+    # RankInfo inputs — single-rank, no parallelism.
+    mesh = MagicMock()
+    mesh.mesh_dim_names = ()
+    mesh.size.return_value = 1
+    mesh.get_local_rank.return_value = 0
+    engine.world_mesh = mesh
+    engine.world_size = 1
+    engine.rank = 0
+    engine.data_parallel_world_size = 1
+    engine.dp_rank = 0
+
+    # This is the core of the regression: adapter must call these two.
+    engine._compute_dtype.return_value = compute_dtype
+
+    def _cast(t: torch.Tensor) -> torch.Tensor:
+        if t.is_floating_point() and t.dtype != compute_dtype:
+            return t.to(compute_dtype)
+        return t
+
+    engine._cast_to_compute_dtype.side_effect = _cast
+    return engine
+
+
+def test_get_weight_metadata_reports_compute_dtype_not_storage_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ParameterMeta.dtype and ParameterShardMeta.dtype must both be the
+    compute dtype the rollout side expects, even when the underlying
+    tensors are stored in fp32 master precision (PR #1369)."""
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    engine = _make_engine(compute_dtype=torch.bfloat16)
+    adapter = AwexFSDPAdapter(engine)
+
+    metadata = adapter.get_weight_metadata()
+
+    assert len(metadata) == 2, "expected one ParameterMeta per parameter"
+    for meta in metadata:
+        assert meta.dtype == torch.bfloat16, (
+            f"ParameterMeta.dtype for {meta.name} is {meta.dtype}; "
+            f"must be compute dtype (bf16), not fp32 storage dtype"
+        )
+        assert len(meta.shards) == 1
+        assert meta.shards[0].dtype == torch.bfloat16, (
+            f"ParameterShardMeta.dtype for {meta.name} is {meta.shards[0].dtype}; "
+            f"must be compute dtype (bf16), not fp32 storage dtype"
+        )
+
+
+def test_get_local_shard_parameters_returns_compute_dtype_tensors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tensors handed to NCCL must be in compute dtype so the wire
+    byte count matches ParameterMeta.dtype and the rollout receive
+    buffer."""
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    engine = _make_engine(compute_dtype=torch.bfloat16)
+    adapter = AwexFSDPAdapter(engine)
+
+    params = adapter.get_local_shard_parameters()
+
+    assert set(params.keys()) == {"weight", "bias"}
+    for name, tensor in params.items():
+        assert tensor.dtype == torch.bfloat16, (
+            f"{name} handed to NCCL is {tensor.dtype}; must be compute "
+            f"dtype (bf16) to match the sender-side ParameterMeta.dtype"
+        )
+
+
+def test_no_op_when_storage_already_matches_compute_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When storage dtype already equals compute dtype (e.g. user set
+    optimizer_dtype=bf16 explicitly), the adapter must still report
+    that dtype and hand through tensors unchanged."""
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    # Model tensors are fp32 by default; force compute dtype to fp32 so
+    # cast is a no-op path.
+    engine = _make_engine(compute_dtype=torch.float32)
+    adapter = AwexFSDPAdapter(engine)
+
+    metadata = adapter.get_weight_metadata()
+    params = adapter.get_local_shard_parameters()
+
+    for meta in metadata:
+        assert meta.dtype == torch.float32
+        assert meta.shards[0].dtype == torch.float32
+    for tensor in params.values():
+        assert tensor.dtype == torch.float32


### PR DESCRIPTION
PR #1369 decoupled FSDPEngine storage dtype (optimizer_dtype, fp32 by default) from forward/backward compute dtype (config.dtype, bf16 typically), and added a cast to compute dtype before broadcast on the xccl path and the HF export path. The awex FSDP adapter was missed — it still reports storage dtype in ParameterMeta/ParameterShardMeta and hands the fp32 _local_tensor to NCCL directly.

Rollout engines (SGLang/vLLM) load in compute dtype, so their receive buffers are sized for bf16. When train sends fp32 (4B/elem) and rollout expects bf16 (2B/elem), NCCL sees a byte-count mismatch: first real transfer trips the ProcessGroupNCCL.cpp:4004 "unbatched P2P op with size 0" warning, lazy-inits a new 2-rank sub-communicator against a stale/mismatched size, and hangs. Megatron does not hit this because megatron_engine has no optimizer_dtype split — storage stays bf16.

Fix: mirror the #1369 cast in the awex FSDP adapter. Report _compute_dtype() in ParameterMeta.dtype / ParameterShardMeta.dtype, and call FSDPEngine._cast_to_compute_dtype() on the local shard before send. Transfer plan and wire byte counts now agree.

Refs #1369.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
