### PR TITLE
fix(api): return float zero after async reward timeout

### DIFF
--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -158,7 +158,7 @@ class AsyncRewardWrapper:
                     f"{'Returning 0.' if is_last else 'Retrying...'}"
                 )
                 if is_last:
-                    return 0
+                    return 0.0
             except BrokenProcessPool:
                 logger.warning(
                     f"ProcessPoolExecutor broken (attempt {attempt + 1}/{self.max_retries + 1}). "
@@ -180,4 +180,4 @@ class AsyncRewardWrapper:
                 if is_last:
                     raise
 
-        return 0
+        return 0.0

--- a/tests/test_async_reward_wrapper.py
+++ b/tests/test_async_reward_wrapper.py
@@ -69,7 +69,8 @@ class TestAsyncRewardWrapperTimeout:
             _slow_reward, timeout_seconds=0.1, max_workers=1, max_retries=1
         )
         result = await wrapper(10.0)
-        assert result == 0
+        assert isinstance(result, float)
+        assert result == 0.0
 
     @pytest.mark.asyncio
     async def test_timeout_no_retries_returns_zero(self):
@@ -77,7 +78,8 @@ class TestAsyncRewardWrapperTimeout:
             _slow_reward, timeout_seconds=0.1, max_workers=1, max_retries=0
         )
         result = await wrapper(10.0)
-        assert result == 0
+        assert isinstance(result, float)
+        assert result == 0.0
 
 
 class TestAsyncRewardWrapperBrokenPool:


### PR DESCRIPTION
## Description

`AsyncRewardWrapper.__call__` declares a `float` result, but its
wrapper-owned timeout fallbacks return the integer `0`. This can be rejected
by the v1 OpenAI proxy workflow; v2 happens to normalize numeric rewards,
but switching controller versions is not a drop-in fix and v1 remains the
default.

Return `0.0` from both fallback paths and strengthen the existing timeout
tests to verify the result type. Successful user reward values are unchanged.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; existing regression tests were strengthened
- [x] Documentation updated (not applicable)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr`
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

Not applicable.

## Additional Context

Validation:

- `python -m pytest -q tests/test_async_reward_wrapper.py` — 15 passed
- `SKIP=generate-cli-docs pre-commit run --all-files`
