### PR TITLE
fix(data_proxy): require admin key for /register_model to prevent SSRF

### DIFF
--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -695,6 +695,13 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
     @app.post("/register_model", response_model=RegisterModelResponse)
     async def register_model(request: Request):
+        # /register_model configures an external upstream URL that the data
+        # proxy will fetch on behalf of /chat/completions callers. Without
+        # authentication, any network-adjacent attacker could point a model
+        # name at an internal address (e.g. cloud metadata service) and then
+        # trigger a server-side fetch via /chat/completions, exfiltrating the
+        # response — a classic SSRF (CWE-918). Restrict to the admin key.
+        _require_admin_key(request, app.state.session_store)
         body = await request.json()
         name = body.get("name") or body.get("model")
         url = body.get("url", "")


### PR DESCRIPTION
## Description

Closes #1549.

The `/register_model` endpoint on the inference-service data proxy (`areal/v2/inference_service/data_proxy/app.py`) accepts an arbitrary upstream URL from the request body and stores it in the in-memory model registry, without any authentication check. Every peer model-management endpoint on the same app (`unregister_model`, list/inspect at lines 467, 725, 771) already gates on `_require_admin_key(...)`, so the missing check on `/register_model` is a clear inconsistency rather than a design choice.

Once a URL is registered, a subsequent unauthenticated `POST /chat/completions` with `model=<attacker-name>` causes the proxy to issue a server-side HTTP request to that URL (see the fetch at lines 573/609) and return the response body to the caller. Because the service binds to `0.0.0.0` by default (`data_proxy/config.py`, `__main__.py`), any network-adjacent attacker can drive the process to fetch:

- cloud instance metadata (`http://169.254.169.254/latest/meta-data/...`) — credential theft on AWS/GCP/Azure clusters
- other loopback/internal services the training cluster reaches but the attacker does not
- internal port scanning via response/timing differentials

This is CWE-918 (Server-Side Request Forgery). Severity: high — unauthenticated, network-reachable, high-value target (IMDS credentials from a training cluster).

## Related Issue

Closes #1549

## Type of Change

- [x] 🐛 Bug fix

## Fix

Add the same admin-key check that already guards the sibling endpoints:

```python
@app.post("/register_model", response_model=RegisterModelResponse)
async def register_model(request: Request):
    _require_admin_key(request, app.state.session_store)
    ...
```

Seven lines including a comment, no behavior change for legitimate operators who already pass the admin key (the same header the other model-management routes require). No new dependencies, no config surface changes.

## Proof of Concept

Against a default-configured data proxy reachable at `PROXY`:

```bash
# 1. Register a malicious upstream (no auth required — this is the bug)
curl -sS -X POST "$PROXY/register_model" \
  -H 'Content-Type: application/json' \
  -d '{"name":"pwn","url":"http://169.254.169.254/latest/meta-data"}'

# 2. Trigger the server-side fetch and read the response body
curl -sS -X POST "$PROXY/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{"model":"pwn","messages":[{"role":"user","content":"x"}]}'
# → response contains the IMDS listing (iam/, hostname, etc.)

# 3. Pivot to IAM credentials
curl -sS -X POST "$PROXY/register_model" \
  -H 'Content-Type: application/json' \
  -d '{"name":"creds","url":"http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>"}'
curl -sS -X POST "$PROXY/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{"model":"creds","messages":[{"role":"user","content":"x"}]}'
```

After the fix, step 1 returns HTTP 401/403 from `_require_admin_key` and the chain cannot start.

## Testing

- Verified the endpoint exists at `data_proxy/app.py:696` and the fetch path at lines 573/609.
- Verified `_require_admin_key` is defined at line 125 and used identically on lines 467, 725, 771 — the fix reuses the existing helper with no new logic.
- Confirmed no FastAPI router-level `dependencies=[...]` gate exists on the app (grep for `APIRouter(dependencies` / `include_router(.*dependencies` returns nothing in this file), so the "unauthenticated" threat model is not silently mitigated by an outer layer.
- Confirmed the default bind is `0.0.0.0` in `config.py` / `__main__.py`, so exposure is not localhost-only in typical deployments.
- Pre-commit / diff scope: single-file, +7/-0.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether an upstream reverse proxy or router-level `Depends(...)` might already require auth — none exists on this FastAPI app. We checked whether the `/chat/completions` handler validates that the registered URL points to an allowed host — it does not; it fetches whatever was stored. We checked whether the preconditions (network reach to the data-proxy port) already grant the attacker the same access the SSRF provides — they do not: the SSRF specifically pierces into loopback and link-local (IMDS) surfaces that the external caller cannot reach directly. The finding survives.

## Checklist

- [x] I have read the Contributing Guide
- [x] Relevant tests pass; behavior for authorized callers is unchanged (same helper as sibling endpoints)
- [x] Branch is up to date with `main`
- [x] Self-reviewed

## Additional Context

The fix is intentionally minimal to make backporting easy. A follow-up hardening (host allow-list / block link-local + loopback in `/register_model`) would provide defense-in-depth, but the auth check alone closes the unauthenticated attack path, which is the material risk here.