### PR TITLE
fix: harden v2 teardown after TMS offload

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from contextlib import contextmanager, nullcontext
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -138,6 +138,9 @@ if TYPE_CHECKING:
     from areal.api.cli_args import DPOEngineConfig, PPOActorConfig, PPOCriticConfig
 
 
+_DESTROY_BARRIER_TIMEOUT = timedelta(seconds=10)
+
+
 @dataclasses.dataclass
 class FSDPTrainContext:
     """Context passed through FSDP forward/backward pipeline.
@@ -229,6 +232,7 @@ class FSDPEngine(TrainEngine):
         self._version: int = 0
 
         self._initialized = False
+        self._destroyed = False
         self.own_global_group = False
         self._cpu_group: dist.ProcessGroup
         self.weight_update_group_initialized = False
@@ -318,6 +322,9 @@ class FSDPEngine(TrainEngine):
         return cls(config)
 
     def create_process_group(self, parallel_strategy: ParallelStrategy | None = None):
+        # Starting a new process-group lifecycle makes the engine destroyable
+        # again if callers intentionally reuse the instance.
+        self._destroyed = False
         patch_dist_group_timeout(DIST_GROUP_DEFAULT_TIMEOUT)
 
         backend = current_platform.communication_backend
@@ -377,6 +384,8 @@ class FSDPEngine(TrainEngine):
         assert ft_spec is not None, "FSDPEngine requires FinetuneSpec to initialize."
         if pkg_version.is_version_less("torch", "2.4.0"):
             raise RuntimeError("areal only supports FSDP2, which requires torch>=2.4.0")
+
+        self._destroyed = False
 
         if is_tms_enabled():
             torch_memory_saver.hook_mode = "preload"
@@ -505,6 +514,21 @@ class FSDPEngine(TrainEngine):
         return self._cpu_group
 
     def destroy(self):
+        if getattr(self, "_destroyed", False):
+            return
+
+        # torch-memory-saver 0.0.9 cannot free a paused allocation safely:
+        # pause() has already unmapped it and released the CUDA handle, while
+        # free() repeats those operations.  Normalize the local TMS state before
+        # deleting model objects so their destructors only see active mappings.
+        # Keep this branch collective-free: ranks may observe different local
+        # state, and all ranks join the common CPU barrier below afterwards.
+        # TODO: Remove after torch-memory-saver#92 is fixed in the required release.
+        if self.is_offload:
+            torch_memory_saver.resume()
+            self.is_offload = False
+            current_platform.synchronize()
+
         self._initialized = False
         if hasattr(self, "optimizer"):
             del self.optimizer
@@ -531,7 +555,11 @@ class FSDPEngine(TrainEngine):
             # harmless but produces a noisy stderr backtrace at teardown.
             if getattr(self, "_cpu_group", None) is not None:
                 try:
-                    dist.barrier(group=self._cpu_group)
+                    dist.monitored_barrier(
+                        group=self._cpu_group,
+                        timeout=_DESTROY_BARRIER_TIMEOUT,
+                        wait_all_ranks=True,
+                    )
                 except Exception as e:  # pragma: no cover - best-effort
                     self.logger.warning(
                         f"pre-destroy CPU barrier failed (ignored): {e}"
@@ -541,6 +569,7 @@ class FSDPEngine(TrainEngine):
             # more than once (e.g. via cleanup hooks), the second call
             # must not try to destroy already-destroyed groups.
             self.own_global_group = False
+        self._destroyed = True
 
     @property
     def initialized(self) -> bool:
@@ -939,12 +968,11 @@ class FSDPEngine(TrainEngine):
         # Use torch_memory_saver to pause CUDA memory
         current_platform.clear_memory()
         torch_memory_saver.pause()
+        self.is_offload = True
 
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)
         self.get_device_stats().log("after offload model")
-
-        self.is_offload = True
 
     def onload(self) -> None:
         """Onload model memory from CPU back to GPU using torch_memory_saver.
@@ -953,12 +981,11 @@ class FSDPEngine(TrainEngine):
         """
 
         torch_memory_saver.resume()
+        self.is_offload = False
 
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)
         self.get_device_stats().log("after onload model")
-
-        self.is_offload = False
 
     def clear_batches(self, shard_ids: list[str] | None = None) -> None:
         """Drain this worker's client-side RTensor fetch buffer.

--- a/areal/infra/rpc/guard/app.py
+++ b/areal/infra/rpc/guard/app.py
@@ -31,7 +31,7 @@ from typing import Any
 
 from flask import Flask, current_app, jsonify, request
 
-from areal.infra.utils.proc import kill_process_tree, run_with_streaming_logs
+from areal.infra.utils.proc import kill_process_group, run_with_streaming_logs
 from areal.utils import logging
 from areal.utils.network import find_free_ports, format_hostport
 
@@ -126,26 +126,44 @@ def get_state() -> GuardState:
 
 
 def cleanup_forked_children(state: GuardState) -> None:
-    """Clean up all forked child processes.
+    """Clean up all forked child process groups.
 
-    Copies the child list under the lock, then releases before blocking
-    kills (avoids holding the lock for up to 4s × N children).
+    Records are removed only after their independently tracked process group
+    is verified empty, so a failed shutdown remains retryable.
     """
     with state.forked_children_lock:
-        if not state.forked_children:
+        children_to_kill = list(
+            dict.fromkeys([*state.forked_children, *state.forked_children_map.values()])
+        )
+        if not children_to_kill:
             return
-        children_to_kill = list(state.forked_children)
-        state.forked_children.clear()
-        state.forked_children_map.clear()
 
     logger.info(f"Cleaning up {len(children_to_kill)} forked child processes")
     for child in children_to_kill:
         try:
-            if child.poll() is None:  # Still running
-                kill_process_tree(child.pid, timeout=3, graceful=True)
-                logger.info(f"Killed forked child process {child.pid}")
+            # The shell leader may already have exited while descendants stay
+            # alive. Its PID is also the dedicated PGID created by /fork.
+            kill_process_group(child.pid, timeout=3, graceful=True)
+            try:
+                child.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                logger.warning(f"Timed out reaping forked child leader {child.pid}")
+
+            with state.forked_children_lock:
+                try:
+                    state.forked_children.remove(child)
+                except ValueError:
+                    pass
+                stale_keys = [
+                    key
+                    for key, process in state.forked_children_map.items()
+                    if process is child
+                ]
+                for key in stale_keys:
+                    state.forked_children_map.pop(key, None)
+            logger.info(f"Killed forked child process group {child.pid}")
         except Exception as e:
-            logger.error(f"Error killing forked child {child.pid}: {e}")
+            logger.error(f"Error killing forked child group {child.pid}: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +261,7 @@ def create_app(state: GuardState) -> Flask:
 
         Returns::
 
-            {"status": "success", "host": "10.0.0.1", "pid": 42}
+            {"status": "success", "host": "10.0.0.1", "pid": 42, "pgid": 42}
         """
         s = get_state()
 
@@ -304,6 +322,7 @@ def create_app(state: GuardState) -> Flask:
                 merged_log,
                 role,
                 env=child_env,
+                isolate_process_group=True,
             )
 
             with s.forked_children_lock:
@@ -320,6 +339,7 @@ def create_app(state: GuardState) -> Flask:
                     "status": "success",
                     "host": s.server_host,
                     "pid": child_process.pid,
+                    "pgid": child_process.pid,
                 }
             )
 
@@ -358,17 +378,10 @@ def create_app(state: GuardState) -> Flask:
 
             key = (role, worker_index)
 
-            # Remove from tracking structures (hold lock only for dict/list ops)
+            # Keep tracking until the process group is verified empty so a
+            # failed kill remains retryable.
             with s.forked_children_lock:
-                child_process = s.forked_children_map.pop(key, None)
-                if child_process:
-                    try:
-                        s.forked_children.remove(child_process)
-                    except ValueError:
-                        logger.warning(
-                            f"Process for {role}/{worker_index} was in map "
-                            "but not in list"
-                        )
+                child_process = s.forked_children_map.get(key)
 
             if child_process is None:
                 return (
@@ -380,13 +393,13 @@ def create_app(state: GuardState) -> Flask:
 
             pid = child_process.pid
 
-            # Kill process tree (outside lock to avoid blocking)
+            # Kill the stable PGID even if the tracked shell leader exited.
             try:
-                if child_process.poll() is None:  # Still running
-                    kill_process_tree(pid, timeout=3, graceful=True)
-                    logger.info(
-                        f"Killed forked worker {role}/{worker_index} (pid={pid})"
-                    )
+                kill_process_group(pid, timeout=3, graceful=True)
+                try:
+                    child_process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    logger.warning(f"Timed out reaping forked child leader {pid}")
             except Exception as e:
                 logger.error(
                     f"Error killing forked worker "
@@ -397,16 +410,32 @@ def create_app(state: GuardState) -> Flask:
                         {
                             "error": f"Failed to kill forked worker: {str(e)}",
                             "pid": pid,
+                            "pgid": pid,
                         }
                     ),
                     500,
                 )
 
+            with s.forked_children_lock:
+                if s.forked_children_map.get(key) is child_process:
+                    s.forked_children_map.pop(key, None)
+                try:
+                    s.forked_children.remove(child_process)
+                except ValueError:
+                    logger.warning(
+                        f"Process for {role}/{worker_index} was in map but not in list"
+                    )
+
+            logger.info(
+                f"Killed forked worker {role}/{worker_index} (pid={pid}, pgid={pid})"
+            )
+
             return jsonify(
                 {
                     "status": "success",
                     "message": (
-                        f"Killed forked worker {role}/{worker_index} (pid={pid})"
+                        f"Killed forked worker {role}/{worker_index} "
+                        f"(pid={pid}, pgid={pid})"
                     ),
                 }
             )

--- a/areal/infra/utils/proc.py
+++ b/areal/infra/utils/proc.py
@@ -9,6 +9,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -98,6 +99,7 @@ def run_with_streaming_logs(
     env: dict[str, str] | None = None,
     env_vars_in_cmd: dict[str, str] | None = None,
     stdout: IO | None = None,
+    isolate_process_group: bool = False,
 ) -> subprocess.Popen:
     """Run a command with streaming output to stdout and log files.
 
@@ -117,6 +119,10 @@ def run_with_streaming_logs(
         Environment variables to prefix in the shell command (KEY=VALUE format)
     stdout : IO | None
         File object for stdout. Defaults to sys.stdout
+    isolate_process_group : bool
+        Create the shell pipeline as the leader of a new process group.  This
+        keeps the existing session while giving callers a stable boundary for
+        terminating descendants after the shell leader exits. POSIX only.
 
     Returns
     -------
@@ -127,6 +133,10 @@ def run_with_streaming_logs(
         cmd, str(log_file), str(merged_log), role, env_vars=env_vars_in_cmd
     )
 
+    if isolate_process_group and os.name != "posix":
+        raise RuntimeError("Process-group isolation is only supported on POSIX")
+
+    popen_kwargs = {"process_group": 0} if isolate_process_group else {}
     return subprocess.Popen(
         shell_cmd,
         shell=True,
@@ -134,7 +144,84 @@ def run_with_streaming_logs(
         env=env,
         stdout=stdout or sys.stdout,
         stderr=stdout or sys.stdout,
+        **popen_kwargs,
     )
+
+
+def _get_process_group_members(pgid: int) -> list[psutil.Process]:
+    """Return live, non-zombie processes that currently belong to ``pgid``."""
+    members: list[psutil.Process] = []
+    for process in psutil.process_iter(["pid", "status"]):
+        try:
+            if os.getpgid(process.pid) != pgid:
+                continue
+            if process.info["status"] == psutil.STATUS_ZOMBIE:
+                continue
+            members.append(process)
+        except (ProcessLookupError, PermissionError, psutil.Error):
+            continue
+    return members
+
+
+def _wait_for_process_group_exit(pgid: int, timeout: float) -> list[int]:
+    deadline = time.monotonic() + timeout
+    while True:
+        members = _get_process_group_members(pgid)
+        if not members:
+            return []
+        if time.monotonic() >= deadline:
+            return sorted(process.pid for process in members)
+        time.sleep(0.05)
+
+
+def kill_process_group(
+    pgid: int,
+    timeout: float = 5,
+    graceful: bool = True,
+) -> None:
+    """Terminate and verify an isolated POSIX process group.
+
+    Unlike :func:`kill_process_tree`, this remains effective after the tracked
+    shell leader exits and descendants are reparented.  It must only be used
+    for groups explicitly created with ``isolate_process_group=True``.
+    """
+    if os.name != "posix":
+        raise RuntimeError("Process-group termination is only supported on POSIX")
+    if pgid <= 0:
+        raise ValueError(f"Invalid process group id: {pgid}")
+    if pgid == os.getpgrp():
+        raise RuntimeError(f"Refusing to terminate the current process group {pgid}")
+
+    members = _get_process_group_members(pgid)
+    if not members:
+        logger.info(f"Process group {pgid} already terminated")
+        return
+
+    initial_pids = sorted(process.pid for process in members)
+    first_signal = signal.SIGTERM if graceful else signal.SIGKILL
+    logger.info(f"Sending {first_signal.name} to process group {pgid}: {initial_pids}")
+    try:
+        os.killpg(pgid, first_signal)
+    except ProcessLookupError:
+        return
+
+    remaining = _wait_for_process_group_exit(pgid, timeout if graceful else 1)
+    if remaining and graceful:
+        logger.warning(
+            f"Force killing process group {pgid}; remaining PIDs: {remaining}"
+        )
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        remaining = _wait_for_process_group_exit(pgid, 1)
+
+    if remaining:
+        raise RuntimeError(
+            f"Process group {pgid} still has live members after termination: "
+            f"{remaining}"
+        )
+    logger.info(f"Successfully cleaned up process group {pgid}")
 
 
 def kill_process_tree(

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import traceback
+from dataclasses import dataclass
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -26,6 +27,47 @@ if TYPE_CHECKING:
     from areal.api.scheduler_api import Scheduler, Worker
 
 logger = logging.getLogger("GatewayTrainController")
+
+
+@dataclass(frozen=True)
+class TeardownCallResult:
+    """Outcome of one bounded controller teardown operation."""
+
+    phase: str
+    target: str
+    success: bool
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class TeardownReport:
+    """Immutable aggregate of graceful and forced teardown outcomes."""
+
+    awex_results: tuple[TeardownCallResult, ...] = ()
+    engine_results: tuple[TeardownCallResult, ...] = ()
+    forked_service_results: tuple[TeardownCallResult, ...] = ()
+    guard_results: tuple[TeardownCallResult, ...] = ()
+    scheduler_results: tuple[TeardownCallResult, ...] = ()
+    controller_results: tuple[TeardownCallResult, ...] = ()
+
+    @property
+    def results(self) -> tuple[TeardownCallResult, ...]:
+        return (
+            self.awex_results
+            + self.engine_results
+            + self.forked_service_results
+            + self.guard_results
+            + self.scheduler_results
+            + self.controller_results
+        )
+
+    @property
+    def failures(self) -> tuple[TeardownCallResult, ...]:
+        return tuple(result for result in self.results if not result.success)
+
+    @property
+    def successful(self) -> bool:
+        return not self.failures
 
 
 class GatewayTrainController:
@@ -70,6 +112,7 @@ class GatewayTrainController:
         self._init_lock = threading.Lock()
         self._workers_ready = threading.Event()
         self._shutdown_requested = threading.Event()
+        self._last_teardown_report: TeardownReport | None = None
 
     # -- Initialize --------------------------------------------------------
 
@@ -583,9 +626,10 @@ class GatewayTrainController:
 
     def _kill_forked_service(
         self, guard_addr: str, role: str, worker_index: int
-    ) -> None:
+    ) -> TeardownCallResult:
         import requests
 
+        target = f"{guard_addr} {role}/{worker_index}"
         try:
             resp = requests.post(
                 f"{guard_addr}/kill_forked_worker",
@@ -594,12 +638,63 @@ class GatewayTrainController:
             )
             if resp.status_code == 200:
                 logger.info("Killed forked service %s/%d", role, worker_index)
-            else:
-                logger.warning(
-                    "Failed to kill %s/%d: %s", role, worker_index, resp.text
+                return TeardownCallResult("forked-service", target, True)
+            if resp.status_code == 404:
+                logger.info(
+                    "Forked service %s/%d was already absent", role, worker_index
                 )
+                return TeardownCallResult("forked-service", target, True)
+
+            error = f"HTTP {resp.status_code}: {resp.text}"
+            logger.warning("Failed to kill %s/%d: %s", role, worker_index, error)
+            return TeardownCallResult("forked-service", target, False, error)
         except Exception as exc:
             logger.error("Error killing %s/%d: %s", role, worker_index, exc)
+            return TeardownCallResult("forked-service", target, False, str(exc))
+
+    def _verify_guard_cleanup(self, guard_addr: str) -> TeardownCallResult:
+        import requests
+
+        try:
+            resp = requests.get(f"{guard_addr}/health", timeout=5)
+            resp.raise_for_status()
+            child_count = resp.json().get("forked_children")
+            if child_count != 0:
+                error = f"guard still tracks {child_count!r} forked children"
+                return TeardownCallResult("guard-drain", guard_addr, False, error)
+            return TeardownCallResult("guard-drain", guard_addr, True)
+        except Exception as exc:
+            return TeardownCallResult("guard-drain", guard_addr, False, str(exc))
+
+    def _cleanup_forked_services(self) -> tuple[TeardownCallResult, ...]:
+        services = list(reversed(self._forked_services))
+        ingress_services = [item for item in services if item[1] != "train-worker"]
+        training_workers = [item for item in services if item[1] == "train-worker"]
+
+        results = [self._kill_forked_service(*item) for item in ingress_services]
+        if training_workers:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(len(training_workers), 32),
+                thread_name_prefix="ctrl_teardown",
+            ) as executor:
+                futures = [
+                    (item, executor.submit(self._kill_forked_service, *item))
+                    for item in training_workers
+                ]
+                for item, future in futures:
+                    try:
+                        results.append(future.result())
+                    except Exception as exc:  # pragma: no cover - defensive
+                        guard_addr, role, worker_index = item
+                        results.append(
+                            TeardownCallResult(
+                                "forked-service",
+                                f"{guard_addr} {role}/{worker_index}",
+                                False,
+                                str(exc),
+                            )
+                        )
+        return tuple(results)
 
     # -- Health checks -----------------------------------------------------
 
@@ -1100,7 +1195,7 @@ class GatewayTrainController:
 
     # -- Destroy -----------------------------------------------------------
 
-    def _graceful_shutdown_workers(self) -> None:
+    def _graceful_shutdown_workers(self) -> TeardownReport:
         """Destroy engines on all training workers before killing processes.
 
         ``dist.destroy_process_group()`` is a local operation
@@ -1110,40 +1205,78 @@ class GatewayTrainController:
         ``recvValue failed`` warning from the now-dead TCPStore.
         """
         if not self._worker_addrs:
-            return
+            return TeardownReport()
 
-        async def _shutdown_all() -> None:
-            timeout = aiohttp.ClientTimeout(total=30)
+        async def _shutdown_phase(
+            session: aiohttp.ClientSession,
+            phase: str,
+            path: str,
+            *,
+            payload: dict[str, Any] | None = None,
+        ) -> tuple[TeardownCallResult, ...]:
+            async def _shutdown_one(addr: str) -> TeardownCallResult:
+                try:
+                    kwargs = {"json": payload} if payload is not None else {}
+                    async with session.post(f"{addr}{path}", **kwargs) as resp:
+                        resp.raise_for_status()
+                    return TeardownCallResult(phase, addr, True)
+                except Exception as exc:
+                    return TeardownCallResult(phase, addr, False, str(exc))
+
+            return tuple(
+                await asyncio.gather(
+                    *[_shutdown_one(addr) for addr in self._worker_addrs]
+                )
+            )
+
+        async def _shutdown_all() -> TeardownReport:
+            timeout = aiohttp.ClientTimeout(total=self.config.request_timeout)
             async with aiohttp.ClientSession(timeout=timeout) as session:
-                tasks = []
-                for addr in self._worker_addrs:
-                    tasks.append(_shutdown_one(session, addr))
-                await asyncio.gather(*tasks, return_exceptions=True)
-
-        async def _shutdown_one(session: aiohttp.ClientSession, addr: str) -> None:
-            try:
-                async with session.post(f"{addr}/awex/teardown") as resp:
-                    resp.raise_for_status()
-            except Exception as e:
-                logger.warning(
-                    "Graceful shutdown: failed to call /awex/teardown on %s: %s",
-                    addr,
-                    e,
+                # This is intentionally global two-phase teardown.  No rank
+                # starts destroying its engine/process groups until every rank
+                # has completed (or failed) AWEX teardown.
+                awex_results = await _shutdown_phase(session, "awex", "/awex/teardown")
+                engine_results = await _shutdown_phase(
+                    session, "engine", "/destroy_engine", payload={}
                 )
-            try:
-                async with session.post(f"{addr}/destroy_engine", json={}) as resp:
-                    resp.raise_for_status()
-            except Exception as e:
-                logger.warning(
-                    "Graceful shutdown: failed to call /destroy_engine on %s: %s",
-                    addr,
-                    e,
+                return TeardownReport(
+                    awex_results=awex_results,
+                    engine_results=engine_results,
                 )
 
-        run_async_task(_shutdown_all)
-        logger.info("All training worker engines destroyed gracefully")
+        try:
+            report = run_async_task(_shutdown_all)
+        except Exception as exc:
+            # A session/event-loop failure must not prevent the guard and
+            # scheduler fallbacks below from draining worker processes.
+            error = f"teardown orchestration failed: {exc}"
+            report = TeardownReport(
+                awex_results=tuple(
+                    TeardownCallResult("awex", addr, False, error)
+                    for addr in self._worker_addrs
+                ),
+                engine_results=tuple(
+                    TeardownCallResult("engine", addr, False, error)
+                    for addr in self._worker_addrs
+                ),
+            )
+        if report.successful:
+            logger.info("All training worker engines destroyed gracefully")
+        else:
+            for failure in report.failures:
+                logger.warning(
+                    "Training worker teardown failed during %s on %s: %s",
+                    failure.phase,
+                    failure.target,
+                    failure.error,
+                )
+            logger.error(
+                "Training worker graceful teardown incomplete: %d operation(s) failed",
+                len(report.failures),
+            )
+        return report
 
-    def _cleanup_runtime_state(self) -> None:
+    def _cleanup_runtime_state(self) -> TeardownReport:
         if self._router_addr and self._model_addr:
             try:
                 import requests
@@ -1157,30 +1290,43 @@ class GatewayTrainController:
             except Exception:
                 logger.error("Failed to unregister model: %s", traceback.format_exc())
 
-        self._graceful_shutdown_workers()
+        worker_report = self._graceful_shutdown_workers()
 
-        for guard_addr, role, worker_index in reversed(self._forked_services):
-            try:
-                self._kill_forked_service(guard_addr, role, worker_index)
-            except Exception:
-                logger.error(
-                    "Error killing %s/%d: %s",
-                    role,
-                    worker_index,
-                    traceback.format_exc(),
+        forked_service_results = self._cleanup_forked_services()
+        guard_addrs = list(dict.fromkeys(self._guard_addrs))
+        if guard_addrs:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(len(guard_addrs), 32),
+                thread_name_prefix="guard_verify",
+            ) as executor:
+                guard_results = tuple(
+                    executor.map(self._verify_guard_cleanup, guard_addrs)
                 )
+        else:
+            guard_results = ()
         self._forked_services.clear()
 
+        scheduler_results: list[TeardownCallResult] = []
+        failed_scheduler_roles: set[str] = set()
         for role in reversed(self._service_roles):
             try:
-                self.scheduler.delete_workers(role=role)
+                self.scheduler.delete_workers(role=role, reverse_order=True)
                 logger.info("Workers deleted for role: %s", role)
-            except Exception:
+                scheduler_results.append(TeardownCallResult("scheduler", role, True))
+            except Exception as exc:
+                failed_scheduler_roles.add(role)
                 logger.error(
                     "Error deleting workers for %s: %s", role, traceback.format_exc()
                 )
-        self._service_roles.clear()
+                scheduler_results.append(
+                    TeardownCallResult("scheduler", role, False, str(exc))
+                )
+        self._service_roles = [
+            role for role in self._service_roles if role in failed_scheduler_roles
+        ]
         self._worker_addrs.clear()
+        if not failed_scheduler_roles:
+            self._guard_addrs.clear()
         self._router_addr = ""
         self._gateway_addr = ""
         self._model_addr = ""
@@ -1196,16 +1342,55 @@ class GatewayTrainController:
 
         import torch.distributed as dist
 
+        controller_results: list[TeardownCallResult] = []
         if self._own_process_group:
             try:
                 if dist.is_initialized():
                     dist.destroy_process_group()
-            except Exception:
+                controller_results.append(
+                    TeardownCallResult(
+                        "controller-process-group",
+                        "default",
+                        True,
+                    )
+                )
+                self._own_process_group = False
+            except Exception as exc:
                 logger.error(
                     "Failed to destroy process group: %s", traceback.format_exc()
                 )
-            finally:
-                self._own_process_group = False
+                controller_results.append(
+                    TeardownCallResult(
+                        "controller-process-group",
+                        "default",
+                        False,
+                        str(exc),
+                    )
+                )
+
+        report = TeardownReport(
+            awex_results=worker_report.awex_results,
+            engine_results=worker_report.engine_results,
+            forked_service_results=forked_service_results,
+            guard_results=guard_results,
+            scheduler_results=tuple(scheduler_results),
+            controller_results=tuple(controller_results),
+        )
+        self._last_teardown_report = report
+        for failure in (
+            report.forked_service_results
+            + report.guard_results
+            + report.scheduler_results
+            + report.controller_results
+        ):
+            if not failure.success:
+                logger.error(
+                    "Controller teardown failed during %s on %s: %s",
+                    failure.phase,
+                    failure.target,
+                    failure.error,
+                )
+        return report
 
     def destroy(self) -> None:
         self._shutdown_requested.set()
@@ -1214,4 +1399,23 @@ class GatewayTrainController:
         if future is not None:
             future.cancel()
 
+        # Do not replace a prior failure report with an empty success report
+        # when cleanup hooks call destroy() again after all targets are gone.
+        has_runtime_state = bool(
+            self._worker_addrs
+            or self._forked_services
+            or self._guard_addrs
+            or self._service_roles
+            or self._router_addr
+            or self._gateway_addr
+            or self._model_addr
+            or self._async_client is not None
+            or self._own_process_group
+        )
+        if not has_runtime_state and self._last_teardown_report is not None:
+            return
+
+        # Preserve the historical best-effort public API.  Callers destroy
+        # multiple controllers sequentially, so raising here would skip later
+        # cleanup.  Failures remain visible in logs and the immutable report.
         self._cleanup_runtime_state()

--- a/tests/infra/data_service/test_guard.py
+++ b/tests/infra/data_service/test_guard.py
@@ -76,9 +76,10 @@ def test_fork_raw_command_success(mock_run, client, state: GuardState):
     assert data["host"] == "10.0.0.1"
     assert data["pid"] == 42
     assert ("worker", 1) in state.forked_children_map
+    assert mock_run.call_args.kwargs["isolate_process_group"] is True
 
 
-@patch("areal.infra.rpc.guard.app.kill_process_tree")
+@patch("areal.infra.rpc.guard.app.kill_process_group")
 def test_kill_known_worker(mock_kill, client, state: GuardState):
     mock_proc = _make_mock_process(pid=123)
     state.forked_children.append(mock_proc)
@@ -90,7 +91,7 @@ def test_kill_known_worker(mock_kill, client, state: GuardState):
     mock_kill.assert_called_once_with(123, timeout=3, graceful=True)
 
 
-@patch("areal.infra.rpc.guard.app.kill_process_tree")
+@patch("areal.infra.rpc.guard.app.kill_process_group")
 def test_cleanup_kills_all_running_children(mock_kill, state: GuardState):
     proc1 = _make_mock_process(pid=100)
     proc2 = _make_mock_process(pid=200)
@@ -102,3 +103,18 @@ def test_cleanup_kills_all_running_children(mock_kill, state: GuardState):
     assert mock_kill.call_count == 2
     assert state.forked_children == []
     assert state.forked_children_map == {}
+
+
+@patch("areal.infra.rpc.guard.app.kill_process_group")
+def test_kill_failure_keeps_worker_tracked(mock_kill, client, state: GuardState):
+    mock_proc = _make_mock_process(pid=123)
+    state.forked_children.append(mock_proc)
+    state.forked_children_map[("test", 0)] = mock_proc
+    mock_kill.side_effect = RuntimeError("group still alive")
+
+    resp = client.post("/kill_forked_worker", json={"role": "test", "worker_index": 0})
+
+    assert resp.status_code == 500
+    assert resp.get_json()["pgid"] == 123
+    assert mock_proc in state.forked_children
+    assert state.forked_children_map[("test", 0)] is mock_proc

--- a/tests/infra/test_proc.py
+++ b/tests/infra/test_proc.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import psutil
+import pytest
+
+from areal.infra.utils.proc import kill_process_group, run_with_streaming_logs
+
+MODULE = "areal.infra.utils.proc"
+
+
+def _run_with_mocked_popen(tmp_path: Path, *, isolate: bool):
+    with patch(f"{MODULE}.subprocess.Popen") as popen:
+        run_with_streaming_logs(
+            ["python", "-c", "print('ok')"],
+            tmp_path / "role.log",
+            tmp_path / "merged.log",
+            "worker",
+            isolate_process_group=isolate,
+        )
+    return popen.call_args.kwargs
+
+
+def test_run_with_streaming_logs_preserves_default_process_group(tmp_path: Path):
+    kwargs = _run_with_mocked_popen(tmp_path, isolate=False)
+    assert "process_group" not in kwargs
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups required")
+def test_run_with_streaming_logs_can_create_isolated_process_group(tmp_path: Path):
+    kwargs = _run_with_mocked_popen(tmp_path, isolate=True)
+    assert kwargs["process_group"] == 0
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups required")
+def test_kill_process_group_escalates_to_sigkill():
+    member = MagicMock(pid=123)
+    with (
+        patch(f"{MODULE}.os.getpgrp", return_value=999),
+        patch(f"{MODULE}._get_process_group_members", return_value=[member]),
+        patch(
+            f"{MODULE}._wait_for_process_group_exit",
+            side_effect=[[123], []],
+        ),
+        patch(f"{MODULE}.os.killpg") as killpg,
+    ):
+        kill_process_group(123, timeout=0.1, graceful=True)
+
+    assert killpg.call_args_list == [
+        call(123, signal.SIGTERM),
+        call(123, signal.SIGKILL),
+    ]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups required")
+def test_kill_process_group_rejects_current_group():
+    with (
+        patch(f"{MODULE}.os.getpgrp", return_value=123),
+        pytest.raises(RuntimeError, match="current process group"),
+    ):
+        kill_process_group(123)
+
+
+def _is_live_non_zombie(pid: int) -> bool:
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups required")
+def test_kill_process_group_survives_shell_leader_exit():
+    code = (
+        "import subprocess, sys; "
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(60)'], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
+        "print(child.pid, flush=True)"
+    )
+    leader = subprocess.Popen(
+        [sys.executable, "-c", code],
+        process_group=0,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = leader.communicate(timeout=5)
+    assert leader.returncode == 0, stderr
+    child_pid = int(stdout.strip())
+    assert _is_live_non_zombie(child_pid)
+    assert os.getpgid(child_pid) == leader.pid
+
+    try:
+        kill_process_group(leader.pid, timeout=1, graceful=True)
+        assert not _is_live_non_zombie(child_pid)
+    finally:
+        if _is_live_non_zombie(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups required")
+def test_kill_process_group_force_kills_sigterm_ignoring_member():
+    code = (
+        "import signal, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "print('ready', flush=True); "
+        "time.sleep(60)"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", code],
+        process_group=0,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "ready"
+        kill_process_group(process.pid, timeout=0.1, graceful=True)
+        process.wait(timeout=2)
+        assert process.returncode == -signal.SIGKILL
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=2)

--- a/tests/test_fsdp_destroy.py
+++ b/tests/test_fsdp_destroy.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from areal.engine.fsdp_engine import FSDPEngine
+
+MODULE = "areal.engine.fsdp_engine"
+
+
+def _make_engine(*, is_offload: bool) -> FSDPEngine:
+    engine = object.__new__(FSDPEngine)
+    engine._initialized = True
+    engine._destroyed = False
+    engine.own_global_group = True
+    engine._cpu_group = object()
+    engine.is_offload = is_offload
+    engine._offload_depth = 0
+    engine._per_layer_optim_wrapper = None
+    engine.optimizer = MagicMock()
+    engine.model = MagicMock()
+    engine.logger = MagicMock()
+    engine.get_device_stats = MagicMock(return_value=MagicMock())
+    return engine
+
+
+def test_destroy_offloaded_engine_resumes_before_releasing_resources():
+    engine = _make_engine(is_offload=True)
+    events: list[str] = []
+    tms = MagicMock()
+
+    def _resume_while_resources_are_live() -> None:
+        assert hasattr(engine, "optimizer")
+        assert hasattr(engine, "model")
+        events.append("resume")
+
+    tms.resume.side_effect = _resume_while_resources_are_live
+    platform = MagicMock()
+    platform.synchronize.side_effect = lambda: events.append("synchronize")
+    platform.empty_cache.side_effect = lambda: events.append("empty_cache")
+
+    with (
+        patch(f"{MODULE}.is_tms_enabled", return_value=False),
+        patch(f"{MODULE}.torch_memory_saver", tms),
+        patch(f"{MODULE}.current_platform", platform),
+        patch(f"{MODULE}.gc.collect"),
+        patch(f"{MODULE}.dist.is_initialized", return_value=True),
+        patch(
+            f"{MODULE}.dist.monitored_barrier",
+            side_effect=lambda *, group, **_kwargs: events.append("barrier"),
+        ) as barrier,
+        patch(
+            f"{MODULE}.dist.destroy_process_group",
+            side_effect=lambda: events.append("destroy_process_group"),
+        ),
+    ):
+        engine.destroy()
+
+    assert events == [
+        "resume",
+        "synchronize",
+        "empty_cache",
+        "barrier",
+        "destroy_process_group",
+    ]
+    barrier.assert_called_once_with(
+        group=engine._cpu_group,
+        timeout=timedelta(seconds=10),
+        wait_all_ranks=True,
+    )
+    assert engine.is_offload is False
+    assert engine._initialized is False
+    assert engine._destroyed is True
+    assert engine.own_global_group is False
+
+
+def test_destroy_active_engine_is_idempotent():
+    engine = _make_engine(is_offload=False)
+    tms = MagicMock()
+    platform = MagicMock()
+
+    with (
+        patch(f"{MODULE}.is_tms_enabled", return_value=True),
+        patch(f"{MODULE}.torch_memory_saver", tms),
+        patch(f"{MODULE}.current_platform", platform),
+        patch(f"{MODULE}.gc.collect"),
+        patch(f"{MODULE}.dist.is_initialized", return_value=True),
+        patch(f"{MODULE}.dist.monitored_barrier") as barrier,
+        patch(f"{MODULE}.dist.destroy_process_group") as destroy_group,
+    ):
+        engine.destroy()
+        engine.destroy()
+
+    tms.resume.assert_not_called()
+    platform.empty_cache.assert_called_once_with()
+    barrier.assert_called_once_with(
+        group=engine._cpu_group,
+        timeout=timedelta(seconds=10),
+        wait_all_ranks=True,
+    )
+    destroy_group.assert_called_once_with()
+
+
+def test_destroy_continues_after_monitored_barrier_failure():
+    engine = _make_engine(is_offload=False)
+
+    with (
+        patch(f"{MODULE}.is_tms_enabled", return_value=True),
+        patch(f"{MODULE}.current_platform") as platform,
+        patch(f"{MODULE}.gc.collect"),
+        patch(f"{MODULE}.dist.is_initialized", return_value=True),
+        patch(
+            f"{MODULE}.dist.monitored_barrier",
+            side_effect=RuntimeError("rank 1 missing"),
+        ),
+        patch(f"{MODULE}.dist.destroy_process_group") as destroy_group,
+    ):
+        engine.destroy()
+
+    platform.empty_cache.assert_called_once_with()
+    destroy_group.assert_called_once_with()
+    engine.logger.warning.assert_called_once()
+    assert engine._destroyed is True
+    assert engine.own_global_group is False
+
+
+def test_initialize_starts_new_destroy_lifecycle():
+    engine = _make_engine(is_offload=False)
+    engine._destroyed = True
+
+    with (
+        patch(f"{MODULE}.pkg_version.is_version_less", return_value=False),
+        patch(f"{MODULE}.is_tms_enabled", return_value=False),
+        patch.object(
+            engine,
+            "_create_device_model",
+            side_effect=RuntimeError("stop after lifecycle reset"),
+        ),
+        pytest.raises(RuntimeError, match="stop after lifecycle reset"),
+    ):
+        engine.initialize(addr=None, ft_spec=MagicMock())
+
+    assert engine._destroyed is False
+
+
+def test_offload_commits_state_before_barrier_failure():
+    engine = _make_engine(is_offload=False)
+    tms = MagicMock()
+    platform = MagicMock()
+
+    with (
+        patch(f"{MODULE}.is_tms_enabled", return_value=True),
+        patch(f"{MODULE}.torch_memory_saver", tms),
+        patch(f"{MODULE}.current_platform", platform),
+        patch(f"{MODULE}.dist.barrier", side_effect=RuntimeError("barrier failed")),
+        pytest.raises(RuntimeError, match="barrier failed"),
+    ):
+        engine.offload()
+
+    tms.pause.assert_called_once_with()
+    assert engine.is_offload is True
+
+
+def test_onload_commits_state_before_barrier_failure():
+    engine = _make_engine(is_offload=True)
+    tms = MagicMock()
+    platform = MagicMock()
+
+    with (
+        patch(f"{MODULE}.torch_memory_saver", tms),
+        patch(f"{MODULE}.current_platform", platform),
+        patch(f"{MODULE}.dist.barrier", side_effect=RuntimeError("barrier failed")),
+        pytest.raises(RuntimeError, match="barrier failed"),
+    ):
+        engine.onload()
+
+    tms.resume.assert_called_once_with()
+    assert engine.is_offload is False
+
+
+def test_destroy_resume_failure_leaves_engine_retryable():
+    engine = _make_engine(is_offload=True)
+    tms = MagicMock()
+    tms.resume.side_effect = RuntimeError("resume failed")
+    platform = MagicMock()
+
+    with (
+        patch(f"{MODULE}.is_tms_enabled", return_value=True),
+        patch(f"{MODULE}.torch_memory_saver", tms),
+        patch(f"{MODULE}.current_platform", platform),
+        pytest.raises(RuntimeError, match="resume failed"),
+    ):
+        engine.destroy()
+
+    platform.synchronize.assert_not_called()
+    platform.empty_cache.assert_not_called()
+    assert engine.is_offload is True
+    assert engine._initialized is True
+    assert engine._destroyed is False

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -5,6 +5,7 @@ import os
 import time
 import traceback
 from contextlib import contextmanager
+from queue import Empty
 
 import pytest
 import torch.distributed as dist
@@ -14,7 +15,7 @@ from tests.utils import get_model_path
 from areal.api import FinetuneSpec
 from areal.api.alloc_mode import ModelAllocation
 from areal.api.cli_args import MegatronEngineConfig, OptimizerConfig, TrainEngineConfig
-from areal.engine import FSDPEngine, MegatronEngine
+from areal.engine import FSDPEngine
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 from areal.utils.offload import get_tms_env_vars
@@ -22,6 +23,8 @@ from areal.utils.offload import get_tms_env_vars
 MODEL_PATH = get_model_path(
     "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"
 )
+_SUBPROCESS_TIMEOUT_SECONDS = 300
+_SUBPROCESS_TERMINATE_GRACE_SECONDS = 5
 
 
 def _create_engine(engine_type: str):
@@ -41,6 +44,7 @@ def _create_engine(engine_type: str):
         experiment_name="test_offload",
         trial_name=f"{engine_type}_tms",
         path=MODEL_PATH,
+        attn_impl="sdpa",
         optimizer=OptimizerConfig(),
         megatron=MegatronEngineConfig(),
     )
@@ -51,6 +55,8 @@ def _create_engine(engine_type: str):
     if engine_type == "FSDP":
         engine = FSDPEngine(config)
     elif engine_type == "Megatron":
+        from areal.engine import MegatronEngine
+
         engine = MegatronEngine(config)
     else:
         raise ValueError(f"Unknown engine type: {engine_type}")
@@ -83,12 +89,16 @@ def _run_test(
                 memory_tolerance=memory_tolerance,
                 warmup_rounds=warmup_rounds,
             )
-            if output_queue:
-                output_queue.put(True)
         finally:
             engine.destroy()
             if dist.is_initialized():
                 dist.destroy_process_group()
+
+        # Report success only after teardown completed.  TMS failures can exit
+        # the subprocess from engine.destroy(), so publishing earlier masks the
+        # exact lifecycle regression this test is intended to catch.
+        if output_queue:
+            output_queue.put(True)
 
     except Exception as e:
         print(f"[Subprocess] Error: {e}")
@@ -106,33 +116,74 @@ def _run_test(
 @contextmanager
 def _tms_env_context():
     tms_env = get_tms_env_vars()
-    os.environ.update(tms_env)
-    yield
+    previous = {key: os.environ.get(key) for key in tms_env}
+    try:
+        os.environ.update(tms_env)
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def _run_in_subprocess(target, kwargs):
     """Run function in a subprocess with TMS environment configured."""
     ctx = multiprocessing.get_context("spawn")
     output_queue = ctx.Queue()
-    kwargs["output_queue"] = output_queue
+    process_kwargs = {**kwargs, "output_queue": output_queue}
+    p = ctx.Process(target=target, kwargs=process_kwargs)
 
-    # Set env vars in parent process before spawning
-    # Spawned process will inherit these variables
-    with _tms_env_context():
-        p = ctx.Process(target=target, kwargs=kwargs)
-        p.start()
-        p.join()
+    try:
+        # Set env vars in parent process before spawning. Spawned processes
+        # inherit them, while the context restores the pytest parent afterward.
+        with _tms_env_context():
+            p.start()
+            p.join(timeout=_SUBPROCESS_TIMEOUT_SECONDS)
 
-    # Check results
-    if not output_queue.empty():
-        success = output_queue.get()
-        if not success:
-            pytest.fail("Test failed in subprocess")
-    else:
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout=_SUBPROCESS_TERMINATE_GRACE_SECONDS)
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=_SUBPROCESS_TERMINATE_GRACE_SECONDS)
+            pytest.fail(
+                f"Subprocess timed out after {_SUBPROCESS_TIMEOUT_SECONDS} seconds"
+            )
+
         if p.exitcode != 0:
             pytest.fail(f"Subprocess crashed with exit code {p.exitcode}")
-        else:
+
+        try:
+            success = output_queue.get(timeout=1)
+        except Empty:
             pytest.fail("Subprocess finished but returned no result")
+        if not success:
+            pytest.fail("Test failed in subprocess")
+    finally:
+        output_queue.close()
+        output_queue.join_thread()
+
+
+def _run_offload_then_destroy(engine_type: str, output_queue=None):
+    """Leave an engine paused and verify its native teardown completes."""
+    try:
+        engine = _create_engine(engine_type)
+        try:
+            engine.offload()
+        finally:
+            engine.destroy()
+            if dist.is_initialized():
+                dist.destroy_process_group()
+
+        if output_queue:
+            output_queue.put(True)
+    except Exception:
+        traceback.print_exc()
+        if output_queue:
+            output_queue.put(False)
+        raise
 
 
 def get_gpu_memory_allocated_gb() -> float:
@@ -237,4 +288,13 @@ def test_engine_offload_and_onload(engine_type):
             "memory_tolerance": 0.1,
             "warmup_rounds": 3,
         },
+    )
+
+
+@pytest.mark.slow
+def test_fsdp_destroy_while_offloaded():
+    """Destroying a paused FSDP engine must not double-free TMS mappings."""
+    _run_in_subprocess(
+        target=_run_offload_then_destroy,
+        kwargs={"engine_type": "FSDP"},
     )

--- a/tests/v2/inference_service/test_guard.py
+++ b/tests/v2/inference_service/test_guard.py
@@ -146,11 +146,13 @@ class TestFork:
         assert data["status"] == "success"
         assert data["host"] == "10.0.0.1"
         assert data["pid"] == 55
+        assert data["pgid"] == 55
         assert "port" not in data
 
         call_args = mock_run.call_args
         cmd = call_args[0][0]
         assert cmd == raw
+        assert call_args.kwargs["isolate_process_group"] is True
 
     @patch(f"{GUARD_APP}.run_with_streaming_logs")
     def test_fork_tracks_child(self, mock_run, client):
@@ -222,7 +224,7 @@ class TestForkErrorHandling:
 
 
 class TestKillForkedWorker:
-    @patch(f"{GUARD_APP}.kill_process_tree")
+    @patch(f"{GUARD_APP}.kill_process_group")
     def test_kill_known_worker(self, mock_kill, client):
         mock_proc = _make_mock_process(pid=123)
         guard_module._state.forked_children.append(mock_proc)
@@ -250,7 +252,7 @@ class TestKillForkedWorker:
         assert resp.status_code == 404
         assert "not found" in resp.get_json()["error"].lower()
 
-    @patch(f"{GUARD_APP}.kill_process_tree")
+    @patch(f"{GUARD_APP}.kill_process_group")
     def test_kill_already_exited_worker(self, mock_kill, client):
         mock_proc = _make_mock_process(pid=456, running=False)
         guard_module._state.forked_children.append(mock_proc)
@@ -261,7 +263,7 @@ class TestKillForkedWorker:
             json={"role": "done", "worker_index": 0},
         )
         assert resp.status_code == 200
-        mock_kill.assert_not_called()
+        mock_kill.assert_called_once_with(456, timeout=3, graceful=True)
 
     def test_kill_missing_role(self, client):
         resp = client.post("/kill_forked_worker", json={"worker_index": 0})
@@ -273,7 +275,7 @@ class TestKillForkedWorker:
         assert resp.status_code == 400
         assert "worker_index" in resp.get_json()["error"].lower()
 
-    @patch(f"{GUARD_APP}.kill_process_tree")
+    @patch(f"{GUARD_APP}.kill_process_group")
     def test_kill_then_kill_again_returns_404(self, mock_kill, client):
         mock_proc = _make_mock_process(pid=789)
         guard_module._state.forked_children.append(mock_proc)
@@ -293,7 +295,7 @@ class TestKillForkedWorker:
 
 
 class TestCleanup:
-    @patch(f"{GUARD_APP}.kill_process_tree")
+    @patch(f"{GUARD_APP}.kill_process_group")
     def test_cleanup_kills_all_running_children(self, mock_kill):
         proc1 = _make_mock_process(pid=100)
         proc2 = _make_mock_process(pid=200)
@@ -312,8 +314,8 @@ class TestCleanup:
         assert guard_module._state.forked_children == []
         assert guard_module._state.forked_children_map == {}
 
-    @patch(f"{GUARD_APP}.kill_process_tree")
-    def test_cleanup_skips_already_exited(self, mock_kill):
+    @patch(f"{GUARD_APP}.kill_process_group")
+    def test_cleanup_kills_group_when_leader_already_exited(self, mock_kill):
         running = _make_mock_process(pid=100, running=True)
         exited = _make_mock_process(pid=200, running=False)
         guard_module._state.forked_children = [running, exited]
@@ -324,17 +326,17 @@ class TestCleanup:
 
         cleanup_forked_children()
 
-        mock_kill.assert_called_once_with(100, timeout=3, graceful=True)
+        assert [call.args[0] for call in mock_kill.call_args_list] == [100, 200]
 
         assert guard_module._state.forked_children == []
         assert guard_module._state.forked_children_map == {}
 
-    @patch(f"{GUARD_APP}.kill_process_tree")
+    @patch(f"{GUARD_APP}.kill_process_group")
     def test_cleanup_no_children_is_noop(self, mock_kill):
         cleanup_forked_children()
         mock_kill.assert_not_called()
 
-    @patch(f"{GUARD_APP}.kill_process_tree")
+    @patch(f"{GUARD_APP}.kill_process_group")
     def test_cleanup_tolerates_kill_exception(self, mock_kill):
         proc1 = _make_mock_process(pid=100)
         proc2 = _make_mock_process(pid=200)
@@ -349,5 +351,5 @@ class TestCleanup:
         cleanup_forked_children()
 
         assert mock_kill.call_count == 2
-        assert guard_module._state.forked_children == []
-        assert guard_module._state.forked_children_map == {}
+        assert guard_module._state.forked_children == [proc1]
+        assert guard_module._state.forked_children_map == {("a", 0): proc1}

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -8,6 +10,8 @@ import pytest
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
 from areal.v2.training_service.controller.controller import (
     GatewayTrainController,
+    TeardownCallResult,
+    TeardownReport,
 )
 
 MODULE = "areal.v2.training_service.controller.controller"
@@ -69,6 +73,42 @@ class _FakeAsyncClient:
         if isinstance(next_item, Exception):
             raise next_item
         return next_item
+
+
+class _FakeAiohttpRequest:
+    def __init__(self, url: str, events: list[str], failures: set[str]) -> None:
+        self._url = url
+        self._events = events
+        self._failures = failures
+
+    async def __aenter__(self):
+        self._events.append(f"start:{self._url}")
+        await asyncio.sleep(0)
+        if self._url in self._failures:
+            self._events.append(f"fail:{self._url}")
+            raise RuntimeError(f"failed: {self._url}")
+        return self
+
+    async def __aexit__(self, *_args):
+        self._events.append(f"done:{self._url}")
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAiohttpSession:
+    def __init__(self, events: list[str], failures: set[str] | None = None) -> None:
+        self._events = events
+        self._failures = failures or set()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    def post(self, url: str, **_kwargs) -> _FakeAiohttpRequest:
+        return _FakeAiohttpRequest(url, self._events, self._failures)
 
 
 class TestGatewayTrainControllerInitialization:
@@ -162,3 +202,188 @@ class TestGatewayTrainControllerInitialization:
         assert controller._gateway_addr == "http://127.0.0.1:18080"
         assert controller.api_key is not None
         assert controller.api_key.startswith("ak-train-role-")
+
+
+class TestGatewayTrainControllerTeardown:
+    def test_worker_shutdown_is_global_two_phase(self):
+        controller = _make_controller()
+        controller._worker_addrs = ["http://worker-0", "http://worker-1"]
+        events: list[str] = []
+        session = _FakeAiohttpSession(events)
+
+        timeout = MagicMock()
+        with (
+            patch(
+                f"{MODULE}.aiohttp.ClientTimeout", return_value=timeout
+            ) as timeout_cls,
+            patch(
+                f"{MODULE}.aiohttp.ClientSession", return_value=session
+            ) as session_cls,
+        ):
+            report = controller._graceful_shutdown_workers()
+
+        assert report.successful
+        timeout_cls.assert_called_once_with(total=controller.config.request_timeout)
+        session_cls.assert_called_once_with(timeout=timeout)
+        last_awex = max(
+            index
+            for index, event in enumerate(events)
+            if event.startswith("done:") and event.endswith("/awex/teardown")
+        )
+        first_engine = min(
+            index
+            for index, event in enumerate(events)
+            if event.startswith("start:") and event.endswith("/destroy_engine")
+        )
+        assert last_awex < first_engine
+
+    def test_forked_service_cleanup_orders_ingress_and_parallelizes_workers(self):
+        controller = _make_controller()
+        controller._forked_services = [
+            ("http://guard-0", "train-worker", 0),
+            ("http://guard-1", "train-worker", 1),
+            ("http://guard-0", "router", 0),
+            ("http://guard-0", "data-proxy", 0),
+            ("http://guard-0", "gateway", 0),
+        ]
+        calls: list[tuple[str, int]] = []
+        calls_lock = threading.Lock()
+        workers_started = threading.Barrier(2, timeout=1)
+
+        def _kill(_guard_addr: str, role: str, worker_index: int):
+            with calls_lock:
+                calls.append((role, worker_index))
+            if role == "train-worker":
+                workers_started.wait()
+            return TeardownCallResult("forked-service", role, True)
+
+        with patch.object(controller, "_kill_forked_service", side_effect=_kill):
+            results = controller._cleanup_forked_services()
+
+        assert calls[:3] == [("gateway", 0), ("data-proxy", 0), ("router", 0)]
+        assert set(calls[3:]) == {("train-worker", 0), ("train-worker", 1)}
+        assert len(results) == 5
+        assert all(result.success for result in results)
+
+    def test_awex_failure_still_destroys_all_engines_without_false_success_log(self):
+        controller = _make_controller()
+        controller._worker_addrs = ["http://worker-0", "http://worker-1"]
+        failed_url = "http://worker-0/awex/teardown"
+        events: list[str] = []
+        session = _FakeAiohttpSession(events, failures={failed_url})
+
+        with (
+            patch(f"{MODULE}.aiohttp.ClientSession", return_value=session),
+            patch(f"{MODULE}.logger") as logger,
+        ):
+            report = controller._graceful_shutdown_workers()
+
+        assert [(result.phase, result.target) for result in report.failures] == [
+            ("awex", "http://worker-0")
+        ]
+        assert sum(event.endswith("/destroy_engine") for event in events) == 4
+        assert not any(
+            "destroyed gracefully" in str(call) for call in logger.info.call_args_list
+        )
+        logger.error.assert_called_once()
+
+    def test_worker_shutdown_orchestration_failure_returns_report(self):
+        controller = _make_controller()
+        controller._worker_addrs = ["http://worker-0", "http://worker-1"]
+
+        with patch(
+            f"{MODULE}.aiohttp.ClientSession",
+            side_effect=RuntimeError("session failed"),
+        ):
+            report = controller._graceful_shutdown_workers()
+
+        assert len(report.awex_results) == 2
+        assert len(report.engine_results) == 2
+        assert not report.successful
+        assert all(
+            "session failed" in (result.error or "") for result in report.results
+        )
+
+    def test_destroy_reports_failures_after_scheduler_fallback(self):
+        scheduler = MagicMock()
+        controller = _make_controller(scheduler)
+        controller._worker_addrs = ["http://worker-0"]
+        controller._guard_addrs = ["http://guard-0"]
+        controller._forked_services = [("http://guard-0", "train-worker", 0)]
+        controller._service_roles = ["actor-guard"]
+        worker_report = TeardownReport(
+            engine_results=(
+                TeardownCallResult("engine", "http://worker-0", False, "disconnected"),
+            )
+        )
+        fork_result = TeardownCallResult(
+            "forked-service", "train-worker/0", False, "kill failed"
+        )
+
+        with (
+            patch.object(
+                controller,
+                "_graceful_shutdown_workers",
+                return_value=worker_report,
+            ),
+            patch.object(
+                controller,
+                "_cleanup_forked_services",
+                return_value=(fork_result,),
+            ),
+            patch.object(
+                controller,
+                "_verify_guard_cleanup",
+                return_value=TeardownCallResult(
+                    "guard-drain", "http://guard-0", False, "one child"
+                ),
+            ),
+        ):
+            controller.destroy()
+
+        report = controller._last_teardown_report
+        assert report is not None
+        assert not report.successful
+        assert {result.phase for result in report.failures} == {
+            "engine",
+            "forked-service",
+            "guard-drain",
+        }
+        scheduler.delete_workers.assert_called_once_with(
+            role="actor-guard", reverse_order=True
+        )
+
+    def test_destroy_preserves_failure_report_when_called_again(self):
+        controller = _make_controller()
+        failure = TeardownReport(
+            engine_results=(
+                TeardownCallResult("engine", "http://worker-0", False, "failed"),
+            )
+        )
+        controller._last_teardown_report = failure
+
+        with patch.object(controller, "_cleanup_runtime_state") as cleanup:
+            controller.destroy()
+
+        cleanup.assert_not_called()
+        assert controller._last_teardown_report is failure
+
+    def test_destroy_reports_process_group_failure_and_keeps_ownership(self):
+        controller = _make_controller()
+        controller._own_process_group = True
+
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch(
+                "torch.distributed.destroy_process_group",
+                side_effect=RuntimeError("group teardown failed"),
+            ),
+        ):
+            controller.destroy()
+
+        report = controller._last_teardown_report
+        assert report is not None
+        assert [(result.phase, result.error) for result in report.failures] == [
+            ("controller-process-group", "group teardown failed")
+        ]
+        assert controller._own_process_group is True


### PR DESCRIPTION
## Description

Fix the v2 training teardown race reported in #1565, where an FSDP engine can
release TMS-backed resources while they are paused and forked services can
outlive controller-owned process groups.

This change:

- resumes paused TMS allocations before FSDP teardown, uses a bounded monitored
  barrier, and keeps destroy idempotent;
- performs worker shutdown in two global phases (all AWEX teardown calls, then
  all engine destroy calls) and returns an aggregate teardown report instead of
  logging false success;
- isolates forked services in process groups, applies TERM-to-KILL escalation,
  and verifies that no non-zombie descendants remain before dropping guard
  state;
- preserves failed scheduler/process-group ownership for a retry and adds
  regression coverage for ordering, idempotency, failure reporting, and native
  TMS teardown.

## Related Issue

Fixes #1565

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable; no documentation changes)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):** None.

## Additional Context

### Validation

Commands executed:

```bash
pre-commit run --all-files

pytest -q \
  tests/infra/data_service/test_guard.py \
  tests/infra/test_proc.py \
  tests/test_fsdp_destroy.py \
  tests/v2/inference_service/test_guard.py \
  tests/v2/training_service/test_controller_unit.py

pytest -q tests/test_offload.py::test_fsdp_destroy_while_offloaded
```

Results:

- Full repository pre-commit gate passed.
- Focused CPU suite: 58 passed across FSDP destroy, process cleanup, guard, and
  controller tests.
- Single-GPU native TMS regression: 1 passed in 37.54s.
- **Two-GPU validation completed** on 2 x RTX 3090 with PyTorch 2.9.1+cu129 and
  NCCL 2.27.5:
  - NCCL two-rank `all_reduce` smoke test passed;
  - direct FSDP/TMS teardown with Qwen3-0.6B and `fsdp:d2p1t1` passed on both
    ranks;
  - controller-level teardown E2E passed with
    `{"awex":2,"controller":0,"engine":2,"failures":0,"forked_service":5,"guard":2,"scheduler":1}`;
  - no allocator double-free, NCCL disconnect, orphan worker, or residual
    GPU-memory condition was observed after teardown.

### Test boundaries

- P2P was unavailable on the test host, so the two-GPU run validates teardown
  correctness only; it is not a performance result.
- The controller E2E used a test-only launcher shim to bypass the host image's
  `stdbuf`/TMS `LD_PRELOAD` collision; it did not modify repository code.
- `tests/test_local_scheduler.py` remains skipped by its existing module-level
  marker (91 skips).
- Multi-node integration and a full LoRA training run were not executed.

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
