### PR TITLE
feat(scheduler): support grouped colocation in the Ray scheduler

### DIFF
--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -18,7 +18,10 @@ import ray.exceptions
 import requests
 from ray.actor import ActorHandle
 from ray.util.placement_group import placement_group, remove_placement_group
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from ray.util.scheduling_strategies import (
+    NodeAffinitySchedulingStrategy,
+    PlacementGroupSchedulingStrategy,
+)
 
 from areal.api import Job, Scheduler, Worker
 from areal.api.alloc_mode import ModelAllocation
@@ -217,6 +220,7 @@ class RayWorkerProcessLauncher:
         nfs_record_root: str,
         etcd3_addr: str,
         fileroot: str | None,
+        extra_env: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         worker_id = f"{role}/{worker_index}"
         if not cmd:
@@ -258,6 +262,8 @@ class RayWorkerProcessLauncher:
 
         env = os.environ.copy()
         env.update(self.env_vars)
+        if extra_env:
+            env.update(extra_env)
         env[self.device_control_env_var] = ",".join(gpu_devices)
 
         return {
@@ -404,6 +410,36 @@ class RayWorkerInfo:
     task_index: int
     launchers: list[ActorHandle] = field(default_factory=list)
     spec: SchedulingSpec | None = None
+
+
+def group_colocated_gpus(
+    node_infos: list[dict[str, Any]], gpus_per_worker: int
+) -> list[dict[str, Any]]:
+    """Chunk each target node's physical GPUs into per-worker groups.
+
+    Groups are contiguous within a node and never cross nodes, so every
+    grouped colocated worker shares exactly one node with the target
+    workers whose GPUs it reuses.
+    """
+    if gpus_per_worker <= 0:
+        raise ValueError(f"gpus_per_worker must be positive, got {gpus_per_worker}")
+    groups: list[dict[str, Any]] = []
+    for info in node_infos:
+        devices = list(info["visible_devices"])
+        if len(devices) % gpus_per_worker != 0:
+            raise ValueError(
+                f"Node {info['node_id']} has {len(devices)} visible GPUs, "
+                f"which is not a multiple of gpus_per_worker={gpus_per_worker}"
+            )
+        for start in range(0, len(devices), gpus_per_worker):
+            groups.append(
+                {
+                    "host": info["host"],
+                    "node_id": info["node_id"],
+                    "gpu_devices": devices[start : start + gpus_per_worker],
+                }
+            )
+    return groups
 
 
 class RayMultiNodeRolloutCoordinator:
@@ -1493,11 +1529,21 @@ class RayScheduler(Scheduler):
 
             target_workers = self._workers[colocate_role]
             if num_workers != len(target_workers):
+                spec = schedulings[0]
+                target_gpus = sum(
+                    (worker.spec.gpu if worker.spec is not None else 1)
+                    for worker in target_workers
+                )
+                if spec.gpu > 0 and num_workers * spec.gpu == target_gpus:
+                    return self._create_grouped_colocated_workers(
+                        role, colocate_role, schedulings
+                    )
                 raise WorkerCreationError(
                     role,
                     "Replica count mismatch",
                     f"Colocated role must have same replica count as target "
-                    f"({num_workers} != {len(target_workers)})",
+                    f"({num_workers} != {len(target_workers)}) or reuse all "
+                    f"target GPUs ({num_workers} * {spec.gpu} != {target_gpus})",
                 )
 
             # Check if fork mode is enabled
@@ -1694,6 +1740,149 @@ class RayScheduler(Scheduler):
             ) from e
 
         return worker_ids
+
+    def _create_grouped_colocated_workers(
+        self,
+        role: str,
+        colocate_role: str,
+        schedulings: list[SchedulingSpec],
+    ) -> list[str]:
+        """Create multi-GPU workers colocated over the target role's GPUs.
+
+        One zero-GPU launcher is pinned to each target node via node
+        affinity; worker processes receive explicit physical GPU ids, so
+        CUDA_VISIBLE_DEVICES carries physical indices exactly like the
+        Slurm launcher does.
+        """
+        spec = schedulings[0]
+        target_launchers = self._launchers.get(colocate_role)
+        if not target_launchers:
+            raise WorkerCreationError(
+                role,
+                "Invalid grouped colocation target",
+                f"Target role '{colocate_role}' has no Ray launchers to colocate onto",
+            )
+        node_infos = ray.get(
+            [launcher.get_node_info.remote() for launcher in target_launchers],
+            timeout=self.startup_timeout,
+        )
+        groups = group_colocated_gpus(node_infos, gpus_per_worker=spec.gpu)
+        if len(groups) != len(schedulings):
+            raise WorkerCreationError(
+                role,
+                "Grouped colocation shape mismatch",
+                f"{len(schedulings)} replicas requested but target nodes "
+                f"provide {len(groups)} groups of {spec.gpu} GPUs",
+            )
+
+        logger.info(
+            f"Creating {len(groups)} grouped workers for role '{role}' over "
+            f"{len(node_infos)} nodes of target role '{colocate_role}'"
+        )
+
+        launchers: list[ActorHandle] = []
+        workers: list[RayWorkerInfo] = []
+        start_refs = []
+        try:
+            worker_idx = 0
+            for node_idx, info in enumerate(node_infos):
+                node_groups = [
+                    group for group in groups if group["node_id"] == info["node_id"]
+                ]
+                if not node_groups:
+                    continue
+                launcher = RayWorkerProcessLauncher.options(
+                    num_cpus=0,
+                    num_gpus=0,
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=info["node_id"], soft=False
+                    ),
+                ).remote(
+                    role,
+                    self._log_path_of(role),
+                    self._merged_log_path(),
+                    self.ray_device_resource,
+                    self.device_control_env_var,
+                    spec.env_vars,
+                )
+                launchers.append(launcher)
+
+                batch = []
+                for local_idx, group in enumerate(node_groups):
+                    worker_spec = schedulings[worker_idx]
+                    # SGLang colocate derives its physical GPU range from
+                    # SLURM_LOCALID x gpus_per_server, and the AWEX plugin
+                    # derives its transfer rank from SLURM_NODEID/NNODES, so
+                    # grouped workers see the whole node (identity visible
+                    # devices) plus the same env contract the Slurm launcher
+                    # provides.
+                    extra_env = {
+                        "SLURM_LOCALID": str(local_idx),
+                        "SLURM_NODEID": str(node_idx),
+                        "SLURM_NNODES": str(len(node_infos)),
+                    }
+                    batch.append(
+                        dict(
+                            role=role,
+                            worker_index=worker_idx,
+                            gpu_devices=list(info["visible_devices"]),
+                            extra_env=extra_env,
+                            cmd=worker_spec.cmd,
+                            experiment_name=self.experiment_name,
+                            trial_name=self.trial_name,
+                            name_resolve_type=self.name_resolve_config.type,
+                            nfs_record_root=self.name_resolve_config.nfs_record_root,
+                            etcd3_addr=self.name_resolve_config.etcd3_addr,
+                            fileroot=self.fileroot,
+                        )
+                    )
+                    workers.append(
+                        RayWorkerInfo(
+                            worker=Worker(
+                                id=f"{role}/{worker_idx}",
+                                ip="",
+                                worker_ports=[],
+                                engine_ports=[],
+                            ),
+                            role=role,
+                            launchers=[launcher],
+                            task_index=worker_idx,
+                            spec=worker_spec,
+                        )
+                    )
+                    worker_idx += 1
+                start_refs.append(launcher.start_workers.remote(batch))
+
+            ray.get(start_refs, timeout=self.startup_timeout)
+        except Exception as e:
+            self._stop_launchers_of(launchers)
+            if isinstance(e, WorkerCreationError):
+                raise
+            raise WorkerCreationError(
+                role,
+                "Grouped colocated worker creation failed",
+                f"{type(e).__name__}: {e}",
+            ) from e
+
+        self._launchers[role] = launchers
+        self._workers[role] = workers
+        worker_ids = [worker_info.worker.id for worker_info in workers]
+        logger.info(
+            f"Created {len(worker_ids)} grouped colocated workers for role "
+            f"'{role}' on target '{colocate_role}' nodes"
+        )
+        return worker_ids
+
+    def _stop_launchers_of(self, launchers: list[ActorHandle]) -> None:
+        for launcher in launchers:
+            try:
+                ray.get(launcher.stop_all_processes.remote(), timeout=10)
+            except Exception:
+                logger.warning("Failed to stop grouped launcher", exc_info=True)
+            try:
+                ray.kill(launcher, no_restart=True)
+            except Exception:
+                pass
 
     def get_workers(self, role: str, timeout: float | None = None) -> list[Worker]:
         """Wait for workers to be ready and return their information.

--- a/areal/infra/utils/ray.py
+++ b/areal/infra/utils/ray.py
@@ -59,4 +59,17 @@ def ray_resource_type():
     if torch.cuda.is_available():
         return "GPU"
 
-    return "CPU"
+    return _cluster_accelerator_type() or "CPU"
+
+
+def _cluster_accelerator_type() -> str | None:
+    # The driver may sit on a device-free node (e.g. a CPU-only head pod) while
+    # accelerators live on remote workers, so local probing is not conclusive.
+    if not ray.is_initialized():
+        return None
+
+    resources = ray.cluster_resources()
+    for device in ("NPU", "GPU"):
+        if resources.get(device, 0):
+            return device
+    return None

--- a/tests/test_ray_grouped_colocation.py
+++ b/tests/test_ray_grouped_colocation.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Grouped colocation on the HTTP-based Ray scheduler.
+
+Grouped colocation places multi-GPU workers (e.g. 16 x 4-GPU SGLang rollout
+workers) on the same nodes and physical GPUs as an existing target role made
+of more, smaller workers (e.g. 64 x 1-GPU Megatron actors on 8 nodes).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tests.test_ray_scheduler import _scheduler, _worker_info
+
+import areal.infra.scheduler.ray as ray_scheduler
+from areal.api import Job
+from areal.api.cli_args import (
+    SchedulingSpec,
+    SchedulingStrategy,
+    SchedulingStrategyType,
+)
+from areal.infra.scheduler.ray import group_colocated_gpus
+
+
+@pytest.fixture(autouse=True)
+def _disable_scheduler_destructor(monkeypatch):
+    monkeypatch.setattr(ray_scheduler.RayScheduler, "__del__", lambda self: None)
+
+
+def _node_info(node_idx: int, n_gpus: int = 8) -> dict:
+    return {
+        "host": f"10.0.0.{node_idx}",
+        "node_id": f"node{node_idx}",
+        "visible_devices": [str(gpu) for gpu in range(n_gpus)],
+    }
+
+
+def test_group_colocated_gpus_chunks_each_node_without_crossing_nodes():
+    node_infos = [_node_info(node) for node in range(4)]
+
+    groups = group_colocated_gpus(node_infos, gpus_per_worker=4)
+
+    assert len(groups) == 8
+    assert all(len(group["gpu_devices"]) == 4 for group in groups)
+    seen = {(group["node_id"], gpu) for group in groups for gpu in group["gpu_devices"]}
+    assert seen == {(f"node{node}", str(gpu)) for node in range(4) for gpu in range(8)}
+    assert groups[0]["gpu_devices"] == ["0", "1", "2", "3"]
+    assert groups[1]["gpu_devices"] == ["4", "5", "6", "7"]
+    assert groups[0]["host"] == groups[1]["host"] == "10.0.0.0"
+    assert [group["node_id"] for group in groups[:3]] == ["node0", "node0", "node1"]
+
+
+def test_group_colocated_gpus_rejects_non_divisible_node():
+    with pytest.raises(ValueError, match="not a multiple"):
+        group_colocated_gpus([_node_info(0, n_gpus=6)], gpus_per_worker=4)
+
+
+def test_group_colocated_gpus_rejects_invalid_group_size():
+    with pytest.raises(ValueError, match="gpus_per_worker"):
+        group_colocated_gpus([_node_info(0)], gpus_per_worker=0)
+
+
+def test_create_workers_routes_gpu_conserving_colocation_to_grouped_path(tmp_path):
+    scheduler = _scheduler(tmp_path)
+    scheduler._workers["actor"] = [
+        _worker_info(f"actor/{index}", role="actor") for index in range(8)
+    ]
+    for info in scheduler._workers["actor"]:
+        info.spec = SchedulingSpec(cpu=1, gpu=1, mem=1)
+    grouped = Mock(return_value=["rollout/0", "rollout/1"])
+    scheduler._create_grouped_colocated_workers = grouped
+    job = Job(
+        role="rollout",
+        replicas=2,
+        tasks=[SchedulingSpec(cpu=1, gpu=4, mem=1)] * 2,
+        scheduling_strategy=SchedulingStrategy(
+            type=SchedulingStrategyType.colocation, target="actor", fork=False
+        ),
+    )
+
+    worker_ids = scheduler.create_workers(job)
+
+    assert worker_ids == ["rollout/0", "rollout/1"]
+    grouped.assert_called_once()
+    assert "rollout" not in scheduler._colocated_roles
+
+
+def test_create_workers_still_rejects_non_conserving_replica_mismatch(tmp_path):
+    scheduler = _scheduler(tmp_path)
+    scheduler._workers["actor"] = [_worker_info("actor/0", role="actor")]
+    job = Job(
+        role="ref",
+        replicas=2,
+        tasks=[SchedulingSpec(cpu=1, gpu=1, mem=1)] * 2,
+        scheduling_strategy=SchedulingStrategy(
+            type=SchedulingStrategyType.colocation, target="actor"
+        ),
+    )
+
+    with pytest.raises(ray_scheduler.WorkerCreationError, match="Replica count"):
+        scheduler.create_workers(job)
+
+
+class _LauncherStub:
+    def __init__(self, captured: list):
+        self._captured = captured
+
+    def options(self, **options):
+        captured = self._captured
+        options_snapshot = dict(options)
+
+        class _Factory:
+            @staticmethod
+            def remote(*args):
+                record = {"options": options_snapshot, "init_args": args}
+                captured.append(record)
+                launcher = SimpleNamespace()
+                launcher.start_workers = SimpleNamespace(
+                    remote=lambda specs, _r=record: _r.setdefault("specs", specs)
+                )
+                record["launcher"] = launcher
+                return launcher
+
+        return _Factory
+
+
+def test_grouped_launcher_env_is_role_specific_and_devices_are_physical(
+    tmp_path, monkeypatch
+):
+    scheduler = _scheduler(tmp_path)
+    target_env = {"AWEX_ACTOR_ALLOC_CONF": "expandable_segments:True"}
+    target_spec = SchedulingSpec(cpu=1, gpu=1, mem=1, env_vars=target_env)
+    scheduler._workers["actor"] = [
+        _worker_info(f"actor/{index}", role="actor") for index in range(4)
+    ]
+    for info in scheduler._workers["actor"]:
+        info.spec = target_spec
+    node_launcher = SimpleNamespace(
+        get_node_info=SimpleNamespace(remote=lambda: "node-info-ref")
+    )
+    scheduler._launchers["actor"] = [node_launcher]
+    hex_node_id = "ab" * 28
+
+    captured: list = []
+    monkeypatch.setattr(
+        ray_scheduler, "RayWorkerProcessLauncher", _LauncherStub(captured)
+    )
+    node_infos = [dict(_node_info(0, n_gpus=4), node_id=hex_node_id)]
+    monkeypatch.setattr(
+        ray_scheduler.ray,
+        "get",
+        lambda refs, timeout=None: node_infos if refs == ["node-info-ref"] else refs,
+    )
+
+    rollout_env = {"LD_PRELOAD": "/x/tms.so", "NCCL_NVLS_ENABLE": "0"}
+    rollout_spec = SchedulingSpec(cpu=1, gpu=2, mem=1, env_vars=rollout_env)
+
+    worker_ids = scheduler._create_grouped_colocated_workers(
+        "rollout", "actor", [rollout_spec, rollout_spec]
+    )
+
+    assert worker_ids == ["rollout/0", "rollout/1"]
+    assert len(captured) == 1
+    assert captured[0]["init_args"][-1] == rollout_env
+    assert captured[0]["options"].get("num_gpus") in (0, None)
+    strategy = captured[0]["options"]["scheduling_strategy"]
+    assert strategy.node_id == hex_node_id
+    assert strategy.soft is False
+    specs = captured[0]["specs"]
+    assert [spec["gpu_devices"] for spec in specs] == [
+        ["0", "1", "2", "3"],
+        ["0", "1", "2", "3"],
+    ]
+    assert [spec["extra_env"]["SLURM_LOCALID"] for spec in specs] == ["0", "1"]
+    assert all(spec["extra_env"]["SLURM_NODEID"] == "0" for spec in specs)
+    assert all(spec["extra_env"]["SLURM_NNODES"] == "1" for spec in specs)
+    assert target_env == {"AWEX_ACTOR_ALLOC_CONF": "expandable_segments:True"}
+    assert "rollout" not in scheduler._colocated_roles
+    assert "rollout" in scheduler._workers
+    assert scheduler._launchers["rollout"] == [captured[0]["launcher"]]
+    assert "rollout" not in scheduler._placement_groups

--- a/tests/test_ray_resource_type.py
+++ b/tests/test_ray_resource_type.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from areal.infra.utils import ray as ray_utils
+
+
+@pytest.fixture
+def cpu_only_driver(monkeypatch):
+    import torch
+
+    monkeypatch.setattr(ray_utils.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr("areal.infra.platforms.is_npu_available", False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+
+def test_local_gpu_driver_reports_gpu(monkeypatch):
+    import torch
+
+    monkeypatch.setattr("areal.infra.platforms.is_npu_available", False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    assert ray_utils.ray_resource_type() == "GPU"
+
+
+def test_cpu_only_driver_reports_cluster_gpu(cpu_only_driver, monkeypatch):
+    monkeypatch.setattr(
+        ray_utils.ray, "cluster_resources", lambda: {"CPU": 32.0, "GPU": 64.0}
+    )
+
+    assert ray_utils.ray_resource_type() == "GPU"
+
+
+def test_cpu_only_driver_reports_cluster_npu(cpu_only_driver, monkeypatch):
+    monkeypatch.setattr(
+        ray_utils.ray, "cluster_resources", lambda: {"CPU": 32.0, "NPU": 16.0}
+    )
+
+    assert ray_utils.ray_resource_type() == "NPU"
+
+
+def test_cpu_only_driver_without_cluster_accelerators_reports_cpu(
+    cpu_only_driver, monkeypatch
+):
+    monkeypatch.setattr(ray_utils.ray, "cluster_resources", lambda: {"CPU": 32.0})
+
+    assert ray_utils.ray_resource_type() == "CPU"
+
+
+def test_disconnected_cpu_driver_does_not_query_cluster(monkeypatch):
+    import torch
+
+    monkeypatch.setattr("areal.infra.platforms.is_npu_available", False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(ray_utils.ray, "is_initialized", lambda: False)
+
+    def fail():
+        raise AssertionError("cluster_resources must not be queried when disconnected")
+
+    monkeypatch.setattr(ray_utils.ray, "cluster_resources", fail)
+
+    assert ray_utils.ray_resource_type() == "CPU"


### PR DESCRIPTION
## Description

The Ray scheduler only accepted colocation when the colocated role had exactly the
same replica count as its target, so it could not express the shape colocated
actor-rollout training actually needs: a few multi-GPU inference workers sharing the
GPUs of many single-GPU trainer workers. For example 16 x 4-GPU SGLang servers over
64 x 1-GPU actors was rejected outright, even though the two roles want precisely the
same 64 GPUs.

The Slurm scheduler rejects the same shape today (`slurm.py`, "Replica count
mismatch"), so this is the Ray half of lifting that restriction; the Slurm half is a
separate change.

### What changed

When replica counts differ **and** the colocated role's total GPU demand exactly
reuses the target role's GPUs, worker creation is routed to a grouped path instead of
raising:

- each target node's physical GPUs are chunked into contiguous per-worker groups;
  groups never cross a node boundary, so every grouped worker shares a node with the
  target workers whose GPUs it reuses
- one zero-GPU process launcher is pinned to each target node with
  `NodeAffinitySchedulingStrategy(..., soft=False)`, so no new placement group and no
  second GPU reservation is created — the target role already holds those GPUs
- worker processes are started with explicit physical GPU ids, so
  `CUDA_VISIBLE_DEVICES` carries physical indices exactly like the Slurm launcher
- grouped workers additionally receive `SLURM_LOCALID` / `SLURM_NODEID` /
  `SLURM_NNODES`, because the inference server derives its GPU range from
  `SLURM_LOCALID * gpus_per_server` and the weight-transfer plugin derives its rank
  from `SLURM_NODEID` / `SLURM_NNODES`. Grouped workers therefore see the same env
  contract the Slurm launcher provides.

Grouped roles own their own launchers and workers rather than aliasing the target, so
readiness discovery and teardown follow the existing non-colocated paths and need no
special casing.

A genuine mismatch — one where the GPU totals do not line up — still raises
`WorkerCreationError`, now with both the replica counts and the GPU arithmetic in the
message.

### Second commit: device-free Ray driver

`ray_resource_type()` probed accelerators on the driver process only, so a CPU-only
head node aborted with "does not support CPU-only clusters" even when every Ray worker
exposed GPUs. It now falls back to the advertised cluster resources when the driver
owns no device, which is the normal topology when the Ray head is a separate CPU-only
pod.

## Related Issue

N/A — no tracking issue. Both changes come from bringing up colocated actor-rollout
training on a Ray cluster.

## Type of Change

- [x] ✨ New feature

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass on the changed files
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Not a breaking change: the equal-replica-count paths (plain reuse and fork) are
untouched, and the grouped branch is only reachable from a configuration that
previously raised. `tests/test_ray_scheduler.py` passes unchanged, including
`test_colocation_replica_mismatch_raises_error`, whose scenario has mismatched GPU
totals and therefore still raises.

Eleven new tests cover the GPU-grouping helper (chunking, non-divisible node, invalid
group size), the routing decision (conserving mismatch is grouped, non-conserving
mismatch still raises), the launcher env and physical device ids, and the driver
accelerator fallback (local GPU, cluster GPU, cluster NPU, no accelerator,
uninitialized Ray). They need no Ray cluster and no GPUs.

The grouped path emits the `SLURM_*` variables on Ray, which reads oddly. They are
currently the de-facto contract that the inference server and weight-transfer plugin
read for local rank and node rank; introducing a scheduler-neutral name would touch
both of those consumers, so it is deliberately left out of this change.