### PR TITLE
feat(scheduler): honor reservation, exclusive and user env overrides on Slurm

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1132,6 +1132,16 @@ class SchedulingSpec:
     nodelist: str | None = field(
         default=None, metadata={"help": "sbatch/srun's `--nodelist` option for slurm."}
     )
+    reservation: str | None = field(
+        default=None,
+        metadata={"help": "sbatch's `--reservation` option for slurm."},
+    )
+    exclusive: bool = field(
+        default=False,
+        metadata={
+            "help": "sbatch's `--exclusive` option for slurm. Ensures nodes are not shared with other jobs."
+        },
+    )
     exclude: str | None = field(
         default=None, metadata={"help": "sbatch/srun's `--exclude` option for slurm."}
     )

--- a/areal/infra/scheduler/slurm.py
+++ b/areal/infra/scheduler/slurm.py
@@ -390,6 +390,9 @@ class SlurmScheduler(Scheduler):
 
         # Amend environment variables
         for sch in schedulings:
+            # Save user-specified env vars so they take precedence over system defaults
+            user_env = dict(sch.env_vars)
+
             # AReaL env var forwarding
             if self.enable_tms_offload:
                 sch.env_vars.update(get_tms_env_vars())
@@ -399,6 +402,9 @@ class SlurmScheduler(Scheduler):
                 existing_env_vars=sch.env_vars,
             )
             sch.env_vars.update(thread_env)
+
+            # Re-apply user env vars to allow explicit overrides
+            sch.env_vars.update(user_env)
 
         if len(schedulings) == 1:
             # Expand single spec to all workers
@@ -836,6 +842,10 @@ class SlurmScheduler(Scheduler):
             sbatch_options.append(f"--nodelist={nodelist}")
         if exclude:
             sbatch_options.append(f"--exclude={exclude}")
+        if spec.reservation:
+            sbatch_options.append(f"--reservation={spec.reservation}")
+        if spec.exclusive:
+            sbatch_options.append("--exclusive")
 
         sbatch_options_str = "\n".join([f"#SBATCH {opt}" for opt in sbatch_options])
 

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -1228,6 +1228,8 @@ Configuration class: SchedulingSpec
 | `container_type`         | string                 | `"apptainer"`                                | Type of containers used in slurm **Choices:** `apptainer`, `none`                                                              |
 | `mount`                  | string                 | `"/storage:/storage"`                        | Mount path for slurm.                                                                                                          |
 | `nodelist`               | string \| None         | `None`                                       | sbatch/srun's `--nodelist` option for slurm.                                                                                   |
+| `reservation`            | string \| None         | `None`                                       | sbatch's `--reservation` option for slurm.                                                                                     |
+| `exclusive`              | boolean                | `False`                                      | sbatch's `--exclusive` option for slurm. Ensures nodes are not shared with other jobs.                                         |
 | `exclude`                | string \| None         | `None`                                       | sbatch/srun's `--exclude` option for slurm.                                                                                    |
 | `ray_placement_strategy` | string \| None         | `None`                                       | Deprecated compatibility field for the legacy Ray scheduler. It is ignored by the current Ray scheduler.                       |
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -1226,6 +1226,8 @@ Configuration class: SchedulingSpec
 | `container_type`         | string                 | `"apptainer"`                                | Type of containers used in slurm **Choices:** `apptainer`, `none`                                                              |
 | `mount`                  | string                 | `"/storage:/storage"`                        | Mount path for slurm.                                                                                                          |
 | `nodelist`               | string \| None         | `None`                                       | sbatch/srun's `--nodelist` option for slurm.                                                                                   |
+| `reservation`            | string \| None         | `None`                                       | sbatch's `--reservation` option for slurm.                                                                                     |
+| `exclusive`              | boolean                | `False`                                      | sbatch's `--exclusive` option for slurm. Ensures nodes are not shared with other jobs.                                         |
 | `exclude`                | string \| None         | `None`                                       | sbatch/srun's `--exclude` option for slurm.                                                                                    |
 | `ray_placement_strategy` | string \| None         | `None`                                       | Deprecated compatibility field for the legacy Ray scheduler. It is ignored by the current Ray scheduler.                       |
 

--- a/tests/test_slurm_reservation_and_env.py
+++ b/tests/test_slurm_reservation_and_env.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for reservation/exclusive sbatch options and env-var precedence."""
+
+from unittest import mock
+
+import pytest
+
+from areal.api.cli_args import NameResolveConfig, SchedulingSpec
+from areal.infra.scheduler.slurm import SlurmScheduler
+
+
+class TestSchedulingSpecSlurmOptions:
+    def test_reservation_and_exclusive_default_to_off(self):
+        spec = SchedulingSpec()
+
+        assert spec.reservation is None
+        assert spec.exclusive is False
+
+    @pytest.mark.parametrize(
+        "reservation,exclusive,present,absent",
+        [
+            (None, False, [], ["--reservation", "--exclusive"]),
+            ("shanghai", False, ["--reservation=shanghai"], ["--exclusive"]),
+            (None, True, ["--exclusive"], ["--reservation"]),
+            ("shanghai", True, ["--reservation=shanghai", "--exclusive"], []),
+        ],
+    )
+    def test_options_reach_the_sbatch_script(
+        self, reservation, exclusive, present, absent
+    ):
+        scheduler = object.__new__(SlurmScheduler)
+        scheduler._n_gpus_per_node = 8
+        scheduler.experiment_name = "exp"
+        scheduler.trial_name = "trial"
+        scheduler.fileroot = "/tmp/areal-test"
+        scheduler._slurm_name = lambda role: f"exp-trial-{role}"
+        scheduler.name_resolve_config = NameResolveConfig(
+            type="nfs", nfs_record_root="/tmp/areal-test/nr"
+        )
+        scheduler.container_type = "apptainer"
+        scheduler.container_mounts = "/storage:/storage"
+        scheduler.srun_additional_args = "--unbuffered --mpi=pmi2"
+        spec = SchedulingSpec(
+            gpu=8, cpu=4, mem=32, reservation=reservation, exclusive=exclusive
+        )
+
+        script = SlurmScheduler._generate_sbatch_script(
+            scheduler,
+            role="actor",
+            replicas=8,
+            nodes=1,
+            total_gpus=8,
+            cpus_per_task=4,
+            mem_per_task=32768,
+            schedulings=[spec],
+            nodelist=None,
+            exclude=None,
+        )
+
+        for token in present:
+            assert token in script, f"{token!r} missing from sbatch script"
+        for token in absent:
+            assert token not in script, f"{token!r} unexpectedly in sbatch script"
+
+
+class TestUserEnvPrecedence:
+    def test_user_env_wins_over_framework_defaults(self):
+        scheduler = object.__new__(SlurmScheduler)
+        scheduler.enable_tms_offload = False
+        spec = SchedulingSpec(cpu=4, env_vars={"OMP_NUM_THREADS": "13"})
+
+        with (
+            mock.patch(
+                "areal.infra.scheduler.slurm.get_env_vars",
+                return_value={"OMP_NUM_THREADS": "1", "AREAL_X": "1"},
+            ),
+            mock.patch(
+                "areal.infra.scheduler.slurm.get_thread_env_vars",
+                return_value={"OMP_NUM_THREADS": "4"},
+            ),
+        ):
+            out = SlurmScheduler._prepare_worker_specs(scheduler, "actor", 1, [spec])
+
+        assert out[0].env_vars["OMP_NUM_THREADS"] == "13", (
+            "framework defaults overrode an explicit scheduling_spec env var"
+        )
+        assert out[0].env_vars["AREAL_X"] == "1"
+
+    def test_roles_keep_independent_env_vars(self):
+        scheduler = object.__new__(SlurmScheduler)
+        scheduler.enable_tms_offload = False
+        actor = SchedulingSpec(cpu=4, env_vars={"PYTORCH_CUDA_ALLOC_CONF": "a:1"})
+        rollout = SchedulingSpec(cpu=4, env_vars={})
+
+        with (
+            mock.patch("areal.infra.scheduler.slurm.get_env_vars", return_value={}),
+            mock.patch(
+                "areal.infra.scheduler.slurm.get_thread_env_vars", return_value={}
+            ),
+        ):
+            a = SlurmScheduler._prepare_worker_specs(scheduler, "actor", 1, [actor])
+            r = SlurmScheduler._prepare_worker_specs(scheduler, "rollout", 1, [rollout])
+
+        assert a[0].env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "a:1"
+        assert "PYTORCH_CUDA_ALLOC_CONF" not in r[0].env_vars
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Two ways a `SchedulingSpec` could not express what the user asked for.

`--reservation` and `--exclusive` had no config surface, so runs that need a
reserved partition had to be launched by hand outside the scheduler.

Explicit `env_vars` were also lost: the scheduler applied AReaL's forwarding and
the thread-count defaults *on top of* them, so a spec asking for a specific
`OMP_NUM_THREADS` or allocator config silently got the framework value instead.
The user's mapping is now snapshotted and re-applied last, which also lets two
roles sharing a node carry per-role settings that must differ.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Context

CLI docs regenerated with `docs/generate_cli_docs.py`.

`tests/test_slurm_reservation_and_env.py` asserts the two options appear in (and
stay out of) the generated sbatch script, that an explicit `env_vars` entry wins
over both the forwarding and the thread defaults, and that two roles keep
independent mappings. 7 tests.
