### PR TITLE
feat: add DTE-backed colocated weight transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .claude/settings.local.json
 .claude/sessions/
 .agent/
+.areal_weight_meta/
 
 # Codex repo-local skills live in `.agents/skills/`.
 

--- a/areal/__init__.py
+++ b/areal/__init__.py
@@ -2,9 +2,136 @@
 
 """AReaL: A Large-Scale Asynchronous Reinforcement Learning System for Language Reasoning"""
 
+# The per-role CUDA allocator config must be set BEFORE importing any areal
+# submodule: the `from .infra` chain below initializes CUDA and locks in the
+# allocator config, and it runs before module bodies such as rpc_server.py —
+# so setting the env var at the top of rpc_server.py is already too late.
+# The first lines of this file are the only early-enough location.
+# Only when an AWEX colocate setup explicitly sets AWEX_ACTOR_ALLOC_CONF do
+# the training roles (actor/ref) opt in early; inference roles (rollout /
+# SGLang) keep it off because expandable segments break SGLang engine init.
+# Parse argv with pure stdlib only — importing anything CUDA-adjacent here
+# would defeat the purpose.
+import os as _os
+import sys as _sys
+
+
+def _merge_alloc_conf(_existing: str, _extra: str) -> str:
+    _existing = _existing.strip()
+    _extra_parts = [_p.strip() for _p in _extra.split(",") if _p.strip()]
+    if not _existing:
+        return ",".join(_extra_parts)
+    _existing_keys = {
+        _p.split(":", 1)[0].split("=", 1)[0].strip()
+        for _p in _existing.split(",")
+        if _p.strip()
+    }
+    _merged = [_existing]
+    for _part in _extra_parts:
+        _key = _part.split(":", 1)[0].split("=", 1)[0].strip()
+        if _key not in _existing_keys:
+            _merged.append(_part)
+    return ",".join(_merged)
+
+
+def _early_set_alloc_conf() -> None:
+    role = ""
+    for _i, _a in enumerate(_sys.argv):
+        if _a == "--role" and _i + 1 < len(_sys.argv):
+            role = _sys.argv[_i + 1]
+        elif _a.startswith("--role="):
+            role = _a.split("=", 1)[1]
+    is_inference = ("rollout" in role.lower()) or ("sglang" in role.lower())
+    # AWEX colocate config opts in with AWEX_ACTOR_ALLOC_CONF. Empty/unset keeps
+    # default allocator behavior for non-colocate training runs.
+    conf = _os.environ.get("AWEX_ACTOR_ALLOC_CONF", "")
+    if role and not is_inference and conf.strip():
+        _os.environ["PYTORCH_CUDA_ALLOC_CONF"] = _merge_alloc_conf(
+            _os.environ.get("PYTORCH_CUDA_ALLOC_CONF", ""), conf
+        )
+
+
+_early_set_alloc_conf()
+
+
+def _early_hide_controller_devices() -> None:
+    """Hide accelerators from the single-controller process by default.
+
+    The single-controller trainer only orchestrates remote workers and should hold
+    no device context. But merely importing areal pulls in transformers, which
+    eagerly imports the torchao quantizer; torchao probes the GPU at import
+    (has_triton -> torch.cuda.current_device) and creates a ~hundreds-of-MiB CUDA
+    context. The only reliable way to prevent that probe is to make the accelerator
+    invisible to this process *before* those imports run.
+
+    Controller-like processes hide by default. Set
+    AREAL_HIDE_CONTROLLER_DEVICES=0 to opt out. Every process runs this at
+    ``import areal``, so device-owning workers are protected by positive worker
+    signals rather than by trying to identify every controller entry point.
+
+    As belt-and-suspenders (the local scheduler spawns workers with the controller's
+    full env inherited), we still never hide from a process that carries a
+    device-owning-worker signal: --role (local/slurm RPC workers), AREAL_ROLE_WORKER
+    (Ray engine actors, which carry no --role in argv), or the run-level AREAL_SPMD_MODE
+    (torchrun / launcher SPMD ranks). The original visibility is stashed so the
+    scheduler can still enumerate the worker device pool (important on shared nodes
+    where only a subset of GPUs is assigned). Uses only stdlib, to avoid triggering the
+    very CUDA init we are trying to prevent.
+    """
+
+    def _is_device_owning_worker() -> bool:
+        if _os.environ.get("AREAL_SPMD_MODE", "").lower() in ("1", "true"):
+            return True
+        if _os.environ.get("AREAL_ROLE_WORKER", "").lower() in ("1", "true"):
+            return True
+        return any(_a == "--role" or _a.startswith("--role=") for _a in _sys.argv)
+
+    # Device-owning workers must never be hidden, even if they inherited the opt-in
+    # flag from the controller's environment. --role covers local/slurm RPC workers;
+    # AREAL_ROLE_WORKER covers Ray engine actors (no --role in their argv); the
+    # run-level AREAL_SPMD_MODE covers torchrun / launcher SPMD ranks.
+    if _is_device_owning_worker():
+        return
+    hide_flag = _os.environ.get("AREAL_HIDE_CONTROLLER_DEVICES", "").lower()
+    if hide_flag in ("0", "false"):
+        return
+    if hide_flag not in ("", "1", "true"):
+        return
+
+    # Idempotent: don't re-process if a re-import happens.
+    if _os.environ.get("AREAL_CONTROLLER_HIDDEN_DEVICE_ENV"):
+        return
+
+    def _has_dev(_prefix: str) -> bool:
+        try:
+            return any(
+                _f.startswith(_prefix) and _f[len(_prefix) :].isdigit()
+                for _f in _os.listdir("/dev")
+            )
+        except OSError:
+            return False
+
+    # Map physical accelerator -> its visibility env var, without importing torch.
+    if _has_dev("nvidia"):
+        _env_var = "CUDA_VISIBLE_DEVICES"
+    elif _has_dev("davinci"):
+        _env_var = "ASCEND_RT_VISIBLE_DEVICES"
+    else:
+        return
+
+    _orig = _os.environ.get(_env_var)
+    # Stash for the scheduler: record both the value and whether it was set at all.
+    _os.environ["AREAL_CONTROLLER_HIDDEN_DEVICE_ENV"] = _env_var
+    _os.environ["AREAL_CONTROLLER_ORIG_DEVICES_SET"] = "0" if _orig is None else "1"
+    _os.environ["AREAL_CONTROLLER_ORIG_DEVICES"] = "" if _orig is None else _orig
+    _os.environ[_env_var] = ""
+
+
+_early_hide_controller_devices()
+
 from .version import __version__  # noqa
 
-from .infra import (
+from .infra import (  # noqa: E402
     RolloutController,
     StalenessManager,
     TrainController,

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -256,7 +256,39 @@ class GenerationHyperparameters:
             )
         },
     )
+    keep_partial_group_on_error: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "If True, an exception raised by one of the n_samples rollouts "
+                "inside GroupedRolloutWorkflow is treated as a failed trajectory "
+                "(None) instead of failing the whole group, so the remaining "
+                "valid trajectories are kept. If False (default), the exception "
+                "propagates and the entire group is dropped. Mutually exclusive "
+                "with drop_incomplete_group. Note: the rollout-time "
+                "reward_normalization path still drops the whole group on any "
+                "failure regardless of this flag."
+            )
+        },
+    )
     # NOTE: to add new parameters, please correctly handle them in the `to_openai_args_dict` method.
+
+    def __post_init__(self):
+        if self.keep_partial_group_on_error and self.drop_incomplete_group:
+            raise ValueError(
+                "keep_partial_group_on_error and drop_incomplete_group are "
+                "mutually exclusive: the former keeps valid trajectories of a "
+                "partially-failed group while the latter drops the whole group."
+            )
+        if self.keep_partial_group_on_error:
+            from areal.utils.environ import is_single_controller
+
+            if not is_single_controller():
+                logger.warning(
+                    "keep_partial_group_on_error is not supported in SPMD mode "
+                    "(AREAL_SPMD_MODE=true) and will be disabled."
+                )
+                self.keep_partial_group_on_error = False
 
     def new(self, **kwargs):
         args = asdict(self)
@@ -310,6 +342,7 @@ class GenerationHyperparameters:
     _WORKFLOW_ONLY_ARGS: ClassVar[set[str]] = {
         "reward_normalization",
         "drop_incomplete_group",
+        "keep_partial_group_on_error",
     }
 
     def to_openai_args_dict(
@@ -936,11 +969,12 @@ class MegatronEngineConfig:
 
     # MoE
     moe_router_dtype: str | None = "fp32"
-    moe_shared_expert_overlap: bool = field(
-        default=False,
+    moe_shared_expert_overlap: bool | None = field(
+        default=None,
         metadata={
             "help": "Enable overlapping between shared expert computations and dispatcher communications. "
-            "Without this, the shared experts execute after the routed experts."
+            "Without this, the shared experts execute after the routed experts. "
+            "None keeps the model bridge's own default."
         },
     )
     moe_enable_deepep: bool = False
@@ -961,13 +995,14 @@ class MegatronEngineConfig:
             "Requires TransformerEngine >= 2.7.0.",
         },
     )
-    moe_router_bias_update_rate: float = field(
-        default=0.0,
+    moe_router_bias_update_rate: float | None = field(
+        default=None,
         metadata={
             "help": "Update rate for auxiliary-loss-free MoE load balancing "
             "(DeepSeek V3 style). Controls how fast expert_bias adjusts. "
-            "Default 0.0 disables bias updates; set a positive value such as "
-            "1e-3 to enable.",
+            "None keeps the model bridge's own default (AReaL bridges "
+            "disable it or derive it from the checkpoint). Set 0.0 to "
+            "disable explicitly; 1e-3 matches DeepSeek V3.",
         },
     )
     moe_z_loss_coeff: float | None = field(
@@ -1152,6 +1187,14 @@ class SchedulingSpec:
         },
     )
     # Slurm specific options
+    request_gpu_gres: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether Slurm should request GPU GRES for this worker job. "
+            "Disable only for colocated jobs that share an existing GPU "
+            "allocation."
+        },
+    )
     srun_additional_args: str = field(
         default="--unbuffered --mpi=pmi2 -K --chdir $PWD",
         metadata={
@@ -1181,6 +1224,16 @@ class SchedulingSpec:
     exclude: str | None = field(
         default=None, metadata={"help": "sbatch/srun's `--exclude` option for slurm."}
     )
+    reservation: str | None = field(
+        default=None,
+        metadata={"help": "sbatch's `--reservation` option for slurm."},
+    )
+    exclusive: bool = field(
+        default=False,
+        metadata={
+            "help": "sbatch's `--exclusive` option for slurm. Ensures nodes are not shared with other jobs."
+        },
+    )
     ray_placement_strategy: str | None = field(
         default=None,
         metadata={
@@ -1198,6 +1251,94 @@ class SchedulingSpec:
                 DeprecationWarning,
                 stacklevel=2,
             )
+
+
+@dataclass
+class DTEConfig:
+    """Configuration for DTE-backed colocated weight updates."""
+
+    enabled: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Enable DTE colocated weight update. None keeps backward "
+                "compatibility with environment variables."
+            )
+        },
+    )
+    transfer: str | None = field(
+        default="full",
+        metadata={
+            "help": (
+                "Weight transfer type: 'full' sends full weights every update; "
+                "'delta' sends a full first update, then DTE deltas."
+            ),
+            "choices": ["full", "delta", None],
+        },
+    )
+    delta_method: str | None = field(
+        default=None,
+        metadata={
+            "help": "How DTE delta mode finds changed weights.",
+            "choices": ["snapshot", "adamw", None],
+        },
+    )
+    anchor_interval: int | None = field(
+        default=0,
+        metadata={"help": "Force a full sync every N deltas. 0 means never."},
+    )
+    bytes_ratio: float | None = field(
+        default=None,
+        metadata={"help": "Per-tensor sparse-vs-dense fallback ratio."},
+    )
+    verify_snapshot: bool | None = field(
+        default=False,
+        metadata={
+            "help": (
+                "Debug only: keep a CPU snapshot and compare it with DTE "
+                "inversion masks."
+            )
+        },
+    )
+    release_train_weights_after_update: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Release training weights after a colocated update so rollout can "
+                "reuse the shared GPU memory."
+            )
+        },
+    )
+    release_initial_rollout_weights: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Release rollout weights during trainer startup. None disables this "
+                "for DTE/AWEX colocation because no weight-update payload has rebuilt "
+                "the rollout weights yet: a released server would generate the whole "
+                "step-1 batch from blank memory (uniform logits)."
+            )
+        },
+    )
+    sync_model_params_before_payload: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Refresh Megatron model-visible params from optimizer main params "
+                "before building the DTE payload."
+            )
+        },
+    )
+    inversion_debug: bool | None = field(
+        default=None,
+        metadata={"help": "Enable verbose DTE inversion debug logging."},
+    )
+    inversion_bf16_margin_rel: float | None = field(
+        default=None,
+        metadata={
+            "help": "Relative BF16 rounding-boundary margin for inversion masks."
+        },
+    )
 
 
 @dataclass
@@ -1296,6 +1437,7 @@ class TrainEngineConfig:
             "choices": ["disk", "xccl", "awex"],
         },
     )
+    dte: DTEConfig = field(default_factory=DTEConfig)
     fsdp: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     archon: ArchonEngineConfig = field(default_factory=ArchonEngineConfig)
     megatron: MegatronEngineConfig = field(default_factory=MegatronEngineConfig)
@@ -1543,7 +1685,7 @@ class RejectionSamplingConfig:
 
         _VALID_LEVELS = ("token", "sequence")
         _VALID_ACTIONS = ("mask", "clamp")
-        _VALID_METRICS = ("ratio", "kl_k1", "kl_k2", "kl_k3")
+        _VALID_METRICS = ("ratio", "kl_k1", "kl_k2", "kl_k3", "binary_kl")
         _VALID_AGGS = ("sum", "mean", "max")
 
         # Validate enum-like fields.
@@ -2060,6 +2202,20 @@ class SGLangConfig:
     num_continuous_decode_steps: int = 1
     load_format: str = "auto"
     enable_memory_saver: bool = False
+    # Back the memory-saver "weights" region with a host copy: pause offloads
+    # the weights to CPU and resume restores them. Required for DTE delta
+    # transfer in colocation — the receiver patches weights in place, so the
+    # pre-update contents (the delta BASE) must survive the release/resume
+    # cycle. FULL transfers rebuild every param and do not need this.
+    enable_weights_cpu_backup: bool = False
+    # "model" (sglang default) seeds per-request sampling defaults from the
+    # checkpoint's generation_config.json; models that ship opinionated
+    # defaults (Qwen3: temperature 0.6/top_k 20/top_p 0.95) then silently
+    # sharpen sampling for any field the request leaves unset, and the served
+    # behavior logprobs no longer match a neutral replay of the same tokens
+    # (observed +0.6 nats vs HF/megatron on Qwen3-30B). "openai" keeps
+    # neutral defaults so RL rollouts sample exactly what gconfig asks for.
+    sampling_defaults: str = "openai"
     allow_auto_truncate: bool = False
     attention_backend: str | None = "fa3"
     enable_multimodal: bool = False
@@ -2098,11 +2254,56 @@ class SGLangConfig:
     # NOTE: These arguments will be parsed into a dict json-string
     # and passed as `model_loader_extra_config` to SGLang.
     enable_multithread_load: bool = False
+    # Optional JSON string merged into the HuggingFace config before SGLang
+    # picks the model class.
+    json_model_override_args: str = "{}"
+    mamba_full_memory_ratio: float = 0.9
 
     # Internal field, not exposed to users.
     enable_return_routed_experts: bool = False
 
     # Use staticmethod to make OmegaConf happy.
+    @staticmethod
+    def _ensure_supported_sglang_args(args: dict[str, Any]) -> None:
+        target_version = "0.5.10.post1"
+        try:
+            if pkg_version.is_version_greater_or_equal("sglang", target_version):
+                return
+        except Exception:
+            pass
+
+        try:
+            from sglang.srt.server_args import ServerArgs
+        except Exception as exc:
+            raise RuntimeError(
+                f"Needs sglang>={target_version} to run the code."
+            ) from exc
+
+        server_fields = getattr(ServerArgs, "__dataclass_fields__", {})
+
+        def will_emit_arg(value: Any) -> bool:
+            return not (
+                value is None
+                or value is False
+                or value == ""
+                or (isinstance(value, list) and not value)
+            )
+
+        missing = sorted(
+            k for k, v in args.items() if k not in server_fields and will_emit_arg(v)
+        )
+        if missing:
+            raise RuntimeError(
+                f"Needs sglang>={target_version} to run the code; "
+                f"current sglang ServerArgs is missing: {missing}"
+            )
+
+        logger.warning(
+            "Installed sglang package version is below %s, but imported ServerArgs "
+            "supports the required launch fields; continuing with patched sglang.",
+            target_version,
+        )
+
     @staticmethod
     def build_cmd(
         sglang_config: "SGLangConfig",
@@ -2147,6 +2348,7 @@ class SGLangConfig:
     ):
         # Map "all-linear" to "all"
         args: dict = conf_as_dict(sglang_config)
+        load_format = args.pop("load_format", "auto")
         if sglang_config.enable_multithread_load:
             model_loader_extra_config = dict(
                 enable_multithread_load=sglang_config.enable_multithread_load,
@@ -2160,6 +2362,7 @@ class SGLangConfig:
             # Model and tokenizer
             tokenizer_path=sglang_config.model_path,
             tokenizer_mode="auto",
+            load_format=load_format,
             trust_remote_code=True,
             is_embedding=False,
             # Other runtime options
@@ -2178,8 +2381,7 @@ class SGLangConfig:
             args["host"] = host
         if port is not None:
             args["port"] = port
-        if not pkg_version.is_version_greater_or_equal("sglang", "0.5.10.post1"):
-            raise RuntimeError("Needs sglang>=0.5.10.post1 to run the code.")
+        SGLangConfig._ensure_supported_sglang_args(args)
         return args
 
 
@@ -2243,6 +2445,36 @@ class AgentConfig:
     reasoning_parser: str = field(
         default="qwen3",
         metadata={"help": "Parser for reasoning content (<think> tags)."},
+    )
+    chat_template_kwargs: dict = field(
+        default_factory=dict,
+        metadata={
+            "help": "Default kwargs forwarded to tokenizer.apply_chat_template "
+            "for every request (session metadata and per-request "
+            "extra_body.chat_template_kwargs override). E.g. "
+            "{'thinking_option': 'auto'} for Bailing v3 templates."
+        },
+    )
+    think_mode: str = field(
+        default="",
+        metadata={
+            "help": "Per-GRPO-group thinking switch sampled at session start: "
+            "'' (disabled), 'on', 'off', 'auto', or 'fusion' (coin flip "
+            "between on/off with think_prob). Dataset rows may override via "
+            "a 'think_mode' field. Requires an adaptive-thinking chat "
+            "template (Bailing v3 midtrain). The sampled mode is locked for "
+            "the whole session (requests cannot override thinking keys) and "
+            "is stamped on exported interactions. Not supported with "
+            "mode='online' (workflow does not start those sessions).",
+            "choices": ["", "on", "off", "auto", "fusion"],
+        },
+    )
+    think_prob: float = field(
+        default=0.5,
+        metadata={
+            "help": "P(thinking on) for think_mode='fusion'; sampled once "
+            "per GRPO group so same-group rollouts share one prompt."
+        },
     )
     chat_template_type: str = field(
         default="hf",
@@ -2337,6 +2569,19 @@ class AgentConfig:
             raise ValueError(
                 "set_reward_finish_timeout must be non-negative, "
                 f"got {self.set_reward_finish_timeout}"
+            )
+        valid_think_modes = ("", "on", "off", "auto", "fusion")
+        if self.think_mode not in valid_think_modes:
+            raise ValueError(
+                f"think_mode must be one of {valid_think_modes}, "
+                f"got {self.think_mode!r}"
+            )
+        if not 0.0 <= self.think_prob <= 1.0:
+            raise ValueError(f"think_prob must be in [0, 1], got {self.think_prob}")
+        if self.think_mode and self.mode == "online":
+            raise ValueError(
+                "think_mode is not supported with mode='online': external "
+                "user sessions are not started by the rollout workflow."
             )
 
 
@@ -2897,6 +3142,25 @@ class ClusterSpecConfig:
         default=8,
         metadata={"help": "Number of GPUs per node (physical)."},
     )
+    ray_port: int = field(
+        default=6379,
+        metadata={
+            "help": "Port of the Ray head (GCS). Used by the in-package Ray "
+            "bootstrap of the Ray launcher when assembling a multi-node "
+            "cluster inside a platform job."
+        },
+    )
+    ray_dashboard_port: int = field(
+        default=8265,
+        metadata={"help": "Port of the Ray dashboard on the head node."},
+    )
+    ray_bootstrap_timeout_seconds: int = field(
+        default=900,
+        metadata={
+            "help": "How long the Ray bootstrap head waits for all "
+            "cluster.n_nodes nodes to join before failing."
+        },
+    )
 
 
 @dataclass
@@ -3265,6 +3529,20 @@ class PPOConfig(BaseExperimentConfig):
             "This results in variable-sized batches of valid data."
         },
     )
+    # NOTE: not annotated as Literal["rollout", "post_batch"] because the
+    # pinned OmegaConf version rejects Literal annotations in structured
+    # configs. Validated in __post_init__ instead.
+    dynamic_filter_mode: str = field(
+        default="rollout",
+        metadata={
+            "help": "When to apply the dynamic filter (dynamic_filter_fn passed to "
+            "PPOTrainer.train). 'rollout' (default): filter each group at rollout time "
+            "on workers; with a fixed batch size, rejected groups are replaced by "
+            "re-sampling new prompts. 'post_batch': filter in the trainer process after "
+            "the whole batch has been collected; rejected groups are dropped without "
+            "re-sampling, so the batch may shrink (same contract as dynamic_bs=True)."
+        },
+    )
 
     def __post_init__(self):
         """Validate the eval generation config."""
@@ -3282,6 +3560,11 @@ class PPOConfig(BaseExperimentConfig):
         # the engine config. Single source of truth: gconfig.lora_name.
         if self.rollout.use_lora and not self.rollout.lora_name:
             self.rollout.lora_name = self.gconfig.lora_name
+        if self.dynamic_filter_mode not in ("rollout", "post_batch"):
+            raise ValueError(
+                f"dynamic_filter_mode must be 'rollout' or 'post_batch', "
+                f"got {self.dynamic_filter_mode!r}"
+            )
         super().__post_init__()
 
 

--- a/areal/engine/awex_colocate.py
+++ b/areal/engine/awex_colocate.py
@@ -1,0 +1,765 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0
+"""AWEX colocate adapter for MegatronEngine (training side).
+
+Provides:
+- Manual GPU→CPU offload for model weights and optimizer states
+- CUDA IPC weight transfer to colocated SGLang (same GPU, via MetaServer)
+- Coordinates with SGLang inference via MetaServer signals
+
+Weight transfer flow (aligned with Asystem nccl_writer colocate mode):
+  1. Convert Megatron params → HF format
+  2. Group tensors by shape/dtype → share_memory_() → cuda_ipc_serialize
+  3. Put serialized IPC handles to MetaServer
+  4. Infer side (same GPU) deserializes via CUDA IPC (zero-copy)
+  5. Infer-only NCCL group handles redistribution among infer ranks
+  6. Infer signals done → train cleans up shared tensors
+
+This adapter is used when weight_update_type == "awex" in colocate mode.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from areal.engine.megatron_engine import MegatronEngine
+
+from areal.utils.logging import getLogger
+
+logger = getLogger("AwexColocate")
+
+
+def awex_colocate_timeout_s(default: float = 1800.0) -> float:
+    value = os.environ.get("AWEX_COLOCATE_TIMEOUT_S", "").strip()
+    if not value:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        logger.warning(
+            "Invalid AWEX_COLOCATE_TIMEOUT_S=%r; using default %.1fs",
+            value,
+            default,
+        )
+        return default
+
+
+class AwexMegatronAdapter:
+    """Training-side adapter for AWEX colocated weight transfer.
+
+    Uses CUDA IPC (share_memory + ForkingPickler serialization) for zero-copy
+    weight transfer to the colocated SGLang process on the same GPU. The infer
+    side handles redistribution among infer ranks via its own NCCL group.
+    """
+
+    def __init__(self, engine: MegatronEngine):
+        self._engine = engine
+        self._offloaded_weights: dict[str, torch.Tensor] = {}
+        self._released_tags: set[str] = set()
+        self._meta_server_addr: str | None = None
+        self._meta_server_client = None
+        self._transfer_rank: int | None = None
+        self._weight_converter = None
+        self._initialized = False
+        self._rank_info = None
+        self._ip_address: str | None = None
+        self._infer_world_size: int | None = None
+        self._num_infer_engines: int | None = None
+        self._logical_train_rank: int | None = None
+
+    def init_colocate_weight_update(
+        self,
+        meta_server_addr: str | None = None,
+        pair_name: str = "default",
+        transfer_rank: int = 0,
+        timeout_s: float | None = None,
+    ) -> None:
+        """Initialize MetaServer connection. NCCL group creation is deferred
+        to the first weight update (lazy init) to allow SGLang to start first.
+        """
+        from awex.meta.meta_server import MetaServerClient, start_meta_server
+
+        if not meta_server_addr:
+            meta_server_addr = os.environ.get("AWEX_META_SERVER_ADDR", "")
+        if not meta_server_addr:
+            host, port = start_meta_server()
+            meta_server_addr = f"{host}:{port}"
+            os.environ["AWEX_META_SERVER_ADDR"] = meta_server_addr
+            logger.info("Started MetaServer at %s", meta_server_addr)
+
+        host, port = meta_server_addr.rsplit(":", 1)
+        self._meta_server_client = MetaServerClient(host, int(port))
+        self._meta_server_addr = meta_server_addr
+        self._transfer_rank = transfer_rank
+        # Train-side wait budget for infer's weights_update_finished signal.
+        # Keep the writer/reader/plugin on one env-controlled timeout to avoid
+        # split-brain diagnostics.
+        self._timeout_s = awex_colocate_timeout_s() if timeout_s is None else timeout_s
+        if dist.get_rank() == 0:
+            self._meta_server_client.put_object(
+                "awex_train_info", {"train_world_size": dist.get_world_size()}
+            )
+            logger.info(
+                "Registered awex_train_info (train_world_size=%d) with MetaServer",
+                dist.get_world_size(),
+            )
+
+        logger.info(
+            "AwexMegatronAdapter initialized: meta_server=%s, transfer_rank=%d",
+            meta_server_addr,
+            transfer_rank,
+        )
+
+    def _lazy_initialize(self) -> None:
+        """Perform deferred initialization: metadata exchange and weight converter setup.
+
+        In colocate mode, train side does NOT join any NCCL group.
+        Weight transfer uses CUDA IPC (share_memory + serialize via MetaServer).
+        The infer side creates its own infer-only NCCL group for redistribution.
+        """
+        if self._initialized:
+            return
+
+        from awex.models.registry import get_train_weights_converter
+        from awex.sharding.param_sharding import get_rank_info_extractor
+        from awex.util.common import get_ip_address
+
+        rank = dist.get_rank()
+
+        self._rank_info = get_rank_info_extractor("mcore")()
+        training_world_size = self._rank_info.world_size
+        self._ip_address = get_ip_address()
+        # CUDA_VISIBLE_DEVICES is the ground truth for physical GPU assignment
+        # (set by SlurmScheduler to isolate each rank to one GPU).
+        # Cannot use torch.cuda.current_device() which always returns 0.
+        cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+        if cuda_visible and "," not in cuda_visible:
+            self._physical_gpu_id = int(cuda_visible)
+        else:
+            self._physical_gpu_id = torch.cuda.current_device()
+
+        from awex.meta.train_meta_resolver import McoreParamMetaResolver
+
+        class _EngineShim:
+            def __init__(self, engine):
+                self.model = engine.model
+                if not isinstance(self.model, (list, tuple)):
+                    self.model = [self.model]
+                self.hf_config = engine.hf_config
+                self.enable_debug_mode = False
+                self.enable_colocate_mode = False
+                self.engine_name = "mcore"
+                self.config = {}
+                self.meta_server_addr = ""
+
+            def release_memory_occupation(self, tags=None):
+                pass
+
+            def resume_memory_occupation(self, tags=None):
+                pass
+
+        shim = _EngineShim(self._engine)
+
+        infer_conf = self._meta_server_client.get_object(
+            "infer_conf", timeout=self._timeout_s
+        )
+        logger.info("Got infer_conf from MetaServer: %s", infer_conf)
+
+        if isinstance(infer_conf.get("hf_config"), dict):
+            from types import SimpleNamespace
+
+            infer_conf["hf_config"] = SimpleNamespace(**infer_conf["hf_config"])
+
+        meta_resolver = McoreParamMetaResolver(shim, self._engine.hf_config, infer_conf)
+        parameters_meta = meta_resolver.get_parameters_meta()
+        logger.info(
+            "Collected training parameters metadata: %d params", len(parameters_meta)
+        )
+
+        if rank == 0:
+            self._meta_server_client.put_object("training_params_meta", parameters_meta)
+            logger.info("Registered training_params_meta with MetaServer")
+
+        self._infer_world_size = infer_conf["infer_world_size"]
+        self._logical_train_rank = self._infer_world_size + self._rank_info.global_rank
+
+        # Register physical device entry for (ip, node_local_gpu_id) -> rank
+        # pairing on the infer side (Asystem reader._init_reader_in_colocate_mode).
+        # device_id must be the node-local physical GPU id (matching the infer
+        # side and the CUDA IPC key), NOT a global rank. CUDA_VISIBLE_DEVICES is
+        # the ground truth since torch.cuda.current_device() is always 0 here.
+        self._meta_server_client.add_object_to_set(
+            "training_device_rank_entries",
+            (self._ip_address, self._physical_gpu_id, self._logical_train_rank),
+        )
+        logger.info(
+            "Registered training_device_rank_entries: (ip=%s, gpu=%d, rank=%d)",
+            self._ip_address,
+            self._physical_gpu_id,
+            self._logical_train_rank,
+        )
+        self._num_infer_engines = self._meta_server_client.get_object(
+            "num_infer_engines", timeout=self._timeout_s
+        )
+        logger.info("Got num_infer_engines=%d from MetaServer", self._num_infer_engines)
+
+        self._weight_converter = get_train_weights_converter(
+            "mcore",
+            self._engine.hf_config.architectures[0],
+            self._engine.hf_config,
+            self._rank_info,
+            {
+                **infer_conf,
+                "train_pp_stage_layer_id_map": (
+                    meta_resolver.get_pp_stage_layer_id_map()
+                ),
+            },
+            tf_config=_get_tf_config(self._engine.model),
+        )
+
+        self._initialized = True
+        logger.info(
+            "Colocate train side initialized: logical_train_rank=%d, "
+            "infer_world_size=%d, train_world_size=%d",
+            self._logical_train_rank,
+            self._infer_world_size,
+            training_world_size,
+        )
+
+    def _release_grad_memory(self) -> None:
+        """Release gradient buffers to free GPU memory before weight conversion.
+
+        Aligned with Asystem release_grad_memory() in megatron_util.py.
+        Saves original sizes to buffer.grad_data_size for later restoration.
+        """
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        if model is None:
+            return
+        if not isinstance(model, (list, tuple)):
+            model = [model]
+        count = 0
+        for chunk in model:
+            if isinstance(chunk, DDP):
+                for buffers in [chunk.buffers, chunk.expert_parallel_buffers]:
+                    for buf in buffers:
+                        if buf.grad_data.storage().size() > 0:
+                            buf.grad_data_size = buf.grad_data.storage().size()
+                            buf.grad_data.storage().resize_(0)
+                            count += 1
+        if count > 0:
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+        logger.info("Released %d grad buffers", count)
+
+    @torch.no_grad()
+    def execute_colocate_weight_update(self, version: int) -> None:
+        """Send weights to colocated inference via CUDA IPC through MetaServer.
+
+        Flow (aligned with Asystem nccl_writer._write_weights_in_colocate_mode):
+          1. Release optimizer states + grad memory to free GPU space
+          2. Convert Megatron params to HF format
+          3. Group tensors by shape/dtype → release originals → offload weights
+          4. Signal all_training_offloaded_weights (reader waits for this)
+          5. share_memory_() + cuda_ipc_serialize → put to MetaServer
+          6. Wait for weights_update_finished (reader done copying)
+          7. Clean up shared tensors → signal write_finished
+          8. Wait for all infer engines to finish (finished_weights_update_engines)
+        """
+        from awex.util.tensor_util import (
+            cuda_ipc_serialize,
+            group_tensors_by_shape_and_dtype,
+            release_tensors,
+        )
+
+        weights_were_offloaded = "weights" in self._released_tags
+
+        # P88: reclaim any IPC-exported blocks from the previous version whose
+        # peer mappings closed after our last collect (belt-and-braces with the
+        # collect in this method's finally block).
+        torch.cuda.ipc_collect()
+
+        # Problem 41: free optimizer states + grad buffers BEFORE reloading the
+        # train weights, not after. The colocated inference engine has already
+        # resumed its full PP=1 weight set (~113 GiB) on this same physical GPU,
+        # so reloading the train param buffers (resize_ allocates GiB-scale
+        # storage per buffer) OOMs on the very first buffer unless optimizer +
+        # grad memory is freed first. This matches Asystem weights_writer order
+        # (release_memory(optimizer) THEN resume_memory(weights), see
+        # _release_memory_for_weights_exchange). Doing resume(weights) first left
+        # only ~4.5 GiB free and failed a 5.25 GiB buffer resize_.
+        # Optimizer/grad offload operate on independent Megatron buffers and do
+        # not require the weights to be resumed, so reordering is safe.
+        self.release_memory(tags=["optimizer"])
+
+        self._release_grad_memory()
+
+        if weights_were_offloaded:
+            self.resume_memory(tags=["weights"])
+
+        # P89: _lazy_initialize AFTER the weights resume — its meta resolver
+        # runs convert_param over live params, which dies with CUDA invalid
+        # argument on resize_(0)-ed storages. The recover path is the only
+        # one that reaches the first transfer with weights offloaded (P86
+        # re-releases them right after the recover load), which is why the
+        # normal step-1 path never hit this.
+        self._lazy_initialize()
+
+        parameters = self._convert_parameters()
+        tensors = list(parameters.values())
+        names = list(parameters.keys())
+        logger.info(
+            "Converted %d params for colocate IPC transfer (version=%d)",
+            len(tensors),
+            version,
+        )
+
+        group_tensors, metadata = group_tensors_by_shape_and_dtype(tensors)
+        torch.cuda.synchronize()
+        logger.info(
+            "Grouped into %d tensor groups for IPC serialization", len(group_tensors)
+        )
+
+        # Problem 71: convert_param returns the ORIGINAL tensor (shared storage)
+        # whenever the conversion is an identity — direct_name_mapping
+        # (embed_tokens / final_layernorm) returns `parameter` as-is, and
+        # `.to(dtype)` (gate.weight, expert_bias) is a no-op when the dtype
+        # already matches. release_tensors() does untyped_storage().resize_(0),
+        # so releasing those entries frees the LIVE module storage. Params are
+        # later rebuilt by the weights offload/reload round-trip, but buffers
+        # (e.g. the fp32 router expert_bias, a register_buffer) are not part of
+        # offload/reload and stay dangling forever -> the post-transfer IMA in
+        # the router/EP path. Only release tensors we actually own (copies).
+        live_storages = set()
+        model = self._engine.model
+        for chunk in model if isinstance(model, (list, tuple)) else [model]:
+            # NB: Megatron DDP shadows nn.Module.buffers with a LIST attribute
+            # (ParamAndGradBuffer); named_parameters/named_buffers stay methods.
+            for _, p in chunk.named_parameters():
+                live_storages.add(p.untyped_storage().data_ptr())
+            for _, b in chunk.named_buffers():
+                live_storages.add(b.untyped_storage().data_ptr())
+        owned = [
+            t for t in tensors if t.untyped_storage().data_ptr() not in live_storages
+        ]
+        logger.info(
+            "Releasing %d/%d converted tensors (%d alias live module storage, "
+            "left to the weights offload path)",
+            len(owned),
+            len(tensors),
+            len(tensors) - len(owned),
+        )
+        release_tensors(owned)
+        del tensors, owned
+        parameters.clear()
+
+        self.release_memory(tags=["weights"])
+
+        ip_address = self._ip_address
+        device_id = self._physical_gpu_id
+        key_suffix = f"_{ip_address}_{device_id}_{version}"
+
+        self._meta_server_client.add_object_to_set(
+            "all_training_offloaded_weights", self._logical_train_rank
+        )
+        logger.info(
+            "Signaled all_training_offloaded_weights (rank=%d)",
+            self._logical_train_rank,
+        )
+
+        group_shared = [t.share_memory_() for t in group_tensors]
+        serialized_weights = cuda_ipc_serialize((group_shared, metadata, names))
+        torch.cuda.synchronize()
+        logger.info("CUDA IPC serialization complete, putting to MetaServer")
+
+        serialized_weights_key = f"training_serialized_weights{key_suffix}"
+        # P91: tell the reader which version we are publishing. The plugin's
+        # background worker used to assume the stream starts at v1, which
+        # deadlocks recover runs (writer resumes at v=global_step, e.g. 9).
+        writer_version_key = f"awex_writer_version_{ip_address}_{device_id}"
+        self._meta_server_client.put_object(writer_version_key, version)
+        logger.info(
+            "Put writer version to MetaServer: key=%s version=%s",
+            writer_version_key,
+            version,
+        )
+        self._meta_server_client.put_object(
+            serialized_weights_key,
+            (self._logical_train_rank, self._rank_info, serialized_weights),
+        )
+        logger.info("Put IPC weights to MetaServer: key=%s", serialized_weights_key)
+
+        update_finished_key = f"weights_update_finished{key_suffix}"
+        try:
+            self._meta_server_client.get_object(
+                update_finished_key, timeout=self._timeout_s
+            )
+            self._meta_server_client.delete_if_exists(update_finished_key)
+            self._meta_server_client.delete_if_exists(serialized_weights_key)
+            logger.info("Got done signal from infer side: %s", update_finished_key)
+        finally:
+            release_tensors(group_tensors)
+            release_tensors(group_shared)
+            del group_tensors, group_shared
+            torch.cuda.synchronize()
+            gc.collect()
+            # P88: storages exported via cudaIpcGetMemHandle park in PyTorch's
+            # CudaIPCSentDataLimbo when freed and are NOT returned to the
+            # allocator until ipc_collect() confirms the peer closed its
+            # mapping. We export GiB-scale group tensors every version and
+            # never collected: the train process residual grew 22.7 -> 36.4 GB
+            # over v1-v9 (trial-0612-1802), eating the colocated rollout's
+            # prefill headroom until its logits all-gather OOMed.
+            torch.cuda.ipc_collect()
+            torch.cuda.empty_cache()
+
+        write_finished_key = f"write_finished{key_suffix}"
+        self._meta_server_client.put_object(write_finished_key, True)
+        logger.info("Signaled write_finished: %s", write_finished_key)
+
+        logger.info("Colocate weight update completed: version=%d", version)
+
+    def finish_colocate_weight_update(self, training_world_size: int) -> None:
+        """Wait for all inference engines to finish weight update, then clean up.
+
+        Aligned with Asystem _finish_weights_update().
+        Called from megatron_engine.update_weights() after barrier.
+        """
+        num_infer_engines = self._num_infer_engines
+        logger.info(
+            "Waiting for %d inference engine(s) to signal finished_weights_update_engines",
+            num_infer_engines,
+        )
+        self._meta_server_client.wait_set_until_size(
+            "finished_weights_update_engines",
+            num_infer_engines,
+            timeout=self._timeout_s,
+        )
+        logger.info("All inference engines finished weights update")
+
+        dist.barrier(group=self._engine.cpu_group)
+
+        if dist.get_rank() == 0:
+            self._meta_server_client.delete_if_exists("finished_weights_update_engines")
+            self._meta_server_client.delete_if_exists("all_training_offloaded_weights")
+        logger.info("Cleaned up MetaServer coordination keys")
+
+    @torch.no_grad()
+    def _convert_parameters(self) -> dict[str, torch.Tensor]:
+        """Convert Megatron parameters to HF format for IPC transfer."""
+        from awex.converter.mcore_converter import get_mcore_model_parameters
+
+        model = self._engine.model
+        if not isinstance(model, (list, tuple)):
+            model = [model]
+
+        converted = {}
+        for vp_stage, m in enumerate(model):
+            for name, param in get_mcore_model_parameters(m).items():
+                for hf_name, hf_param in self._weight_converter.convert_param(
+                    name, param.detach(), vp_stage=vp_stage
+                ):
+                    converted[hf_name] = hf_param
+
+        hf_config = self._engine.hf_config
+        if (
+            getattr(hf_config, "tie_word_embeddings", False)
+            and self._rank_info.pp_rank == self._rank_info.pp_size - 1
+            and "lm_head.weight" not in converted
+            and "model.embed_tokens.weight" in converted
+        ):
+            converted["lm_head.weight"] = converted["model.embed_tokens.weight"]
+
+        logger.info("Converted %d parameters for IPC transfer", len(converted))
+        return converted
+
+    # ── Memory management (manual offload) ────────────────────────────────
+
+    def release_memory(self, tags: list[str] | None = None) -> None:
+        tags = tags or ["optimizer", "weights"]
+        tags_to_release = [t for t in tags if t not in self._released_tags]
+        if not tags_to_release:
+            return
+
+        if "optimizer" in tags_to_release:
+            self._offload_optimizer_states()
+            self._released_tags.add("optimizer")
+
+        if "weights" in tags_to_release:
+            self._offload_model_weights()
+            self._released_tags.add("weights")
+
+        torch.cuda.synchronize()
+        gc.collect()
+        torch.cuda.empty_cache()
+        logger.info("release_memory done: tags=%s", tags_to_release)
+
+    def resume_memory(self, tags: list[str] | None = None) -> None:
+        tags = tags or ["optimizer", "weights"]
+        tags_to_resume = [t for t in tags if t in self._released_tags]
+        if not tags_to_resume:
+            return
+
+        if "weights" in tags_to_resume:
+            self._reload_model_weights(load_grad=False)
+            self._released_tags.discard("weights")
+
+        if "optimizer" in tags_to_resume:
+            self._reload_optimizer_states()
+            self._released_tags.discard("optimizer")
+
+        torch.cuda.synchronize()
+        logger.info("resume_memory done: tags=%s", tags_to_resume)
+
+    def _offload_model_weights(self) -> None:
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        if model is None:
+            return
+        if not isinstance(model, (list, tuple)):
+            model = [model]
+        count = 0
+        for chunk in model:
+            if isinstance(chunk, DDP):
+                for buffers in [chunk.buffers, chunk.expert_parallel_buffers]:
+                    for buf in buffers:
+                        if hasattr(buf, "offload_to_cpu"):
+                            buf.offload_to_cpu()
+                            count += 1
+                            continue
+                        if buf.param_data.storage().size() > 0:
+                            if not hasattr(buf.param_data, "cpu_data"):
+                                buf.param_data.cpu_data = torch.zeros(
+                                    buf.param_data.data.shape,
+                                    dtype=buf.param_data.data.dtype,
+                                    pin_memory=True,
+                                    device="cpu",
+                                )
+                            buf.param_data.cpu_data.copy_(buf.param_data.data)
+                            buf.param_data_size = buf.param_data.storage().size()
+                            buf.param_data.storage().resize_(0)
+                            count += 1
+                        if buf.grad_data.storage().size() > 0:
+                            buf.grad_data_size = buf.grad_data.storage().size()
+                            buf.grad_data.storage().resize_(0)
+            else:
+                for name, param in chunk.named_parameters():
+                    if param.data.is_cuda:
+                        self._offloaded_weights[name] = param.data.detach().to(
+                            "cpu", non_blocking=True
+                        )
+                        param.data = torch.empty(0, device="cpu")
+                        count += 1
+        torch.cuda.synchronize()
+        logger.info("Offloaded %d weight buffers to CPU", count)
+
+    def _reload_model_weights(self, load_grad: bool = False) -> None:
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        if model is None:
+            return
+        if not isinstance(model, (list, tuple)):
+            model = [model]
+        device = self._engine.device
+        for chunk in model:
+            if isinstance(chunk, DDP):
+                for buffers in [chunk.buffers, chunk.expert_parallel_buffers]:
+                    for buf in buffers:
+                        if hasattr(buf, "reload_from_cpu"):
+                            buf.reload_from_cpu(move_grads=load_grad)
+                            continue
+                        if buf.param_data.storage().size() == 0:
+                            buf.param_data.storage().resize_(buf.param_data_size)
+                        buf.param_data.copy_(buf.param_data.cpu_data, non_blocking=True)
+                        if (
+                            load_grad
+                            and hasattr(buf, "grad_data_size")
+                            and buf.grad_data.storage().size() == 0
+                        ):
+                            buf.grad_data.storage().resize_(buf.grad_data_size)
+                            buf.grad_data.zero_()
+            else:
+                for name, param in chunk.named_parameters():
+                    if name in self._offloaded_weights:
+                        param.data = self._offloaded_weights[name].to(
+                            device, non_blocking=True
+                        )
+        self._offloaded_weights.clear()
+        torch.cuda.synchronize()
+        logger.info("Reloaded model weights to GPU (load_grad=%s)", load_grad)
+
+    def ensure_grad_buffers(self) -> None:
+        """Allocate grad buffers if they were freed during offload.
+
+        Called before forward_backward (training) to ensure grad storage
+        is available for backward pass. Separate from _reload_model_weights
+        because compute_logp (inference-only) should not allocate grad buffers.
+        """
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        if model is None:
+            return
+        if not isinstance(model, (list, tuple)):
+            model = [model]
+        count = 0
+        for chunk in model:
+            if isinstance(chunk, DDP):
+                for buffers in [chunk.buffers, chunk.expert_parallel_buffers]:
+                    for buf in buffers:
+                        if (
+                            hasattr(buf, "grad_data_size")
+                            and buf.grad_data.storage().size() == 0
+                        ):
+                            buf.grad_data.storage().resize_(buf.grad_data_size)
+                            buf.grad_data.zero_()
+                            count += 1
+        if count > 0:
+            torch.cuda.synchronize()
+            logger.info("Allocated %d grad buffers for training", count)
+
+    def _get_inner_optimizers(self):
+        optimizer = self._engine.optimizer
+        if optimizer is None:
+            return []
+        if hasattr(optimizer, "chained_optimizers"):
+            inner_optimizers = optimizer.chained_optimizers
+        elif hasattr(optimizer, "optimizers"):
+            inner_optimizers = optimizer.optimizers
+        else:
+            inner_optimizers = [optimizer]
+        return inner_optimizers
+
+    def _offload_optimizer_states(self) -> None:
+        optimizer = self._engine.optimizer
+        if optimizer is None:
+            return
+        # Default path aligns with Asystem HybridEngine
+        # (megatron_util.offload_megatron_optimizer): swap .data / state-dict
+        # references to CPU, never resize_ storages, then purge TE's global
+        # _dummy_wgrads cache and synchronize. Megatron HybridDeviceOptimizer's
+        # offload_to_cpu/restore_from_cpu is kept only as an opt-in fallback —
+        # its internal pointer bookkeeping is hard to validate and HybridEngine
+        # deliberately avoids it.
+        if os.environ.get("AWEX_OPT_OFFLOAD_VIA_HDO", "").strip() == "1" and hasattr(
+            optimizer, "offload_to_cpu"
+        ):
+            optimizer.offload_to_cpu()
+            logger.info("Offloaded optimizer via offload_to_cpu()")
+            return
+
+        inner_optimizers = self._get_inner_optimizers()
+        if not inner_optimizers:
+            return
+
+        count = 0
+        for opt in inner_optimizers:
+            # Offload FP32 main parameter copies (shard_fp32_from_float16_groups)
+            if hasattr(opt, "shard_fp32_from_float16_groups"):
+                for group in opt.shard_fp32_from_float16_groups:
+                    if isinstance(group, list):
+                        for t in group:
+                            if t is not None and t.data.is_cuda:
+                                t.data = t.data.to("cpu", non_blocking=True)
+                                count += 1
+                    elif group is not None and group.data.is_cuda:
+                        group.data = group.data.to("cpu", non_blocking=True)
+                        count += 1
+
+            # Offload Adam states (exp_avg, exp_avg_sq)
+            base_opt = getattr(opt, "optimizer", opt)
+            if not hasattr(base_opt, "state") or base_opt.state is None:
+                continue
+            for state in base_opt.state.values():
+                for key in ("exp_avg", "exp_avg_sq"):
+                    if (
+                        key in state
+                        and isinstance(state[key], torch.Tensor)
+                        and state[key].is_cuda
+                    ):
+                        state[key] = state[key].to("cpu", non_blocking=True)
+                        count += 1
+
+        # HybridEngine's targeted fix: transformer_engine caches dummy wgrad
+        # tensors in a module-global dict; without purging it the GPU memory
+        # is never actually freed and stale references survive the offload.
+        try:
+            from transformer_engine.pytorch.module.base import _dummy_wgrads
+
+            purged = len(_dummy_wgrads)
+            for k in list(_dummy_wgrads):
+                del _dummy_wgrads[k]
+            if purged:
+                logger.info("Purged %d TE _dummy_wgrads cache entries", purged)
+        except ImportError:
+            pass
+        torch.cuda.synchronize()
+        logger.info("Offloaded %d optimizer state tensors to CPU", count)
+
+    def _reload_optimizer_states(self) -> None:
+        optimizer = self._engine.optimizer
+        if optimizer is None:
+            return
+        if os.environ.get("AWEX_OPT_OFFLOAD_VIA_HDO", "").strip() == "1" and hasattr(
+            optimizer, "restore_from_cpu"
+        ):
+            optimizer.restore_from_cpu()
+            logger.info("Reloaded optimizer via restore_from_cpu()")
+            return
+
+        inner_optimizers = self._get_inner_optimizers()
+        if not inner_optimizers:
+            return
+
+        device = self._engine.device
+        count = 0
+        for opt in inner_optimizers:
+            # Reload FP32 main parameter copies
+            if hasattr(opt, "shard_fp32_from_float16_groups"):
+                for group in opt.shard_fp32_from_float16_groups:
+                    if isinstance(group, list):
+                        for t in group:
+                            if t is not None and not t.data.is_cuda:
+                                t.data = t.data.to(device, non_blocking=True)
+                                count += 1
+                    elif group is not None and not group.data.is_cuda:
+                        group.data = group.data.to(device, non_blocking=True)
+                        count += 1
+
+            # Reload Adam states
+            base_opt = getattr(opt, "optimizer", opt)
+            if not hasattr(base_opt, "state") or base_opt.state is None:
+                continue
+            for state in base_opt.state.values():
+                for key in ("exp_avg", "exp_avg_sq"):
+                    if (
+                        key in state
+                        and isinstance(state[key], torch.Tensor)
+                        and not state[key].is_cuda
+                    ):
+                        state[key] = state[key].to(device, non_blocking=True)
+                        count += 1
+        torch.cuda.synchronize()
+        logger.info("Reloaded %d optimizer state tensors to GPU", count)
+
+
+def _get_tf_config(models):
+    if not isinstance(models, (list, tuple)):
+        models = [models]
+    for model in models:
+        for attr in ("transformer_config", "config"):
+            cfg = getattr(model, attr, None)
+            if cfg is not None:
+                return cfg
+    return None

--- a/areal/engine/awex_colocate_reader.py
+++ b/areal/engine/awex_colocate_reader.py
@@ -1,0 +1,995 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""AWEX colocate weight reader (native awex worker-reader adapter).
+
+Runs inside the SGLang scheduler process. This is a thin shell around awex's
+native ``NCCLWorkerWeightsReader`` that:
+
+1. Eager-registers the inference-side metadata the train writer waits for
+   (``infer_conf`` + ``num_infer_engines``), computed via awex's own
+   ``InferParamMetaResolver._get_model_param_info`` + ``_build_params_meta``
+   (no hand-rolled name normalization or shard merging).
+2. Lazily constructs the awex ``NCCLWorkerWeightsReader`` on the first weight
+   update (it needs ``training_params_meta``, which only appears after the
+   first training step) and delegates the whole IPC-collect + StreamBatch
+   transport + writer handshake to it.
+
+Why awex-native instead of the previous hand-written receiver: the community
+SGLang scheduler has no ``execute_task_in_model_worker`` driver layer, so we
+build the awex *worker* reader directly in-process. The native worker reader
+uses ``NcclColocateStreamBatchTransport`` (recursive partition), which is the
+transport Asystem actually ships -- replacing the ring-shift transport that
+deadlocked on the train-PP=4 / infer-PP=1 mismatch.
+
+The plugin shell still owns the steps awex's *driver* would normally do
+(``_pre_update_weights`` wait-for-offload + resume weights, ``_resume_kvcache``
+signal-finished); see ``awex_sglang_plugin.process_awex_queue``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from typing import Any
+
+import torch
+
+
+def _patch_tms_hook_mode() -> None:
+    """Make ``torch_memory_saver.hook_mode`` setter a no-op once initialized.
+
+    ``megatron.core.inference.contexts.dynamic_context`` (pulled in transitively
+    by ``awex.converter.mcore_converter`` -> ``megatron.core``) runs a
+    module-level ``torch_memory_saver.hook_mode = "torch"``. In the SGLang
+    scheduler process the memory_saver singleton is already initialized (sglang
+    ran ``_ensure_initialized``, which ``del``s ``_impl_ctor_kwargs``), so that
+    late assignment raises ``AttributeError``. awex's model registry swallows the
+    import error, the BailingMoe converter never registers, and weight transfer
+    later dies with ``Unsupported attention parameter name: attention.g_proj``.
+    The singleton's own assert already declares post-init configuration
+    unsupported, so dropping the late set is the intended behavior.
+    """
+    try:
+        import torch_memory_saver as _tms
+    except Exception:
+        return
+    inst = getattr(_tms, "torch_memory_saver", None)
+    if inst is None:
+        return
+    cls = type(inst)
+    prop = cls.hook_mode
+    if getattr(prop.fset, "_awex_safe", False):
+        return
+
+    def _safe_setter(self, value):
+        if not hasattr(self, "_impl_ctor_kwargs"):
+            return  # singleton already initialized; late set is a design no-op
+        prop.fset(self, value)
+
+    _safe_setter._awex_safe = True
+    cls.hook_mode = property(prop.fget, _safe_setter)
+
+
+# Must run before any awex import: awex.models.registry auto-imports model
+# modules at module load, and the BailingMoe module's transitive megatron import
+# trips the hook_mode race above.
+_patch_tms_hook_mode()
+
+from awex.meta.infer_meta_resolver import InferParamMetaResolver  # noqa: E402
+from awex.meta.meta_resolver import ParamMetaResolver  # noqa: E402
+from awex.reader.nccl_reader import (  # noqa: E402
+    NCCLWorkerWeightsReader,
+    _wait_colocate_write_finished,
+)
+from awex.sharding import get_sharding_strategy_builder  # noqa: E402
+from awex.util.common import simple_hf_config  # noqa: E402
+
+from areal.utils.logging import getLogger  # noqa: E402
+
+logger = getLogger("AwexColocateReader")
+
+
+class _BailingV3PhysicalKeyNCCLWorkerWeightsReader(NCCLWorkerWeightsReader):
+    """Bailing v3 AWEX reader using physical GPU ids for MetaServer keys.
+
+    This override is intentionally specific to the Bailing v3 colocated
+    Megatron-to-SGLang path. In addition to fixing logical/physical GPU id
+    mapping, it carries Bailing v3 parameter sentinels and transfer workarounds
+    for the model's hybrid attention and MoE sharding. It must not be treated as
+    a generic AWEX reader without validating those assumptions for a new model.
+
+    In AReaL colocate runs each SGLang process is isolated with a single
+    CUDA_VISIBLE_DEVICES entry, so torch/awex see the logical device id as 0.
+    The training writer publishes IPC handles under the node-local physical GPU
+    id. Keep CUDA operations on the logical device, but use the physical id for
+    MetaServer key names and the train/infer device-rank mapping.
+    """
+
+    # Sentinel substrings for post-update data validation (incident 15): after
+    # every weight update, log shape/norm/first-4 values of a few infer-side
+    # tensors. Offline we locate the logged 4-value window inside the
+    # train-side HF checkpoint tensor to see WHICH slice actually landed on
+    # this rank — a mismatch pattern distinguishes shard permutation from
+    # corrupted payloads.
+    _AREAL_SENTINELS = (
+        "word_embeddings",
+        "lm_head",
+        "layers.0.attention.q_proj",
+        "layers.0.attention.k_proj",
+        "layers.0.attention.o_proj",
+        "layers.0.attention.dt_bias",
+        "layers.0.attention.A_log",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.down_proj",
+        "layers.2.mlp.gate.",
+        "layers.2.mlp.experts.0.gate_proj",
+        "layers.2.mlp.experts.0.down_proj",
+        "layers.2.mlp.experts.100.gate_proj",
+        "layers.2.input_layernorm",
+    )
+
+    def __init__(self, *args, physical_gpu_id: int, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._areal_physical_gpu_id = physical_gpu_id
+
+    def update_weights(self, step_id, **kwargs):
+        super().update_weights(step_id, **kwargs)
+        # Opt-in data-validation probe (set AREAL_AWEX_SENTINEL=1): it costs
+        # GPU->CPU syncs per sentinel tensor on every weight update, so it is
+        # OFF by default and should be enabled for bring-up/validation runs
+        # only (~20 log lines per rank per update).
+        if os.environ.get("AREAL_AWEX_SENTINEL", "0") not in ("0", "", "false"):
+            self._areal_log_sentinels(step_id)
+
+    def _areal_log_sentinels(self, step_id) -> None:
+        logged = 0
+        for name, param in getattr(self, "parameters", {}).items():
+            if not any(s in name for s in self._AREAL_SENTINELS):
+                continue
+            try:
+                t = param.detach()
+                flat = t.reshape(-1)[:4].float().tolist()
+                # fp32 accumulation without materializing a full fp32 copy.
+                norm = torch.linalg.vector_norm(t, dtype=torch.float32).item()
+                logger.info(
+                    "[AWEX-SENTINEL] step=%s transfer_rank=%s phys_gpu=%s "
+                    "name=%s shape=%s norm=%.6f first4=%s",
+                    step_id,
+                    self.transfer_rank,
+                    self._areal_physical_gpu_id,
+                    name,
+                    tuple(t.shape),
+                    norm,
+                    [round(v, 8) for v in flat],
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[AWEX-SENTINEL] failed for %s: %s",
+                    name,
+                    exc,
+                )
+            logged += 1
+            if logged >= 20:
+                break
+
+    def _set_device(self):
+        """Pin the reader to the correct logical CUDA device.
+
+        The upstream implementation resolves the device via
+        ``scheduler.gpu_id -> LOCAL_RANK -> 0``. With TP>1 SGLang servers
+        (e.g. flash ``t8``) scheduler processes are NOT isolated via
+        CUDA_VISIBLE_DEVICES and none of those sources are set, so every
+        rank ends up on device 0 -> NCCL "Duplicate GPU detected" at the
+        weights_exchange barrier (942314). Map from the physical GPU id
+        instead: with per-process CVD isolation (tiny ``t1``) device_count
+        is 1 and the logical id is 0; otherwise the logical id equals the
+        node-local physical id.
+        """
+        import torch
+
+        device_count = torch.cuda.device_count() or 1
+        gpu_id = self._areal_physical_gpu_id % device_count
+        prev_device = torch.cuda.current_device()
+        logger.info(
+            "[NCCLWeightsReader] (AReaL override) set device to %d for rank %s "
+            "(physical_gpu_id=%d, device_count=%d, previous device=%d)",
+            gpu_id,
+            self.transfer_rank,
+            self._areal_physical_gpu_id,
+            device_count,
+            prev_device,
+        )
+        torch.cuda.set_device(gpu_id)
+        self.barrier_device = torch.cuda.current_device()
+        self.backend = "nccl"
+        self.ready_tensor = torch.tensor(1).cuda()
+
+    def _init_reader_in_colocate_mode(self):
+        from awex.transfer.transfer_plan import TransferPlanBuilder
+        from awex.util import device as device_util
+        from awex.util.common import get_ip_address
+
+        ip_address = get_ip_address()
+        physical_gpu_id = self._areal_physical_gpu_id
+        self.meta_server_client.add_object_to_set(
+            "inference_device_rank_entries",
+            (ip_address, physical_gpu_id, self.transfer_rank),
+        )
+        self.meta_server_client.wait_set_until_size(
+            "inference_device_rank_entries",
+            self.infer_world_size,
+            timeout=self.timeout,
+        )
+        inference_device_entries = self.meta_server_client.get_set(
+            "inference_device_rank_entries",
+        )
+        self.inference_device_mapping = {
+            (ip_address, device_id): transfer_rank
+            for ip_address, device_id, transfer_rank in inference_device_entries
+        }
+
+        self.meta_server_client.wait_set_until_size(
+            "training_device_rank_entries",
+            self.training_world_size,
+            timeout=self.timeout,
+        )
+        device_rank_entries = self.meta_server_client.get_set(
+            "training_device_rank_entries",
+        )
+        self.training_device_mapping = {
+            (ip_address, device_id): transfer_rank
+            for ip_address, device_id, transfer_rank in device_rank_entries
+        }
+        self.train_to_infer_device_mapping = {}
+        self.infer_to_train_device_mapping = {}
+        for ip_address, device_id, transfer_rank in device_rank_entries:
+            infer_rank = self.inference_device_mapping[(ip_address, device_id)]
+            self.train_to_infer_device_mapping[transfer_rank] = infer_rank
+            self.infer_to_train_device_mapping[infer_rank] = transfer_rank
+
+        plan_builder = TransferPlanBuilder(
+            self.infer_world_size,
+            self.training_world_size,
+            self.num_engines,
+            self.enable_debug_mode,
+        )
+        self.send_transfer_plan = plan_builder.build_local_transfer_plan(
+            self.parameters_meta,
+            self.training_params_meta,
+            self.infer_to_train_device_mapping[self.transfer_rank],
+        )
+        from awex.transfer.nccl_stream_batch import NcclColocateStreamBatchTransport
+
+        self.colocate_transport = NcclColocateStreamBatchTransport(
+            self.transfer_rank,
+            self.infer_world_size,
+        )
+        logger.info(
+            "Initialized NCCL weights reader for rank %d in colocate mode "
+            "(logical_device=%d, physical_gpu_id=%d)",
+            self.transfer_rank,
+            device_util.current_device(),
+            physical_gpu_id,
+        )
+
+    def collect_training_weights(self, step_id, **kwargs):
+        if not self.enable_colocate_mode:
+            return
+
+        from awex.util import device as device_util
+        from awex.util.common import get_ip_address
+        from awex.util.gpu import get_gpu_status
+        from awex.util.system_util import count_open_fds
+        from awex.util.tensor_util import (
+            cuda_ipc_deserialize,
+            ipc_deserialize,
+            reconstruct_tensors_from_groups,
+        )
+
+        ip_address = get_ip_address()
+        physical_gpu_id = self._areal_physical_gpu_id
+        logical_device_id = device_util.current_device()
+        key = f"training_serialized_weights_{ip_address}_{physical_gpu_id}_{step_id}"
+        logger.info(
+            "Start to get serialized ipc weights %s for rank %s (logical_device=%d)",
+            key,
+            self.rank_coordinate,
+            logical_device_id,
+        )
+        self.send_rank, self.send_rank_info, serialized_weights = (
+            self.meta_server_client.get_object(key, timeout=self.timeout)
+        )
+        logger.info(
+            "Finished getting serialized ipc weights %s for rank %s",
+            key,
+            self.rank_coordinate,
+        )
+        logger.info(
+            "GPU status before deserialization:\n%s for rank %s",
+            get_gpu_status(),
+            self.rank_coordinate,
+        )
+        logger.info("Open fds before deserialization: %d", count_open_fds())
+        if self.ipc_backend in ("cpu", "npu"):
+            group_shared, metadata, names = ipc_deserialize(serialized_weights)
+            group_shared = [t.to(logical_device_id) for t in group_shared]
+        else:
+            group_shared, metadata, names = cuda_ipc_deserialize(serialized_weights)
+        device_util.synchronize(device_id=logical_device_id)
+        tensors = reconstruct_tensors_from_groups(group_shared, metadata)
+        device_util.synchronize(device_id=logical_device_id)
+        self.deserialized_weights = dict(zip(names, tensors))
+        logger.info(
+            "Deserialized %d parameters and %d groups",
+            len(self.deserialized_weights),
+            len(group_shared),
+        )
+        logger.info(
+            "GPU status after deserialization for rank %s:\n%s",
+            self.rank_coordinate,
+            get_gpu_status(),
+        )
+        logger.info("Open fds after deserialization: %d", count_open_fds())
+
+    def _update_weights_in_colocate_mode(self, step_id, **kwargs):
+        import gc
+        import time
+
+        import torch
+        import torch.distributed as dist
+        from awex.util import device as device_util
+        from awex.util.common import compute_statistics, get_ip_address
+        from awex.util.gpu import print_current_gpu_status
+
+        assert self.enable_colocate_mode, "Colocate mode is not enabled"
+        self.collect_training_weights(step_id, **kwargs)
+        logger.info(
+            "Start to update weights using NCCL for step %s from %d ranks(%s) "
+            "for rank %s.",
+            step_id,
+            len(self.transfer_plan.operations),
+            self.send_ranks_sample,
+            self.rank_coordinate,
+        )
+        start_time = time.time()
+        self.colocate_transport.update_weights_in_colocate_mode(
+            self.train_to_infer_device_mapping,
+            self.infer_to_train_device_mapping,
+            self.transfer_rank,
+            self.rank_coordinate,
+            self.infer_world_size,
+            self.send_transfer_plan,
+            self.transfer_plan,
+            self.weights_update_group,
+            self.deserialized_weights,
+            self.parameters,
+            step_id=step_id,
+        )
+        print_current_gpu_status(
+            f"after weights update using NCCL for rank {self.rank_coordinate}",
+        )
+        self.deserialized_weights = None
+        gc.collect()
+        torch.cuda.synchronize()
+        duration = time.time() - start_time
+        compute_statistics(
+            self._history_update_weights_time,
+            step_id,
+            duration,
+            "Receive weights using NCCL",
+        )
+        ip_address = get_ip_address()
+        physical_gpu_id = self._areal_physical_gpu_id
+        key_suffix = f"_{ip_address}_{physical_gpu_id}_{step_id}"
+        update_finished_key = f"weights_update_finished{key_suffix}"
+        self.meta_server_client.put_object(update_finished_key, True)
+        dist.barrier(
+            group=self.weights_update_group,
+            device_ids=[device_util.current_device()],
+        )
+        logger.info(
+            "Barrier passed for reader step %s with rank %d",
+            step_id,
+            self.transfer_rank,
+        )
+        gc.collect()
+        if device_util.get_device_type() == "cuda":
+            torch.cuda.empty_cache()
+        write_finished_key = f"write_finished{key_suffix}"
+        _wait_colocate_write_finished(
+            self.meta_server_client,
+            write_finished_key,
+            self.weights_update_group,
+            self.transfer_rank,
+        )
+        logger.info(
+            "Finished updating weights in colocate mode for rank %d",
+            self.transfer_rank,
+        )
+
+
+def _ensure_awex_models_registered() -> None:
+    """Rebuild awex's model registry in case it cached a failed auto-import.
+
+    ``import_model_configs`` is ``lru_cache``-d and ``ModelRegistry`` is built
+    once at module load. If anything imported the registry before our hook_mode
+    patch took effect, the BailingMoe converter would be silently missing. Clear
+    the cache and rebuild now that the patch is in place.
+    """
+    try:
+        from awex.models import registry as _reg
+
+        _reg.import_model_configs.cache_clear()
+        _reg.ModelRegistry.models = _reg.import_model_configs()
+        missing = [
+            m
+            for m in ("BailingMoeV2_5ForCausalLM", "BailingMoeV2ForCausalLM")
+            if m not in _reg.ModelRegistry.models
+        ]
+        if missing:
+            logger.warning(f"awex model registry still missing converters: {missing}")
+    except Exception as e:  # pragma: no cover - diagnostics only
+        logger.warning(f"Failed to rebuild awex model registry: {e}")
+
+
+_ensure_awex_models_registered()
+
+
+class _SingleInstanceMetaResolver(ParamMetaResolver):
+    """Aggregate per-rank raw meta of ONE inference instance into ParameterMeta.
+
+    awex's ``InferParamMetaResolver`` normally drives this via
+    ``execute_task_in_model_worker`` (a driver fan-out we do not have). We
+    instead exchange the per-rank raw meta dicts through the MetaServer
+    (see ``_build_instance_params_meta``) and reuse awex's ``_build_params_meta``
+    for the aggregation, plus awex's own sharding strategy builder for
+    ``_get_sharding_info``. This yields the exact same ``parameters_meta`` the
+    native reader expects, with awex converter parameter names (no hand-rolled
+    normalization).
+    """
+
+    def __init__(self, hf_config, engine_name, infer_engine_config, raw_meta_list):
+        super().__init__(hf_config)
+        self._raw_meta_list = raw_meta_list
+        rank0 = self._select_rank0(raw_meta_list)
+        self._model_arch_name = rank0["model_arch_name"]
+        self._sharding_strategy = get_sharding_strategy_builder(engine_name)(
+            self._model_arch_name,
+            infer_engine_config,
+            rank0["rank_info"],
+        )
+
+    @staticmethod
+    def _select_rank0(raw_meta_list):
+        for info in raw_meta_list:
+            if info["rank_info"].global_rank == 0:
+                return info
+        return raw_meta_list[0]
+
+    def get_model_arch_name(self) -> str:
+        return self._model_arch_name
+
+    def get_parameters_meta(self):
+        return self._build_params_meta()
+
+    def _get_params_raw_meta(self):
+        return self._raw_meta_list
+
+    def _get_sharding_info(self, name, rank_info, param_meta):
+        return self._sharding_strategy.get_sharding_strategy(
+            name, rank_info=rank_info, param_meta=param_meta
+        )
+
+
+class AwexColocateReader:
+    """Thin adapter binding awex's native worker reader into a SGLang scheduler."""
+
+    def __init__(self, scheduler: Any):
+        self._scheduler = scheduler
+        self._meta_server_client = None
+        self._reader: NCCLWorkerWeightsReader | None = None
+        self._released_tags: set[str] = set()
+
+        self._transfer_rank: int | None = None
+        self._local_gpu_id: int | None = None
+        self._infer_world_size: int | None = None
+        self._train_world_size: int | None = None
+        self._meta_server_addr: str | None = None
+
+        # External-instance decomposition (computed in initialize()).
+        self._infer_instance_world_size: int | None = None
+        self._num_infer_engines: int | None = None
+        self._engine_rank: int | None = None
+        self._instance_local_rank: int | None = None
+
+        # Inference-side parameters_meta for ONE engine instance, computed via
+        # awex resolver + MetaServer raw-meta exchange. Reused as the native
+        # reader's ``parameters_meta`` constructor arg.
+        self._infer_params_meta = None
+        self._infer_conf: dict | None = None
+        self._initialized = False
+
+    # ── model / context helpers ───────────────────────────────────────
+
+    def _get_model(self) -> torch.nn.Module:
+        return self._scheduler.tp_worker.model_runner.model
+
+    def _build_model_context(self) -> dict[str, Any]:
+        """awex model_context describing ONE inference engine instance.
+
+        ``world_size`` is the single-server tp*pp; ``global_rank`` is the
+        instance-local rank (= tp_rank for pp=1). The cross-server NCCL identity
+        (engine_rank / global transfer_rank) is tracked separately by the awex
+        reader. ``infer_engine_config`` (== server_args) is required by
+        ``WorkerWeightsReader.__init__`` and the backport's model_context omits
+        it, so we add it here.
+        """
+        scheduler = self._scheduler
+        server_args = scheduler.server_args
+        tp_size = int(getattr(server_args, "tp_size", 1))
+        pp_size = int(getattr(server_args, "pp_size", 1))
+        dp_size = int(getattr(server_args, "dp_size", 1))
+
+        # incident 15: the v3 fork keeps tp_rank on scheduler.tp_worker, NOT on the
+        # Scheduler itself. `getattr(scheduler, "tp_rank", 0)` silently
+        # returned 0 on EVERY rank, so every reader's rank_info claimed
+        # tp_rank=0, the sharding strategy computed offset-0 slices for all 64
+        # ranks, and the whole engine ended up with shard 0 of every tensor
+        # (942397 sentinel: identical norm/first4 across all ranks; MetaServer
+        # raw meta: gr=0..7 but tp=0 everywhere). Resolve through tp_worker
+        # and fall back to the instance-local rank (== tp rank for pp=1);
+        # never silently default to 0.
+        def _rank_attr(name: str) -> int | None:
+            value = getattr(scheduler, name, None)
+            if value is None:
+                value = getattr(getattr(scheduler, "tp_worker", None), name, None)
+            return None if value is None else int(value)
+
+        tp_rank = _rank_attr("tp_rank")
+        if tp_rank is None and self._instance_local_rank is not None:
+            tp_rank = int(self._instance_local_rank) % max(tp_size, 1)
+        if tp_rank is None:
+            raise RuntimeError(
+                "Cannot resolve tp_rank from scheduler/tp_worker and "
+                "instance_local_rank is unset; refusing to default to 0 "
+                "(would silently corrupt the AWEX transfer plan, incident 15)"
+            )
+
+        if self._infer_instance_world_size is not None:
+            world_size = self._infer_instance_world_size
+            global_rank = self._instance_local_rank
+        else:
+            world_size = tp_size * pp_size
+            global_rank = tp_rank
+
+        pp_rank = _rank_attr("pp_rank")
+        attn_tp_rank = _rank_attr("attn_tp_rank")
+        attn_tp_size = _rank_attr("attn_tp_size")
+        attn_dp_rank = _rank_attr("attn_dp_rank")
+
+        return {
+            "scheduler": scheduler,
+            "infer_engine_config": server_args,
+            "tp_rank": tp_rank,
+            "tp_size": tp_size,
+            "pp_rank": 0 if pp_rank is None else pp_rank,
+            "pp_size": pp_size,
+            "dp_size": dp_size,
+            "world_size": world_size,
+            "global_rank": global_rank,
+            "local_rank": tp_rank,
+            "attn_tp_rank": tp_rank if attn_tp_rank is None else attn_tp_rank,
+            "attn_tp_size": tp_size if attn_tp_size is None else attn_tp_size,
+            "attn_dp_rank": 0 if attn_dp_rank is None else attn_dp_rank,
+        }
+
+    def get_parallelism(self) -> dict:
+        ctx = self._build_model_context()
+        server_args = self._scheduler.server_args
+        return {
+            "world_size": ctx["world_size"],
+            "tp_size": int(getattr(server_args, "tp_size", ctx["tp_size"])),
+            "pp_size": int(getattr(server_args, "pp_size", ctx["pp_size"])),
+            "dp_size": int(getattr(server_args, "dp_size", ctx["dp_size"])),
+            "ep_size": int(getattr(server_args, "ep_size", 1)),
+            "num_engines": self._num_infer_engines or 1,
+        }
+
+    # ── metadata (awex-native, no hand-rolled normalization) ──────────
+
+    def _compute_local_raw_meta(self) -> dict:
+        """Per-rank raw meta via awex's own staticmethod (HF-converted names)."""
+        server_args = self._scheduler.server_args
+        model_context = self._build_model_context()
+        return InferParamMetaResolver._get_model_param_info(
+            "sglang",
+            server_args,
+            convert_params=True,
+            engine_rank=self._engine_rank or 0,
+            model=self._get_model(),
+            model_context=model_context,
+        )
+
+    def _build_instance_params_meta(self):
+        """Gather single-instance raw meta via the MetaServer, then aggregate.
+
+        Returns the awex ``parameters_meta`` (list[ParameterMeta]) for ONE
+        inference engine instance (the ``instance_world`` instance-local ranks).
+
+        We exchange per-rank raw meta through the MetaServer instead of an
+        ``all_gather`` over ``tp_cpu_group``: that group is sglang's TP
+        request-broadcast group, driven by the scheduler MainThread's
+        ``recv_requests`` -> ``broadcast_pyobj``. This method runs on the
+        plugin's background thread, so a collective on the shared group races
+        the MainThread broadcast and deadlocks (two ops in flight on one
+        non-thread-safe group). The MetaServer exchange needs no process-group
+        collective, is isolated per engine instance by ``engine_rank``, and also
+        sidesteps the ``dist.new_group`` collective-ordering trap (train + infer
+        share the default world in colocate mode).
+        """
+        local_raw = self._compute_local_raw_meta()
+
+        instance_world = self._infer_instance_world_size or 1
+        if instance_world > 1:
+            client = self._meta_server_client
+            prefix = f"infer_instance_raw_meta_{self._engine_rank}"
+            client.put_object(f"{prefix}_{self._instance_local_rank}", local_raw)
+            raw_meta_list = [
+                client.get_object(f"{prefix}_{r}", timeout=300.0)
+                for r in range(instance_world)
+            ]
+        else:
+            raw_meta_list = [local_raw]
+
+        # MetaServer serializes RankInfo to a dict on the wire (as did the
+        # legacy all_gather); rebuild the object before awex's resolver reads it.
+        from awex.sharding.rank_info import RankInfo
+
+        for info in raw_meta_list:
+            ri = info.get("rank_info")
+            if isinstance(ri, dict):
+                info["rank_info"] = RankInfo(**ri)
+
+        resolver = _SingleInstanceMetaResolver(
+            self._get_model().config,
+            "sglang",
+            self._scheduler.server_args,
+            raw_meta_list,
+        )
+        return resolver.get_parameters_meta()
+
+    def get_weight_metadata(self):
+        """Inference-side parameters_meta for ONE engine instance."""
+        if self._infer_params_meta is None:
+            self._infer_params_meta = self._build_instance_params_meta()
+        return self._infer_params_meta
+
+    # ── eager init: register infer_conf + num_infer_engines ───────────
+
+    def initialize(
+        self,
+        meta_server_addr: str,
+        transfer_rank: int,
+        infer_world_size: int,
+        train_world_size: int,
+        local_gpu_id: int,
+        timeout_s: float = 300.0,
+    ) -> None:
+        """Eager init: publish the metadata the train writer waits for.
+
+        Must NOT block on the training side (runs before the first training step
+        finishes). The native ``NCCLWorkerWeightsReader`` is built lazily in
+        ``update_weights`` once ``training_params_meta`` is available. Device
+        entry registration (``inference_device_rank_entries``) is left to the
+        native reader's ``_init_reader_in_colocate_mode``.
+        """
+        from awex.meta.meta_server import MetaServerClient
+
+        if infer_world_size != train_world_size:
+            raise ValueError(
+                f"Colocate mode requires equal total rank counts "
+                f"(same physical GPUs), got infer={infer_world_size} "
+                f"vs train={train_world_size}"
+            )
+
+        self._transfer_rank = transfer_rank
+        self._local_gpu_id = local_gpu_id
+        self._infer_world_size = infer_world_size
+        self._train_world_size = train_world_size
+        self._meta_server_addr = meta_server_addr
+
+        server_args = self._scheduler.server_args
+        tp_size = int(getattr(server_args, "tp_size", 1))
+        pp_size = int(getattr(server_args, "pp_size", 1))
+        instance_world = max(1, tp_size * pp_size)
+        if infer_world_size % instance_world != 0:
+            raise ValueError(
+                f"infer_world_size ({infer_world_size}) must be divisible by the "
+                f"per-instance world tp*pp ({instance_world})"
+            )
+        self._infer_instance_world_size = instance_world
+        self._num_infer_engines = infer_world_size // instance_world
+        self._engine_rank = transfer_rank // instance_world
+        self._instance_local_rank = transfer_rank % instance_world
+        logger.info(
+            "AWEX instance decomposition: transfer_rank=%d -> engine_rank=%d, "
+            "instance_local_rank=%d (instance_world=%d, num_engines=%d)",
+            transfer_rank,
+            self._engine_rank,
+            self._instance_local_rank,
+            instance_world,
+            self._num_infer_engines,
+        )
+
+        host, port = meta_server_addr.rsplit(":", 1)
+        self._meta_server_client = MetaServerClient(host, int(port))
+
+        # Compute single-instance parameters_meta (also reused as the native
+        # reader's constructor arg later).
+        self.get_weight_metadata()
+
+        par = self.get_parallelism()
+        infer_conf = {
+            "engine_name": "sglang",
+            "infer_atten_tp_size": par["tp_size"],
+            "infer_world_size": infer_world_size,
+            "hf_config": simple_hf_config(self._get_model().config),
+            # P69 root cause: upstream awex's reader publishes router_dtype so
+            # the train-side converter casts mlp.gate.weight to the dtype the
+            # inference engine actually holds (fp32 for BailingMoe). This
+            # hand-rolled infer_conf omitted it, so the converter fell back to
+            # its bf16 default and gate shards went out 2N bytes against a 4N
+            # irecv — the deterministic chunk-7 wedge of trial-0610-1509. The
+            # wire-level dtype reconciliation (0877ea4) papers over any such
+            # mismatch generically, but keep the semantic path whole so new
+            # models behave identically to native awex.
+            "router_dtype": getattr(self._get_model().config, "router_dtype", "bf16"),
+        }
+        self._infer_conf = infer_conf
+
+        # Only one rank publishes the engine-instance-wide info the writer waits
+        # for. transfer_rank 0 is engine_rank 0, instance_local_rank 0.
+        if transfer_rank == 0:
+            self._meta_server_client.put_object("infer_conf", infer_conf)
+            self._meta_server_client.put_object(
+                "num_infer_engines", self._num_infer_engines
+            )
+            logger.info(
+                "Registered infer_conf + num_infer_engines=%d with MetaServer",
+                self._num_infer_engines,
+            )
+
+        self._initialized = True
+        logger.info(
+            "Eager init done: transfer_rank=%d, local_gpu_id=%d, infer_world_size=%d "
+            "(native worker reader construction deferred to first update_weights)",
+            transfer_rank,
+            local_gpu_id,
+            infer_world_size,
+        )
+
+    # ── lazy native-reader construction + weight update ───────────────
+
+    def _ensure_reader(self) -> NCCLWorkerWeightsReader:
+        if self._reader is not None:
+            return self._reader
+
+        client = self._meta_server_client
+        training_params_meta = client.get_object(
+            "training_params_meta", timeout=10000.0
+        )
+        logger.info("Got training_params_meta from MetaServer")
+
+        model_context = self._build_model_context()
+        reader = _BailingV3PhysicalKeyNCCLWorkerWeightsReader(
+            engine_name="sglang",
+            model=self._get_model(),
+            model_context=model_context,
+            infer_conf=self._infer_conf,
+            engine_rank=self._engine_rank,
+            num_engines=self._num_infer_engines,
+            meta_server_addr=self._meta_server_addr,
+            parameters_meta=self._infer_params_meta,
+            training_params_meta=training_params_meta,
+            enable_colocate_mode=True,
+            ipc_backend="cuda",
+            enable_debug_mode=False,
+            physical_gpu_id=self._local_gpu_id,
+        )
+        reader.initialize()
+        self._reader = reader
+        logger.info(
+            "Constructed native NCCLWorkerWeightsReader (transfer_rank=%d, "
+            "engine_rank=%d, num_engines=%d)",
+            reader.transfer_rank,
+            self._engine_rank,
+            self._num_infer_engines,
+        )
+        return reader
+
+    def update_weights(self, version: int) -> None:
+        """Run one colocate weight update via the native awex worker reader.
+
+        The native reader internally does: IPC collect -> StreamBatch transport
+        -> put ``weights_update_finished`` -> barrier -> get_then_delete
+        ``write_finished`` -> flush_cache. The plugin only needs to wrap this
+        with the driver-equivalent wait-for-offload + resume + signal steps.
+        """
+        if not self._initialized:
+            raise RuntimeError("AwexColocateReader not initialized")
+        reader = self._ensure_reader()
+        self._pre_process_model_weights()
+        reader.update_weights(step_id=version)
+        self._rebuild_derived_weights()
+        logger.info("Colocate weight update completed: version=%d", version)
+
+    def _iter_model_parts(self) -> list[tuple[Any, bool]]:
+        models = self._get_model()
+        if isinstance(models, (list, tuple)):
+            if len(models) == 2:
+                return [(models[0], False), (models[1], True)]
+            return [(model, idx > 0) for idx, model in enumerate(models)]
+        return [(models, False)]
+
+    @staticmethod
+    def _call_model_hook(model: Any, hook_name: str, **kwargs: Any) -> bool:
+        hook = getattr(model, hook_name, None)
+        if hook is None:
+            return False
+
+        try:
+            params = inspect.signature(hook).parameters
+        except (TypeError, ValueError):
+            hook()
+            return True
+
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            hook(**kwargs)
+        else:
+            accepted = {
+                name
+                for name, p in params.items()
+                if p.kind
+                in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+            }
+            hook(**{k: v for k, v in kwargs.items() if k in accepted})
+        return True
+
+    def _pre_process_model_weights(self) -> None:
+        """Run model-side pre-load hooks before AWEX writes params in-place."""
+        for model, _ in self._iter_model_parts():
+            if self._call_model_hook(model, "pre_process_weights_if_quant"):
+                logger.info("pre_process_weights_if_quant() prepared model weights")
+
+    def _rebuild_derived_weights(self) -> None:
+        """Re-derive non-parameter tensors after an in-place AWEX weight write.
+
+        P75 root cause: sglang's ``load_model`` ends with
+        ``post_load_weights()``, which splits each MLA layer's
+        ``kv_b_proj.weight`` into the absorbed-path tensors ``w_kc``/``w_vc``
+        — ``.contiguous()`` copies stored as plain attributes, in neither
+        ``named_parameters`` nor ``named_buffers``. The memory-saver
+        release/resume cycle remaps their pages to zeros, and the AWEX reader
+        rewrites only named parameters via in-place ``copy_`` (bypassing
+        ``model.load_weights``), so nothing ever rebuilds them: decode's
+        forward_absorb then consumes zeros and the 4 MLA layers degenerate
+        while the 28 Lightning layers stay healthy (reward 0.77 -> ~0 within
+        5 steps). Rebuild after EVERY transfer — train weights move each
+        version, so a one-time fix would go stale. ``bind_or_assign`` copies
+        into the existing tensors in place, which keeps captured CUDA-graph
+        addresses valid.
+        """
+        did_post_load = False
+        for model, is_nextn in self._iter_model_parts():
+            did_post_load = (
+                self._call_model_hook(
+                    model,
+                    "post_load_weights",
+                    is_nextn=is_nextn,
+                    weight_names=None,
+                )
+                or did_post_load
+            )
+            if self._call_model_hook(model, "post_process_weights_if_quant"):
+                logger.info("post_process_weights_if_quant() finalized model weights")
+
+        torch.cuda.synchronize()
+        if did_post_load:
+            logger.info("post_load_weights() re-derived absorbed MLA weights")
+
+    # ── memory release/resume (delegate to SGLang native) ─────────────
+
+    def release_memory(self, tags: list[str] | None = None) -> None:
+        from sglang.srt.managers.io_struct import ReleaseMemoryOccupationReqInput
+
+        tags = tags or ["kv_cache"]
+        native_tags = [t for t in tags if t not in self._released_tags]
+        if native_tags:
+            req = ReleaseMemoryOccupationReqInput(tags=native_tags)
+            self._scheduler.release_memory_occupation(req)
+            self._released_tags.update(native_tags)
+        logger.info("release_memory: tags=%s", tags)
+
+    def resume_memory(self, tags: list[str] | None = None) -> None:
+        from sglang.srt.managers.io_struct import ResumeMemoryOccupationReqInput
+
+        tags = tags or ["kv_cache"]
+        resume_tags = [t for t in tags if t in self._released_tags]
+        if resume_tags:
+            req = ResumeMemoryOccupationReqInput(tags=resume_tags)
+            self._scheduler.resume_memory_occupation(req)
+            self._released_tags.difference_update(resume_tags)
+        logger.info("resume_memory: tags=%s", tags)
+
+    # ── writer-coordination handshake (driver-equivalent shell steps) ──
+
+    def wait_for_training_offloaded(self, version: int) -> None:
+        """Wait for the writer to offload its model weights (avoid 2x weights).
+
+        Equivalent to awex driver ``_pre_update_weights``'s wait on
+        ``all_training_offloaded_weights``.
+        """
+        from areal.engine.awex_colocate import awex_colocate_timeout_s
+
+        self._meta_server_client.wait_set_until_size(
+            "all_training_offloaded_weights",
+            self._train_world_size,
+            timeout=awex_colocate_timeout_s(),
+        )
+
+    def wait_for_weights_ready(
+        self, version: int, timeout_s: float | None = None
+    ) -> None:
+        """Block until the writer has published THIS version's IPC handles.
+
+        Used by the plugin's background thread as the per-version trigger to
+        enqueue a weight-update marker. We probe the per-version
+        ``training_serialized_weights_{ip}_{gpu}_{version}`` key with MetaServer
+        ``wait_key`` (existence-only, NO deserialization), for two reasons:
+
+        1. Per-version gating. The unversioned ``all_training_offloaded_weights``
+           set is only deleted by the writer's rank0 in ``finish_colocate_weight_update``
+           (a later phase than the engine's signal_finished), so gating on it
+           lets the background thread fire v+1 off a *stale* satisfied set while
+           the writer is still in v's finish phase. The collected v+1 IPC then
+           blocks waiting for a not-yet-published key, hogging the scheduler main
+           loop so it cannot serve rollout -> train waits on rollout -> deadlock.
+           The writer only puts the v+1 serialized key in the NEXT training cycle,
+           so gating on it cannot fire early.
+        2. No double-attach. ``get_object`` would deserialize the CUDA IPC handle
+           in the background thread, racing the worker reader's own collect inside
+           update_weights. ``wait_key`` only checks presence (``_has_key``).
+        """
+        from awex.util.common import get_ip_address
+
+        from areal.engine.awex_colocate import awex_colocate_timeout_s
+
+        ip = get_ip_address()
+        key = f"training_serialized_weights_{ip}_{self._local_gpu_id}_{version}"
+        self._meta_server_client.wait_key(
+            key,
+            timeout=awex_colocate_timeout_s() if timeout_s is None else timeout_s,
+        )
+
+    def signal_finished_weights_update(self) -> None:
+        """Signal this engine finished, so the writer can resume kv_cache.
+
+        Equivalent to awex driver ``_resume_kvcache``'s add to
+        ``finished_weights_update_engines``. Only one rank per engine instance
+        (instance_local_rank == 0) signals, with its real engine_rank, so the
+        set collects exactly num_infer_engines unique entries.
+        """
+        if self._instance_local_rank != 0:
+            return
+        self._meta_server_client.add_object_to_set(
+            "finished_weights_update_engines", self._engine_rank
+        )
+
+    def teardown(self) -> None:
+        self._reader = None
+
+
+__all__ = ["AwexColocateReader"]

--- a/areal/engine/awex_sglang_plugin.py
+++ b/areal/engine/awex_sglang_plugin.py
@@ -1,0 +1,1141 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""AWEX SGLang scheduler plugin for colocated weight transfer.
+
+Patches SGLang's scheduler to inject CUDA IPC weight receiving capabilities.
+When AWEX_META_SERVER_ADDR env var is set, starts a background thread that
+fetches IPC handles from MetaServer (CPU I/O) and queues them for the
+scheduler's main loop to process (CUDA copy on main thread).
+
+Weight transfer flow (aligned with Asystem colocate mode):
+  1. Training side: convert params → cuda_ipc_serialize → MetaServer put
+  2. Background thread: MetaServer get → queue IPC data (CPU only)
+  3. Scheduler main loop: release_memory → deserialize + copy → resume_memory
+  4. Main loop: signal done → train side releases shared tensors
+
+Usage:
+    # Option 1: Register plugin then launch SGLang
+    from areal.engine.awex_sglang_plugin import register_awex_plugin
+    register_awex_plugin()
+
+    # Option 2: Run as entry module (replaces sglang.launch_server)
+    # python3 -m areal.engine.awex_sglang_plugin --model-path ...
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from areal.utils.logging import getLogger
+
+logger = getLogger("AwexSGLangPlugin")
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.environ.get(name, "")
+    if not value:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %.3f", name, value, default)
+        return default
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.environ.get(name, "")
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %d", name, value, default)
+        return default
+
+
+def _scheduler_int_attr(scheduler: Any, name: str, default: int) -> int:
+    for obj in (
+        scheduler,
+        getattr(scheduler, "ps", None),
+        getattr(scheduler, "server_args", None),
+    ):
+        if obj is None or not hasattr(obj, name):
+            continue
+        value = getattr(obj, name)
+        if value is not None:
+            return int(value)
+    return default
+
+
+def _scheduler_callable(scheduler: Any, name: str) -> Callable:
+    for obj in (scheduler, getattr(scheduler, "weight_updater", None)):
+        if obj is None:
+            continue
+        method = getattr(obj, name, None)
+        if callable(method):
+            return method
+    raise AttributeError(f"Scheduler has no callable {name!r}")
+
+
+def _logical_gpu_id(scheduler: Any) -> int:
+    return _scheduler_int_attr(scheduler, "gpu_id", 0)
+
+
+def _physical_gpu_id(scheduler: Any) -> int:
+    """Return the node-local physical GPU id used by AWEX MetaServer keys."""
+
+    logical_gpu_id = _logical_gpu_id(scheduler)
+    visible_devices = [
+        d.strip()
+        for d in os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",")
+        if d.strip()
+    ]
+    if (
+        logical_gpu_id < len(visible_devices)
+        and visible_devices[logical_gpu_id].isdigit()
+    ):
+        return int(visible_devices[logical_gpu_id])
+
+    physical_base = os.environ.get("AREAL_AWEX_PHYSICAL_BASE_GPU_ID", "")
+    if physical_base:
+        try:
+            return int(physical_base) + logical_gpu_id
+        except ValueError:
+            logger.warning(
+                "Invalid AREAL_AWEX_PHYSICAL_BASE_GPU_ID=%r; using logical gpu id %d",
+                physical_base,
+                logical_gpu_id,
+            )
+    return logical_gpu_id
+
+
+def _patch_release_memory_for_retract_pause() -> None:
+    """Allow KV/weights offload while the engine is retract-paused.
+
+    AReaL pauses SGLang with ``/pause_generation {"mode": "retract"}`` before
+    offloading: running requests move to the waiting queue with their KV
+    released, and recompute after ``continue_generation``. The v3 fork gates
+    both ``release_memory_occupation`` (assert) and ``flush_cache`` on
+    ``is_fully_idle()``, which requires an EMPTY waiting queue, so every
+    colocate train step killed all servers with an AssertionError (942388).
+    The v2.5 fork gated both on ``_is_no_request()`` (running requests only),
+    which matches the documented retract semantics ("The KV cache can be
+    flushed in this mode", ``PauseGenerationReqInput``). Restore that
+    behavior, but only when the engine is paused with an empty running
+    batch; any other non-idle state still hits the original assert.
+    """
+    try:
+        from sglang.srt.managers.scheduler_components.weight_updater import (
+            SchedulerWeightUpdaterManager,
+        )
+    except ImportError:
+        logger.warning(
+            "[AWEX] weight_updater module not found; skipping retract-pause "
+            "release_memory_occupation patch",
+        )
+        return
+
+    if getattr(SchedulerWeightUpdaterManager, "_areal_retract_pause_patch", False):
+        return
+
+    orig_release = SchedulerWeightUpdaterManager.release_memory_occupation
+
+    def release_memory_occupation(self, recv_req):
+        scheduler = self.scheduler
+        retract_paused = (
+            scheduler is not None
+            and getattr(scheduler, "_engine_paused", False)
+            and scheduler.running_batch.is_empty()
+            and not self.is_fully_idle()
+        )
+        if not retract_paused:
+            return orig_release(self, recv_req)
+        logger.info(
+            "[AWEX] release_memory_occupation under retract pause: treating "
+            "scheduler as idle (waiting_queue=%d)",
+            len(scheduler.waiting_queue),
+        )
+        # The idle gate is bound in two places: the dataclass field (used by
+        # the assert) and scheduler.is_fully_idle (used inside
+        # scheduler.flush_cache). Shadow both for the duration of the call so
+        # the flush actually resets the radix/KV pools; silently skipping it
+        # would keep stale KV entries alive across the weight update.
+        orig_field = self.is_fully_idle
+        self.is_fully_idle = lambda *args, **kwargs: True
+        scheduler.is_fully_idle = lambda *args, **kwargs: True
+        try:
+            return orig_release(self, recv_req)
+        finally:
+            self.is_fully_idle = orig_field
+            try:
+                del scheduler.is_fully_idle
+            except AttributeError:
+                pass
+
+    SchedulerWeightUpdaterManager.release_memory_occupation = release_memory_occupation
+    SchedulerWeightUpdaterManager._areal_retract_pause_patch = True
+    logger.info(
+        "[AWEX] patched release_memory_occupation for retract-pause offload",
+    )
+
+
+def _patch_flush_cache_for_retract_pause() -> None:
+    """Let flush_cache succeed while the engine is retract-paused.
+
+    The awex reader asserts ``scheduler.flush_cache()`` success right after
+    every weight update (``weights_reader.update_weights``). v3's
+    ``flush_cache`` is gated on ``is_fully_idle()``, which requires an empty
+    waiting queue — but retract-pause parks the in-flight requests exactly
+    there, so on any engine with a pending request the flush returns False
+    and the assert kills the scheduler (942391: 6/8 engines died, the 2
+    with empty queues survived). v2.5 gated the flush on ``_is_no_request()``
+    (running only), which is the validated retract semantics ("The KV cache
+    can be flushed in this mode and will be automatically recomputed after
+    continue_generation"). Restore that: when the engine is paused with an
+    empty running batch, treat the scheduler as idle for the duration of
+    the flush. Retracted requests hold no pool slots, so resetting the
+    radix/KV pools is safe; they re-prefill after continue_generation.
+    """
+    try:
+        from sglang.srt.managers.scheduler import Scheduler
+    except ImportError:
+        logger.warning(
+            "[AWEX] Scheduler import failed; skipping retract-pause flush_cache patch",
+        )
+        return
+
+    if getattr(Scheduler, "_areal_retract_pause_flush", False):
+        return
+
+    orig_flush = Scheduler.flush_cache
+
+    def flush_cache(self, *args, **kwargs):
+        retract_paused = (
+            getattr(self, "_engine_paused", False)
+            and self.running_batch.is_empty()
+            and not self.is_fully_idle()
+        )
+        if not retract_paused:
+            return orig_flush(self, *args, **kwargs)
+        logger.info(
+            "[AWEX] flush_cache under retract pause: treating scheduler as "
+            "idle (waiting_queue=%d)",
+            len(self.waiting_queue),
+        )
+        self.is_fully_idle = lambda *args_, **kwargs_: True
+        try:
+            return orig_flush(self, *args, **kwargs)
+        finally:
+            try:
+                del self.is_fully_idle
+            except AttributeError:
+                pass
+
+    Scheduler.flush_cache = flush_cache
+    Scheduler._areal_retract_pause_flush = True
+    logger.info("[AWEX] patched flush_cache for retract-pause weight updates")
+
+
+def _try_get_writer_version(
+    meta_server_client: Any,
+    key: str,
+    timeout_s: float,
+) -> int | None:
+    """Return the writer's current version if published, otherwise None."""
+
+    try:
+        wait_key = getattr(meta_server_client, "wait_key", None)
+        if callable(wait_key):
+            wait_key(key, timeout=timeout_s)
+        return int(meta_server_client.get_object(key, timeout=timeout_s))
+    except Exception:
+        return None
+
+
+class AwexSchedulerPlugin:
+    """Binds awex weight-receive to a SGLang Scheduler instance.
+
+    Architecture: background thread handles MetaServer I/O (CPU only),
+    scheduler main loop handles CUDA weight copy (via process_awex_queue).
+    """
+
+    def __init__(self, scheduler: Any) -> None:
+        self._scheduler = scheduler
+        self._receiver = None
+        self._bg_thread: threading.Thread | None = None
+        self._weight_queue: queue.Queue = queue.Queue()
+        self._version = 0
+        self._paused_poll_interval_s = max(
+            0.0, _float_env("AWEX_PAUSED_POLL_INTERVAL_S", 0.01)
+        )
+        self._process_queue_when_idle = _bool_env(
+            "AREAL_AWEX_PROCESS_QUEUE_WHEN_IDLE", True
+        )
+        # Idle-poll throttle in *loop iterations*, not wall-clock time: TP
+        # ranks run the scheduler loop in lockstep, so a loop-count gate is
+        # deterministic across ranks (a time-based gate deadlocks, see
+        # _maybe_process_awex_queue_when_idle).
+        self._idle_poll_loops = max(1, _int_env("AWEX_IDLE_POLL_LOOPS", 64))
+
+    def bind(self) -> None:
+        # Fail fast on fork upgrades: validate every scheduler-instance
+        # assumption the colocate integration relies on (incidents 12-15) before
+        # any rollout/weight-update traffic can hit a silent mismatch.
+        from areal.engine.sglang_fork_contract import check_scheduler_contract
+
+        check_scheduler_contract(self._scheduler)
+
+        methods = [
+            "awex_init_receiver",
+            "awex_receive_weights",
+            "awex_release_memory",
+            "awex_resume_memory",
+            "awex_get_weight_metadata",
+            "awex_get_parallelism",
+            "process_awex_queue",
+        ]
+        for name in methods:
+            setattr(self._scheduler, name, getattr(self, name))
+        logger.info(
+            f"[AWEX] AwexSchedulerPlugin bound {len(methods)} methods to scheduler",
+        )
+
+        meta_server_addr = os.environ.get("AWEX_META_SERVER_ADDR")
+        if meta_server_addr:
+            self._start_background_worker(meta_server_addr)
+            self._patch_event_loop()
+
+    def _require_receiver(self):
+        if self._receiver is None:
+            from areal.engine.awex_colocate_reader import AwexColocateReader
+
+            self._receiver = AwexColocateReader(self._scheduler)
+        return self._receiver
+
+    def awex_init_receiver(self, **kwargs: Any) -> None:
+        self._require_receiver().initialize(**kwargs)
+
+    def awex_receive_weights(self, version: int = 0) -> None:
+        self._require_receiver().update_weights(version)
+
+    def awex_release_memory(self, tags: list[str] | None = None) -> None:
+        self._require_receiver().release_memory(tags)
+
+    def awex_resume_memory(self, tags: list[str] | None = None) -> None:
+        self._require_receiver().resume_memory(tags)
+
+    def awex_get_weight_metadata(self) -> list:
+        return self._require_receiver().get_weight_metadata()
+
+    def awex_get_parallelism(self) -> dict:
+        return self._require_receiver().get_parallelism()
+
+    # ── Main loop hook: process queued weight updates ─────────────────
+
+    def process_awex_queue(self, extra_ready: bool = True) -> None:
+        """Called from scheduler main loop. Processes pending weight updates.
+
+        This is a TP-collective operation: ALL TP ranks must call it together
+        (since it's called between recv_requests() calls which use broadcast_pyobj).
+
+        Uses all_reduce(MIN) to check if all TP ranks are ready to process a
+        pending update. ``extra_ready`` lets callers fold per-rank conditions
+        (e.g. idle state) into the collective decision instead of returning
+        early, which would desynchronize the ranks. Only proceeds when ALL
+        ranks are ready, preventing the deadlock where one rank blocks in CUDA
+        ops while others wait in broadcast_pyobj.
+
+        We act as the awex *driver* layer for the queued colocate update. The
+        collect-IPC + StreamBatch transport + writer handshake is delegated to the
+        awex-native worker reader (``AwexColocateReader.update_weights`` ->
+        ``NCCLWorkerWeightsReader``). We only own the driver-equivalent steps
+        around it:
+          1. Wait for all_training_offloaded_weights (= driver _pre_update_weights)
+          2. resume_memory_occupation(weights) — re-allocate infer weight buffers
+          3. reader.update_weights(version) — awex worker reader does the rest:
+             collect IPC + StreamBatch transport + put weights_update_finished
+             + barrier + get_then_delete write_finished + flush_cache
+          4. signal_finished_weights_update (= driver _resume_kvcache)
+        """
+        import torch
+        import torch.distributed
+
+        tp_cpu_group = self._scheduler.tp_cpu_group
+        tp_size = _scheduler_int_attr(self._scheduler, "tp_size", 1)
+
+        has_item = 1 if (extra_ready and not self._weight_queue.empty()) else 0
+
+        if tp_size > 1:
+            has_item_tensor = torch.tensor([has_item], dtype=torch.int32)
+            torch.distributed.all_reduce(
+                has_item_tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=tp_cpu_group,
+            )
+            all_ready = has_item_tensor.item() == 1
+        else:
+            all_ready = has_item == 1
+
+        if not all_ready:
+            return
+
+        item = self._weight_queue.get_nowait()
+        version = item["version"]
+        gpu_id = getattr(self._scheduler, "gpu_id", "?")
+        logger.info(
+            f"[AWEX] main loop: processing weight update v{version} (gpu_id={gpu_id})",
+        )
+
+        from sglang.srt.managers.io_struct import ResumeMemoryOccupationReqInput
+
+        receiver = self._require_receiver()
+
+        # Step 1: Wait for writer to offload its model weights first (= awex driver
+        # _pre_update_weights). Ensures no 2x model weights on GPU simultaneously.
+        # The background thread already gated on this, so this returns immediately;
+        # kept for driver-equivalent clarity.
+        logger.info(
+            f"[AWEX] main loop: waiting for all_training_offloaded_weights (gpu_id={gpu_id})",
+        )
+        receiver.wait_for_training_offloaded(version)
+        logger.info(
+            f"[AWEX] main loop: writer offloaded weights confirmed (gpu_id={gpu_id})",
+        )
+
+        # Step 2: Resume weight memory (memory_saver re-allocates buffers).
+        resume_req = ResumeMemoryOccupationReqInput(tags=["weights"])
+        resume_memory_occupation = _scheduler_callable(
+            self._scheduler, "resume_memory_occupation"
+        )
+        resume_memory_occupation(resume_req)
+        logger.info(
+            f"[AWEX] main loop: resumed weight memory for v{version} (gpu_id={gpu_id})",
+        )
+
+        # Step 3: Delegate the whole collect-IPC + StreamBatch transport + writer
+        # handshake (put weights_update_finished + barrier + get_then_delete
+        # write_finished + flush_cache) to the awex-native worker reader.
+        try:
+            receiver.update_weights(version)
+            logger.info(
+                f"[AWEX] main loop: weight update done for v{version} (gpu_id={gpu_id})",
+            )
+        except Exception:
+            logger.exception(
+                "AWEX main loop failed to update weights v%s on gpu_id=%s",
+                version,
+                gpu_id,
+            )
+            raise
+
+        # Step 4: Signal that this infer engine finished weight update, so the
+        # writer can resume kv_cache (= awex driver _resume_kvcache).
+        receiver.signal_finished_weights_update()
+        self._version = version
+
+    # ── Patch scheduler event loop to call process_awex_queue ─────────
+
+    def _patch_event_loop(self) -> None:
+        """Inject process_awex_queue into scheduler's event loops.
+
+        SGLang uses event_loop_overlap by default. Patch both for safety.
+        Weight updates process when engine is paused (no ongoing inference).
+        """
+        scheduler = self._scheduler
+        plugin = self
+
+        _orig_log_decode_stats = getattr(scheduler, "log_decode_stats", None)
+        _orig_log_decode_stats_every_iteration = getattr(
+            scheduler, "log_decode_stats_every_iteration", None
+        )
+        has_decode_stats = callable(_orig_log_decode_stats)
+        has_decode_iter_stats = callable(_orig_log_decode_stats_every_iteration)
+
+        if has_decode_stats:
+
+            def _tracked_log_decode_stats(*args, **kwargs):
+                scheduler._areal_awex_last_decode_stats_ct = getattr(
+                    scheduler, "forward_ct_decode", None
+                )
+                return _orig_log_decode_stats(*args, **kwargs)
+
+            scheduler.log_decode_stats = _tracked_log_decode_stats
+        else:
+            logger.info(
+                "[AWEX] Scheduler has no log_decode_stats; "
+                "skipping decode metrics restore hook",
+            )
+
+        if has_decode_iter_stats:
+
+            def _tracked_log_decode_stats_every_iteration(*args, **kwargs):
+                scheduler._areal_awex_last_decode_stats_every_iter_ct = getattr(
+                    scheduler, "forward_ct_decode", None
+                )
+                return _orig_log_decode_stats_every_iteration(*args, **kwargs)
+
+            scheduler.log_decode_stats_every_iteration = (
+                _tracked_log_decode_stats_every_iteration
+            )
+        else:
+            logger.info(
+                "[AWEX] Scheduler has no log_decode_stats_every_iteration; "
+                "skipping per-iteration decode metrics restore hook",
+            )
+
+        def _maybe_restore_decode_metrics(stage, batch, result):
+            if os.environ.get("AREAL_AWEX_FORCE_SGLANG_METRICS", "1") != "1":
+                return
+            if stage != "after_process_batch_result" or batch is None:
+                return
+            mode = getattr(getattr(batch, "forward_mode", None), "name", None)
+            if mode != "DECODE":
+                return
+            if not getattr(scheduler, "current_scheduler_metrics_enabled", False):
+                return
+
+            current_ct = getattr(scheduler, "forward_ct_decode", None)
+            interval = (
+                getattr(
+                    getattr(scheduler, "server_args", None), "decode_log_interval", 1
+                )
+                or 1
+            )
+            should_log_decode = current_ct is not None and current_ct % interval == 0
+
+            if (
+                has_decode_stats
+                and callable(getattr(scheduler, "log_decode_stats", None))
+                and should_log_decode
+                and getattr(scheduler, "_areal_awex_last_decode_stats_ct", None)
+                != current_ct
+            ):
+                can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+                logger.debug(
+                    f"[AWEX-METRICS] restoring native log_decode_stats "
+                    f"gpu_id={getattr(scheduler, 'gpu_id', '?')} "
+                    f"forward_ct_decode={current_ct}",
+                )
+                scheduler.log_decode_stats(can_run_cuda_graph, running_batch=batch)
+
+            if (
+                has_decode_iter_stats
+                and callable(
+                    getattr(scheduler, "log_decode_stats_every_iteration", None)
+                )
+                and getattr(
+                    scheduler, "_areal_awex_last_decode_stats_every_iter_ct", None
+                )
+                != current_ct
+            ):
+                scheduler.log_decode_stats_every_iteration(
+                    batch,
+                    num_accepted_tokens=getattr(result, "num_accepted_tokens", 0),
+                )
+
+        def _recv_requests():
+            if hasattr(scheduler, "recv_requests"):
+                return scheduler.recv_requests()
+            return scheduler.request_receiver.recv_requests()
+
+        def _on_idle():
+            if hasattr(scheduler, "self_check_during_idle"):
+                scheduler.self_check_during_idle()
+            else:
+                scheduler.on_idle()
+
+        def _is_idle_for_awex_update() -> bool:
+            is_fully_idle = getattr(scheduler, "is_fully_idle", None)
+            if callable(is_fully_idle):
+                try:
+                    return bool(is_fully_idle())
+                except TypeError:
+                    return bool(is_fully_idle(for_health_check=False))
+
+            for attr in ("cur_batch", "last_batch"):
+                if getattr(scheduler, attr, None) is not None:
+                    return False
+
+            result_queue = getattr(scheduler, "result_queue", None)
+            if result_queue is not None and len(result_queue) > 0:
+                return False
+
+            running_batch = getattr(scheduler, "running_batch", None)
+            if running_batch is not None:
+                is_empty = getattr(running_batch, "is_empty", None)
+                if callable(is_empty) and not is_empty():
+                    return False
+
+            return True
+
+        def _maybe_process_awex_queue_when_idle(loop_count: int) -> None:
+            if not plugin._process_queue_when_idle:
+                return
+            # DEADLOCK WARNING: everything gating the all_reduce inside
+            # process_awex_queue() MUST be deterministic and identical across
+            # TP ranks. Loop iterations are lockstep (every iteration goes
+            # through the recv_requests broadcast), so a loop-count throttle
+            # is safe. A wall-clock throttle (time.monotonic) is NOT: ranks
+            # hit the window at different times, some skip the all_reduce
+            # while others enter it, and the next recv_requests broadcast
+            # cross-deadlocks against the pending all_reduce (observed as
+            # TP0 stuck in broadcast_pyobj vs TP1-7 stuck in all_reduce).
+            if loop_count % plugin._idle_poll_loops != 0:
+                return
+
+            tp_size = _scheduler_int_attr(scheduler, "tp_size", 1)
+            is_idle = _is_idle_for_awex_update()
+            if tp_size == 1:
+                if is_idle and not plugin._weight_queue.empty():
+                    plugin.process_awex_queue()
+                return
+
+            # Rank-local idle state is folded into the collective vote instead
+            # of gating it, so all ranks always enter the all_reduce together.
+            plugin.process_awex_queue(extra_ready=is_idle)
+
+        # Patch event_loop_overlap (the one actually used by SGLang)
+        _orig_overlap = scheduler.event_loop_overlap
+
+        def _patched_overlap():
+            """Patched overlap loop that checks awex queue when paused."""
+            from collections import deque
+
+            scheduler.result_queue = deque()
+            _loop_count = 0
+            _paused_reported = False
+
+            def pop_and_process():
+                tmp_batch, tmp_result = scheduler.result_queue.popleft()
+                scheduler.process_batch_result(tmp_batch, tmp_result)
+                _maybe_restore_decode_metrics(
+                    "after_process_batch_result", tmp_batch, tmp_result
+                )
+
+            logger.info(
+                f"[AWEX] _patched_overlap STARTING (gpu_id={getattr(scheduler, 'gpu_id', '?')})",
+            )
+
+            while True:
+                recv_reqs = _recv_requests()
+                if recv_reqs:
+                    req_types = [type(r).__name__ for r in recv_reqs]
+                    has_control = any(
+                        t
+                        not in (
+                            "TokenizedGenerateReqInput",
+                            "TokenizedEmbeddingReqInput",
+                        )
+                        for t in req_types
+                    )
+                    if has_control:
+                        logger.info(
+                            f"[AWEX] loop gpu_id={getattr(scheduler, 'gpu_id', '?')}: "
+                            f"recv {len(recv_reqs)} reqs, types={req_types[:5]}, "
+                            f"_engine_paused={scheduler._engine_paused}, loop={_loop_count}",
+                        )
+
+                was_paused = scheduler._engine_paused
+                scheduler.process_input_requests(recv_reqs)
+                if scheduler._engine_paused != was_paused:
+                    logger.info(
+                        f"[AWEX] _engine_paused CHANGED: {was_paused} → {scheduler._engine_paused} "
+                        f"(gpu_id={getattr(scheduler, 'gpu_id', '?')}, loop={_loop_count})",
+                    )
+
+                if scheduler._engine_paused:
+                    if not _paused_reported:
+                        logger.info(
+                            f"[AWEX] _patched_overlap: _engine_paused=True detected! "
+                            f"(gpu_id={getattr(scheduler, 'gpu_id', '?')}, loop_count={_loop_count})",
+                        )
+                        _paused_reported = True
+                    plugin.process_awex_queue()
+                    time.sleep(plugin._paused_poll_interval_s)
+                    continue
+
+                _loop_count += 1
+                batch = scheduler.get_next_batch_to_run()
+                scheduler.cur_batch = batch
+                disable_overlap_for_batch = scheduler.is_disable_overlap_for_batch(
+                    batch
+                )
+
+                if disable_overlap_for_batch:
+                    pop_and_process()
+
+                if batch:
+                    batch_result = scheduler.run_batch(batch)
+                    scheduler.result_queue.append((batch.copy(), batch_result))
+                else:
+                    batch_result = None
+
+                if scheduler.last_batch:
+                    if not disable_overlap_for_batch:
+                        pop_and_process()
+                elif batch is None:
+                    _on_idle()
+
+                _maybe_process_awex_queue_when_idle(_loop_count)
+
+                if scheduler.is_generation:
+                    scheduler.launch_batch_sample_if_needed(batch_result)
+
+                scheduler.last_batch = batch
+
+        scheduler.event_loop_overlap = _patched_overlap
+
+        # Also patch event_loop_normal as fallback
+        _orig_normal = scheduler.event_loop_normal
+
+        def _patched_normal():
+            logger.info(
+                f"[AWEX] _patched_normal STARTING (gpu_id={getattr(scheduler, 'gpu_id', '?')})",
+            )
+            _loop_count = 0
+            while True:
+                recv_reqs = _recv_requests()
+                scheduler.process_input_requests(recv_reqs)
+                if scheduler._engine_paused:
+                    plugin.process_awex_queue()
+                    time.sleep(plugin._paused_poll_interval_s)
+                    continue
+                _loop_count += 1
+                batch = scheduler.get_next_batch_to_run()
+                scheduler.cur_batch = batch
+                if batch:
+                    result = scheduler.run_batch(batch)
+                    scheduler.process_batch_result(batch, result)
+                    _maybe_restore_decode_metrics(
+                        "after_process_batch_result", batch, result
+                    )
+                else:
+                    _on_idle()
+                _maybe_process_awex_queue_when_idle(_loop_count)
+                scheduler.last_batch = batch
+
+        scheduler.event_loop_normal = _patched_normal
+        logger.info(
+            "[AWEX] Patched event_loop_overlap + event_loop_normal with awex queue",
+        )
+
+    # ── Background thread: MetaServer I/O only (no CUDA ops) ─────────
+
+    def _start_background_worker(self, meta_server_addr: str) -> None:
+        self._bg_thread = threading.Thread(
+            target=self._background_worker,
+            args=(meta_server_addr,),
+            daemon=True,
+        )
+        self._bg_thread.start()
+        gpu_id = _logical_gpu_id(self._scheduler)
+        physical_gpu_id = _physical_gpu_id(self._scheduler)
+        logger.info(
+            f"[AWEX] Started background worker thread "
+            f"(gpu_id={gpu_id}, physical_gpu_id={physical_gpu_id}, "
+            f"meta_server={meta_server_addr})",
+        )
+
+    def _background_worker(self, meta_server_addr: str) -> None:
+        """Initialize the reader, then gate weight-update triggers to the main loop.
+
+        This thread does NOT perform any CUDA memory writes. It only:
+        1. Connects to MetaServer and initializes the awex worker reader
+        2. Blocks on the per-version writer-offload signal (a set-size wait)
+        3. Enqueues a version marker so the TP-collective main-loop gate fires
+           (the awex worker reader collects the IPC handles itself inside
+           update_weights, so no large payload is prefetched here)
+        """
+        import torch
+
+        gpu_id = _logical_gpu_id(self._scheduler)
+        physical_gpu_id = _physical_gpu_id(self._scheduler)
+        torch.cuda.set_device(gpu_id)
+        logger.info(
+            f"[AWEX] background worker: set CUDA device to {gpu_id} "
+            f"(physical_gpu_id={physical_gpu_id})",
+        )
+
+        try:
+            self._init_receiver_from_meta_server(meta_server_addr)
+        except Exception:
+            logger.exception("AWEX background worker initialization failed")
+            return
+
+        logger.info(
+            "[AWEX] background worker: initialization complete, entering fetch loop",
+        )
+        # Recover can resume weight-transfer versions from the checkpoint step
+        # instead of v1, so sync the first version from the writer.
+        from awex.meta.meta_server import MetaServerClient as _MSC
+        from awex.util.common import get_ip_address as _get_ip
+
+        _host, _port = meta_server_addr.rsplit(":", 1)
+        _ver_client = _MSC(_host, int(_port))
+        _ver_key = f"awex_writer_version_{_get_ip()}_{physical_gpu_id}"
+        writer_version_poll_timeout_s = max(
+            0.1,
+            _float_env("AWEX_WRITER_VERSION_POLL_TIMEOUT_S", 5.0),
+        )
+        writer_version_log_interval_s = max(
+            writer_version_poll_timeout_s,
+            _float_env("AWEX_WRITER_VERSION_LOG_INTERVAL_S", 60.0),
+        )
+        last_writer_wait_log_s = 0.0
+        version = None
+        while version is None:
+            version = _try_get_writer_version(
+                _ver_client,
+                _ver_key,
+                timeout_s=writer_version_poll_timeout_s,
+            )
+            if version is not None:
+                break
+
+            now = time.monotonic()
+            if now - last_writer_wait_log_s >= writer_version_log_interval_s:
+                logger.info(
+                    "[AWEX] background worker: waiting for first writer version "
+                    "key %s; initial RL rollout can run before actor.update_weights",
+                    _ver_key,
+                )
+                last_writer_wait_log_s = now
+            time.sleep(min(1.0, writer_version_poll_timeout_s))
+
+        logger.info(
+            f"[AWEX] background worker: writer stream starts at v{version}",
+        )
+        retries = 0
+        # Slow online environments can spend tens of minutes between updates.
+        # Keep the reader alive across transient wait timeouts.
+        max_retries = int(os.environ.get("AWEX_READER_MAX_RETRIES", "1000"))
+
+        while True:
+            try:
+                # Block on THIS version's writer-published IPC handles
+                # (existence-only probe, no deserialization). This is the
+                # per-version trigger: the writer only publishes v+1's key in the
+                # next training cycle, so the background thread cannot fire early
+                # off a stale unversioned set and dead-lock the main loop. See
+                # AwexColocateReader.wait_for_weights_ready for the full rationale.
+                logger.info(
+                    f"[AWEX] background worker: waiting for writer weights v{version}",
+                )
+                receiver = self._require_receiver()
+                receiver.wait_for_weights_ready(version)
+                logger.info(
+                    f"[AWEX] background worker: writer published v{version}, "
+                    f"queuing for main loop",
+                )
+
+                # Queue a version marker for the main loop (no CUDA ops here).
+                self._weight_queue.put({"version": version})
+
+                # Wait for main loop to finish processing before gating the next.
+                while self._version < version:
+                    time.sleep(0.1)
+
+                version += 1
+                retries = 0
+            except Exception as e:
+                retries += 1
+                logger.exception(
+                    "AWEX background worker failed while waiting for writer "
+                    "weights v%s (attempt %s/%s): %s",
+                    version,
+                    retries,
+                    max_retries,
+                    e,
+                )
+                if retries >= max_retries:
+                    logger.info(
+                        f"[AWEX] background worker: giving up after {max_retries} failures",
+                    )
+                    break
+                time.sleep(min(2**retries, 30))
+
+    def _init_receiver_from_meta_server(self, meta_server_addr: str):
+        """Connect to MetaServer, get train info, initialize colocate receiver."""
+        from awex.meta.meta_server import MetaServerClient
+
+        host, port = meta_server_addr.rsplit(":", 1)
+
+        client = None
+        for attempt in range(60):
+            try:
+                client = MetaServerClient(host, int(port))
+                break
+            except Exception:
+                if attempt % 10 == 0:
+                    logger.info(
+                        f"[AWEX] background worker: MetaServer not ready, retrying... "
+                        f"(attempt {attempt + 1}, addr={meta_server_addr})",
+                    )
+                time.sleep(5)
+        if client is None:
+            raise RuntimeError(
+                f"Failed to connect to MetaServer at {meta_server_addr} after 60 attempts"
+            )
+
+        logger.info(
+            f"[AWEX] background worker: connected to MetaServer at {meta_server_addr}",
+        )
+
+        receiver = self._require_receiver()
+
+        # `physical_gpu_id` is node-local. Multi-node colocate needs a globally
+        # unique transfer rank that stays physically paired with the training
+        # process. SGLang may run with logical gpu_id=0 under CUDA_VISIBLE_DEVICES
+        # isolation, so do not use scheduler.gpu_id for AWEX keys.
+        gpu_id = _logical_gpu_id(self._scheduler)
+        physical_gpu_id = _physical_gpu_id(self._scheduler)
+        node_id = int(os.environ.get("SLURM_NODEID", "0"))
+        nnodes = int(os.environ.get("SLURM_NNODES", "1"))
+
+        logger.info(
+            f"[AWEX] background worker: waiting for awex_train_info "
+            f"(gpu_id={gpu_id}, physical_gpu_id={physical_gpu_id}, "
+            f"node_id={node_id}, nnodes={nnodes})",
+        )
+        # The driver publishes awex_train_info only after rollout init finishes,
+        # so large models need the same timeout budget as the weight path.
+        from areal.engine.awex_colocate import awex_colocate_timeout_s
+
+        train_info = client.get_object(
+            "awex_train_info",
+            timeout=awex_colocate_timeout_s(),
+        )
+        train_world_size = train_info["train_world_size"]
+        # In colocate mode train and infer share the same N physical GPUs, so the
+        # global infer NCCL world spans the same N ranks (numerically == train
+        # world). This is a *physical* coincidence (same GPUs), NOT a requirement
+        # that train/infer parallel topologies match: the infer side decomposes
+        # into num_infer_engines DP replicas inside receiver.initialize().
+        infer_world_size = train_world_size
+
+        n_gpus_per_node = max(1, infer_world_size // nnodes)
+        transfer_rank = node_id * n_gpus_per_node + physical_gpu_id
+
+        logger.info(
+            f"[AWEX] background worker: got train_world_size={train_world_size}, "
+            f"infer_world_size={infer_world_size}, n_gpus_per_node={n_gpus_per_node}, "
+            f"transfer_rank={transfer_rank}, physical_gpu_id={physical_gpu_id}",
+        )
+
+        receiver.initialize(
+            meta_server_addr=meta_server_addr,
+            transfer_rank=transfer_rank,
+            infer_world_size=infer_world_size,
+            train_world_size=train_world_size,
+            local_gpu_id=physical_gpu_id,
+        )
+        logger.info(
+            f"[AWEX] background worker: receiver initialized "
+            f"(transfer_rank={transfer_rank}, infer_world_size={infer_world_size})",
+        )
+
+
+@dataclass
+class ModelWorkerTask:
+    """Task for execute_task_in_model_worker (PR #13595 backport for SGLang 0.5.9)."""
+
+    task_func: Callable
+    kwargs: dict = field(default_factory=dict)
+
+
+def register_awex_plugin() -> None:
+    """Patch Scheduler.__init__ to inject awex plugin after construction.
+
+    Must be called INSIDE the scheduler child process (not the parent),
+    because SGLang spawns scheduler processes via mp.Process with "spawn"
+    start method, which doesn't inherit parent-process monkey-patches.
+    """
+    from sglang.srt.managers.scheduler import Scheduler
+
+    _orig_init = Scheduler.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        logger.info(
+            "[AWEX] Scheduler.__init__ entering "
+            "(pid=%s, CUDA_VISIBLE_DEVICES=%s, AWEX_META_SERVER_ADDR=%s)",
+            os.getpid(),
+            os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+            os.environ.get("AWEX_META_SERVER_ADDR", ""),
+        )
+        try:
+            _orig_init(self, *args, **kwargs)
+        except BaseException:
+            logger.exception("[AWEX] Scheduler.__init__ original init failed")
+            raise
+        logger.info(
+            "[AWEX] Scheduler.__init__ original init complete "
+            "(gpu_id=%s, tp_rank=%s, tp_size=%s)",
+            getattr(self, "gpu_id", "?"),
+            getattr(self, "tp_rank", "?"),
+            _scheduler_int_attr(self, "tp_size", 1),
+        )
+        try:
+            AwexSchedulerPlugin(self).bind()
+            _patch_execute_task_in_model_worker(self)
+        except BaseException:
+            logger.exception("[AWEX] Scheduler.__init__ AWEX bind failed")
+            raise
+        logger.info("[AWEX] Scheduler.__init__ AWEX bind complete")
+
+    Scheduler.__init__ = _patched_init
+    logger.info("[AWEX] Patched Scheduler.__init__ with awex plugin")
+
+
+def _patch_execute_task_in_model_worker(scheduler) -> None:
+    """Add execute_task_in_model_worker to Scheduler (backport from PR #13595)."""
+
+    if callable(getattr(scheduler, "execute_task_in_model_worker", None)):
+        logger.info(
+            "[AWEX] Scheduler already has native execute_task_in_model_worker; "
+            "skipping legacy backport",
+        )
+        return
+
+    task_cls = _get_model_worker_task_cls()
+
+    def execute_task_in_model_worker(task_spec):
+        model_context = dict(
+            tp_rank=_scheduler_int_attr(scheduler, "tp_rank", 0),
+            tp_size=_scheduler_int_attr(scheduler, "tp_size", 1),
+            server_args=scheduler.server_args,
+            scheduler=scheduler,
+        )
+        kwargs = dict(task_spec.kwargs)
+        kwargs["model_context"] = model_context
+        kwargs["model"] = scheduler.tp_worker.model_runner.model
+        kwargs["model_runner"] = scheduler.tp_worker.model_runner
+        return task_spec.task_func(**kwargs)
+
+    scheduler.execute_task_in_model_worker = execute_task_in_model_worker
+
+    if hasattr(scheduler, "_request_dispatcher"):
+        scheduler._request_dispatcher._mapping[task_cls] = execute_task_in_model_worker
+        logger.info("[AWEX] Registered execute_task_in_model_worker in dispatcher")
+
+
+def _get_model_worker_task_cls():
+    try:
+        from sglang.srt.managers.io_struct import ModelWorkerTask as SGLangTask
+
+        return SGLangTask
+    except (ImportError, AttributeError):
+        return ModelWorkerTask
+
+
+def awex_run_scheduler_process(*args, **kwargs):
+    """Scheduler process entry point that registers awex plugin.
+
+    Memory management (pause/resume weights, KV cache, CUDA graphs) is handled
+    at runtime by AWEX's release_memory/resume_memory, matching HybridEngine.
+    No init-time memory patching needed.
+    """
+    import os
+
+    meta_addr = os.environ.get("AWEX_META_SERVER_ADDR")
+    logger.info(
+        "[AWEX] awex_run_scheduler_process starting "
+        "(pid=%s, meta_server=%s, CUDA_VISIBLE_DEVICES=%s)",
+        os.getpid(),
+        meta_addr or "",
+        os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+    )
+    if meta_addr:
+        from areal.engine.sglang_fork_contract import check_static_contract
+
+        check_static_contract()
+        register_awex_plugin()
+        _patch_release_memory_for_retract_pause()
+        _patch_flush_cache_for_retract_pause()
+    else:
+        logger.info(
+            "[AWEX] No AWEX_META_SERVER_ADDR, skipping plugin registration",
+        )
+    from sglang.srt.managers.scheduler import run_scheduler_process
+
+    try:
+        return run_scheduler_process(*args, **kwargs)
+    except BaseException:
+        logger.exception("[AWEX] run_scheduler_process failed")
+        raise
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    # The actor-side env may ship expandable_segments:True (fragmentation
+    # fix, HybridEngine-aligned), and the colocated rollout worker inherits
+    # the same scheduling_spec env. SGLang's memory saver (and CUDA graph
+    # pools) cannot run on expandable segments, so flip it to False for
+    # this process tree BEFORE any CUDA initialization — mirror of
+    # HybridEngine ainfer _normalize_cuda_alloc_conf_for_memory_saver.
+    # Only touch the env when expandable_segments is explicitly set:
+    # leaving "" untouched keeps the legacy (validated) behavior bit-exact.
+    _conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    if "expandable_segments" in _conf.lower():
+        _tokens = [
+            t.strip()
+            for t in _conf.split(",")
+            if t.strip() and not t.strip().lower().startswith("expandable_segments")
+        ]
+        _tokens.append("expandable_segments:False")
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = ",".join(_tokens)
+
+    logger.info(
+        "[AWEX] awex_sglang_plugin __main__ starting "
+        "(pid=%s, CUDA_VISIBLE_DEVICES=%s, AWEX_META_SERVER_ADDR=%s)",
+        os.getpid(),
+        os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        os.environ.get("AWEX_META_SERVER_ADDR", ""),
+    )
+
+    from sglang.srt.entrypoints.http_server import launch_server
+    from sglang.srt.plugins import load_plugins
+    from sglang.srt.server_args import prepare_server_args
+    from sglang.srt.utils import (
+        COMPILE_CACHE_DIRS,
+        COMPILE_CACHE_ROOT,
+        kill_process_tree,
+    )
+    from sglang.srt.utils.compile_cache import prepare_compile_cache
+
+    load_plugins()
+    prepare_compile_cache(COMPILE_CACHE_ROOT, COMPILE_CACHE_DIRS)
+    server_args = prepare_server_args(sys.argv[1:])
+    # In AWEX colocated mode the scheduler may not be able to serve requests
+    # until the first weight sync (actor holds GPUs / writer version not yet
+    # published). SGLang's warmup request would then hang for 600s
+    # (_execute_server_warmup default timeout) and kill_process_tree() the
+    # whole server. Skip the warmup: _wait_and_warmup marks the server Up
+    # directly when skip_server_warmup is set.
+    if not server_args.skip_server_warmup:
+        logger.info(
+            "[AWEX] forcing skip_server_warmup=True to avoid warmup-timeout "
+            "suicide before the first weight sync"
+        )
+        server_args.skip_server_warmup = True
+    try:
+        launch_server(
+            server_args,
+            run_scheduler_process_func=awex_run_scheduler_process,
+        )
+    finally:
+        kill_process_tree(os.getpid(), include_parent=False)

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -129,7 +129,11 @@ from areal.utils.data import (
 from areal.utils.functional import gather_logprobs, gather_logprobs_entropy
 from areal.utils.hf_utils import load_hf_processor_and_tokenizer, load_hf_tokenizer
 from areal.utils.network import find_free_ports, format_host_for_url, gethostip
-from areal.utils.offload import is_tms_enabled, torch_memory_saver
+from areal.utils.offload import (
+    is_tms_enabled,
+    normalize_tms_ld_preload,
+    torch_memory_saver,
+)
 from areal.utils.perf_tracer import trace_perf, trace_scope
 from areal.utils.save_load import get_state_dict_from_repo_id_or_path
 
@@ -938,6 +942,7 @@ class FSDPEngine(TrainEngine):
 
         # Use torch_memory_saver to pause CUDA memory
         current_platform.clear_memory()
+        normalize_tms_ld_preload()
         torch_memory_saver.pause()
 
         current_platform.synchronize()

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -10,6 +10,7 @@ import math
 import os
 import re
 import struct
+import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from contextlib import contextmanager
@@ -133,7 +134,11 @@ from areal.utils.functional import gather_logprobs, gather_logprobs_entropy
 from areal.utils.hf_utils import load_hf_processor_and_tokenizer, load_hf_tokenizer
 from areal.utils.lock import DistributedLock
 from areal.utils.network import find_free_ports, format_host_for_url, gethostip
-from areal.utils.offload import is_tms_enabled, torch_memory_saver
+from areal.utils.offload import (
+    is_tms_enabled,
+    normalize_tms_ld_preload,
+    torch_memory_saver,
+)
 from areal.utils.perf_tracer import trace_perf, trace_scope
 from areal.utils.seeding import get_seed
 
@@ -319,6 +324,7 @@ class MegatronEngine(TrainEngine):
         self._initialized = False
         self.rollout_engine: InferenceEngine | None = None
         self.rollout_coordinator: DistRolloutCoordinator | None = None
+        self._awex_adapter = None  # AwexMegatronAdapter for colocate mode
         self.weight_update_group_initialized: bool = False
         self.weight_update_group_name: str
         self.weight_update_master_addr: str
@@ -506,6 +512,14 @@ class MegatronEngine(TrainEngine):
             # such as loss fusions.
             if self.mcore_config.use_deterministic_algorithms:
                 set_deterministic_algorithms(self.tf_config, prebuild=True)
+
+            # Precision-alignment dumps (AReaL-friend tools/precision-alignment):
+            # when AREAL_DUMP_ROUTING is set, enable megatron RouterReplay
+            # recording so MoE expert indices can be captured during forward.
+            if os.environ.get("AREAL_DUMP_ROUTING", "") and hasattr(
+                self.tf_config, "moe_enable_routing_replay"
+            ):
+                self.tf_config.moe_enable_routing_replay = True
 
             self.is_vision_model = is_valid_vision_model(self.hf_config.model_type)
             # GDN/SSM models (e.g. Qwen3.5) reject packed THD input and must run
@@ -712,8 +726,24 @@ class MegatronEngine(TrainEngine):
                     glu_fc1_names.add(_normalize_glu_param_name(full_name))
         return glu_fc1_names
 
+    @staticmethod
+    def _ensure_hf_rope_compat(hf_config) -> None:
+        # transformers v5 moved rope_theta into rope_parameters, but mbridge
+        # still reads hf_config.rope_theta directly (llm_bridge.py). Custom
+        # configs (bailing) keep the attribute, stock ones (Qwen3Moe) do not:
+        # materialize it back so the bridge sees a v4-shaped config.
+        if hf_config is None or "rope_theta" in hf_config.__dict__:
+            return
+        rope_params = getattr(hf_config, "rope_parameters", None) or {}
+        if "rope_theta" in rope_params:
+            hf_config.rope_theta = rope_params["rope_theta"]
+
     def _build_hf_mcore_bridge(self):
         if self.bridge_cls == "mbridge":
+            hf_config = PretrainedConfig.from_pretrained(
+                self.config.path, trust_remote_code=True
+            )
+            self._ensure_hf_rope_compat(hf_config)
             self.bridge = mbridge.AutoBridge.from_pretrained(
                 self.config.path, trust_remote_code=True
             )
@@ -728,13 +758,23 @@ class MegatronEngine(TrainEngine):
                 )
 
             # Set MoE configuration overrides (aux-loss-free balancing, z-loss).
+            # mbridge extra_args override per-model bridge kwargs, so fields
+            # whose cli default may disagree with a bridge's deliberate
+            # default are forwarded only when explicitly configured
+            # (None = keep the bridge default).
             moe_extra_args: dict = {
                 "moe_token_dispatcher_type": self.mcore_config.moe_token_dispatcher_type,
                 "moe_permute_fusion": self.mcore_config.moe_permute_fusion,
                 "moe_router_fusion": self.mcore_config.moe_router_fusion,
-                "moe_shared_expert_overlap": self.mcore_config.moe_shared_expert_overlap,
-                "moe_router_bias_update_rate": self.mcore_config.moe_router_bias_update_rate,
             }
+            if self.mcore_config.moe_shared_expert_overlap is not None:
+                moe_extra_args["moe_shared_expert_overlap"] = (
+                    self.mcore_config.moe_shared_expert_overlap
+                )
+            if self.mcore_config.moe_router_bias_update_rate is not None:
+                moe_extra_args["moe_router_bias_update_rate"] = (
+                    self.mcore_config.moe_router_bias_update_rate
+                )
             if self.mcore_config.moe_router_dtype is not None:
                 moe_extra_args["moe_router_dtype"] = self.mcore_config.moe_router_dtype
             if self.mcore_config.moe_z_loss_coeff is not None:
@@ -1020,6 +1060,11 @@ class MegatronEngine(TrainEngine):
                     raise ValueError(
                         "HF format does not support optimizer state saving, please use DCP format instead."
                     )
+                # HF export all-gathers full tensors across TP; reclaim allocator
+                # headroom first. Kept out of the dcp/recover path, which is
+                # frequency-driven and should not pay a full-heap GC per save.
+                gc.collect()
+                current_platform.empty_cache()
                 self._save_model_to_hf(
                     meta.path,
                     tokenizer=meta.tokenizer,
@@ -1088,17 +1133,50 @@ class MegatronEngine(TrainEngine):
             model.zero_grad_buffer()
 
     def optimizer_step(self):
+        step_dirty_stats: dict[str, float] = {}
+        awex_adapter = getattr(self, "_awex_weight_update_adapter", None)
+        before_optimizer_step = getattr(awex_adapter, "before_optimizer_step", None)
+        if before_optimizer_step is not None:
+            try:
+                step_dirty_stats.update(before_optimizer_step())
+            except Exception:
+                self.logger.exception("AWEX step-dirty dry-run pre-hook failed")
+
+        step_start = time.perf_counter()
         with trace_scope("megatron_engine.step"):
             update_successful, grad_norm, _ = self.optimizer.step()
+        step_time = time.perf_counter() - step_start
+        after_optimizer_step = getattr(awex_adapter, "after_optimizer_step", None)
+        if after_optimizer_step is not None:
+            try:
+                step_dirty_stats.update(
+                    after_optimizer_step(bool(update_successful), grad_norm=grad_norm)
+                )
+            except Exception:
+                self.logger.exception("AWEX step-dirty dry-run post-hook failed")
+        # AdamW inversion needs the LR that produced this just-finished update.
+        # RL trainers may step the LR scheduler before the weight-transfer hook
+        # runs, so keep a copy on each param group before the scheduler mutates
+        # ``lr`` for the next optimizer step.
+        for group in self.optimizer.param_groups:
+            group["_areal_last_step_lr"] = float(group["lr"])
         current_lr = self.optimizer.param_groups[0]["lr"]
 
-        return dict(
+        stats = dict(
             update_successful=float(update_successful),
             grad_norm=float(grad_norm) if grad_norm is not None else float("nan"),
             lr=current_lr,
+            **{"perf/optimizer_step_time": step_time},
         )
+        stats.update(step_dirty_stats)
+        return stats
 
     def lr_scheduler_step(self):
+        if os.environ.get("AREAL_DUMP_ROUTING", "") or os.environ.get(
+            "AREAL_DUMP_LOGP", ""
+        ):
+            # Precision-alignment forward-only mode: no optimizer/scheduler.
+            return
         assert self.lr_scheduler is not None, "LR Scheduler is not initialized."
         self.lr_scheduler.step(1)
 
@@ -1355,9 +1433,13 @@ class MegatronEngine(TrainEngine):
         # that extra division would shrink every gradient (and thus grad_norm and the
         # effective optimizer step) by `num_microbatches`.
         loss_multiplier = (
-            mpu.get_data_parallel_world_size()
-            * self.optimizer.get_loss_scale().item()
-            * len(mb_list)
+            float(mpu.get_data_parallel_world_size())
+            if _fwd_only
+            else (
+                mpu.get_data_parallel_world_size()
+                * self.optimizer.get_loss_scale().item()
+                * len(mb_list)
+            )
         )
 
         def process_output(
@@ -1375,8 +1457,11 @@ class MegatronEngine(TrainEngine):
         self.forward_backward_batch(
             mb_list,
             process_output,
-            forward_only=False,
+            forward_only=_fwd_only,
         )
+
+        if _fwd_only:
+            return {"num_micro_batches": len(mb_list.mbs)}
 
         # Step 4: Optimizer step
         stats = self.optimizer_step()
@@ -1576,6 +1661,7 @@ class MegatronEngine(TrainEngine):
                 m.offload_grad_buffers(synchronize=False, empty_cache=False)
 
         current_platform.clear_memory()
+        normalize_tms_ld_preload()
         torch_memory_saver.pause()
 
         # TODO: NCCL offload
@@ -1721,6 +1807,103 @@ class MegatronEngine(TrainEngine):
     def get_device_stats(self) -> DeviceRuntimeInfo:
         return DeviceRuntimeInfo.get_current()
 
+    def warmup_communicators(self) -> None:
+        """Eagerly build every NCCL communicator the train step needs.
+
+        PyTorch creates 2-rank communicators for unbatched pipeline
+        send/recv lazily, and NCCL connects transport buffers per
+        protocol on first use. After a recover restart those connects
+        would otherwise happen inside the first ppo_update, when the
+        device is already at peak occupancy, and the ~10MB transport
+        calloc fails on the PP-last-stage ranks. Exercising each group
+        and message-size class here, while memory is still light, makes
+        those allocations happen up front; the buffers persist across
+        offload/onload for the lifetime of the process.
+        """
+        if os.environ.get("AREAL_SKIP_COMM_WARMUP", "").strip() == "1":
+            return
+        if not dist.is_initialized():
+            return
+        device = torch.cuda.current_device()
+        small = torch.ones(1024, dtype=torch.bfloat16, device=device)
+        large = torch.ones(16 * 1024 * 1024, dtype=torch.bfloat16, device=device)
+        # Sweep every registered NCCL group (attention DP/TP, expert
+        # EP/expert-DP, model-parallel variants, ...) instead of naming
+        # them: a hand-written enumeration misses groups created by other
+        # components (e.g. the MoE expert grad-bucket reduction), and any
+        # missed group still connects lazily at peak memory.
+        # pg_map insertion order is the collective creation order, so all
+        # member ranks reach shared groups in the same relative order.
+        from torch.distributed.distributed_c10d import _world
+
+        for group in list(_world.pg_map):
+            try:
+                if "nccl" not in str(dist.get_backend(group)).lower():
+                    continue
+                ws = dist.get_world_size(group=group)
+                if ws <= 1:
+                    continue
+                dist.all_reduce(small.clone(), group=group)
+                dist.all_reduce(large.clone(), group=group)
+                chunk = 4096
+                a2a_in = torch.ones(chunk * ws, dtype=torch.bfloat16, device=device)
+                dist.all_to_all_single(torch.empty_like(a2a_in), a2a_in, group=group)
+                big_chunk = (4 * 1024 * 1024 // ws) * ws
+                a2a_big = torch.ones(big_chunk, dtype=torch.bfloat16, device=device)
+                dist.all_to_all_single(torch.empty_like(a2a_big), a2a_big, group=group)
+            except Exception:
+                self.logger.warning(
+                    "communicator warmup skipped one group", exc_info=True
+                )
+        dp_group = mpu.get_data_parallel_group(with_context_parallel=True)
+        dp_size = dist.get_world_size(group=dp_group)
+        if dp_size > 1:
+            shard = torch.empty(
+                large.numel() // dp_size, dtype=large.dtype, device=device
+            )
+            dist.reduce_scatter_tensor(shard, large, group=dp_group)
+            dist.all_gather_into_tensor(large, shard, group=dp_group)
+        pp_size = mpu.get_pipeline_model_parallel_world_size()
+        if pp_size > 1:
+            pp_rank = mpu.get_pipeline_model_parallel_rank()
+            nxt = mpu.get_pipeline_model_parallel_next_rank()
+            prv = mpu.get_pipeline_model_parallel_prev_rank()
+            is_first = mpu.is_pipeline_first_stage(ignore_virtual=True)
+            is_last = mpu.is_pipeline_last_stage(ignore_virtual=True)
+            for buf in (small, large):
+                send_buf = buf.clone()
+                recv_buf = torch.empty_like(buf)
+                # Unbatched pair comms, both directions; even ranks send
+                # first so the chain cannot deadlock.
+                for send_peer, recv_peer, do_send, do_recv in (
+                    (nxt, prv, not is_last, not is_first),
+                    (prv, nxt, not is_first, not is_last),
+                ):
+                    if pp_rank % 2 == 0:
+                        if do_send:
+                            dist.send(send_buf, send_peer)
+                        if do_recv:
+                            dist.recv(recv_buf, recv_peer)
+                    else:
+                        if do_recv:
+                            dist.recv(recv_buf, recv_peer)
+                        if do_send:
+                            dist.send(send_buf, send_peer)
+                ops = []
+                if not is_last:
+                    ops.append(dist.P2POp(dist.isend, send_buf, nxt))
+                if not is_first:
+                    ops.append(dist.P2POp(dist.irecv, recv_buf, prv))
+                if ops:
+                    for work in dist.batch_isend_irecv(ops):
+                        work.wait()
+        del small, large
+        torch.cuda.synchronize()
+        dist.barrier(group=self.cpu_group)
+        self.logger.info(
+            "[COMM-WARMUP rank %s] communicator warmup complete", dist.get_rank()
+        )
+
     def start_memory_profile(self, max_entries: int = 100000) -> None:
         torch.cuda.memory._record_memory_history(max_entries=max_entries)
 
@@ -1793,6 +1976,14 @@ class MegatronEngine(TrainEngine):
 
     def _create_optimizer(self, ft_spec: FinetuneSpec) -> None:
         if self.optimizer_config is None:
+            return
+        if os.environ.get("AREAL_DUMP_ROUTING", "") or os.environ.get(
+            "AREAL_DUMP_LOGP", ""
+        ):
+            self.logger.info(
+                "[MegatronEngine] AREAL_DUMP_ROUTING/LOGP set, skipping optimizer "
+                "creation to save GPU memory (precision-alignment forward-only mode)."
+            )
             return
         assert self.model is not None and len(self.model) > 0
 
@@ -2892,6 +3083,33 @@ class MegatronEngine(TrainEngine):
                     inputs = {
                         k: v for k, v in inputs.items() if not k.startswith("_cp_")
                     }
+
+            # Precision-alignment logp dump: save final per-token logprobs for
+            # the first microbatch (last PP stage only; this branch already is).
+            _logp_dump_path = os.environ.get("AREAL_DUMP_LOGP", "")
+            if _logp_dump_path and not getattr(self, "_logp_dumped", False):
+                pp_rank = mpu.get_pipeline_model_parallel_rank()
+                cp_rank = mpu.get_context_parallel_rank()
+                if (
+                    mpu.get_data_parallel_rank() == 0
+                    and mpu.get_tensor_model_parallel_rank() == 0
+                ):
+                    save_data = {
+                        "logprobs": logprobs.detach().cpu(),
+                        "input_ids": inputs["input_ids"].detach().cpu(),
+                        "pp_rank": pp_rank,
+                        "cp_rank": cp_rank,
+                    }
+                    if "loss_mask" in inputs:
+                        save_data["loss_mask"] = inputs["loss_mask"].detach().cpu()
+                    out_file = f"{_logp_dump_path}.pp{pp_rank}.cp{cp_rank}.pt"
+                    torch.save(save_data, out_file)
+                    self.logger.info(
+                        f"[LOGP-DUMP] pp={pp_rank} cp={cp_rank} "
+                        f"logprobs={list(logprobs.shape)} -> {out_file}"
+                    )
+                self._logp_dumped = True
+
             loss = loss_fn(
                 logprobs,
                 entropy,
@@ -2902,6 +3120,14 @@ class MegatronEngine(TrainEngine):
                 vocab_norm_logits=vocab_norm_logits,
             )
         else:
+            if inputs.get("_cp_padded_cu_seqlens") is not None:
+                # The CP reassembly/unpad path lives in the actor branch
+                # above; here `output` would be the padded zigzag CP-local
+                # shard while `inputs` carries full-order loss_mask —
+                # silently mismatched shapes. Fail fast instead.
+                raise NotImplementedError(
+                    "Critic training with context parallelism > 1 is not supported yet."
+                )
             values = output.squeeze(-1)
             loss = loss_fn(values, inputs)
 

--- a/areal/engine/sglang_fork_contract.py
+++ b/areal/engine/sglang_fork_contract.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang fork contract checks for the AWEX colocate integration.
+
+The AWEX colocate plugin reaches into SGLang internals that carry no API
+stability guarantee (scheduler attributes, weight updater, pause/flush
+semantics). Fork upgrades have repeatedly broken these assumptions
+SILENTLY; incidents this guards against:
+
+- incident 12: pause mode default flipped semantics; scheduler never paused.
+- incident 13/14: release_memory_occupation / flush_cache idle gates tightened,
+  asserts killed every server under retract-pause.
+- incident 15: Scheduler.tp_rank moved to tp_worker; getattr default 0 routed
+  train shard 0 to all 64 inference ranks (silent weight corruption).
+
+These checks turn that class of failure into a startup error. Run
+``check_static_contract()`` in the scheduler process BEFORE the Scheduler
+is constructed and ``check_scheduler_contract(scheduler)`` when the plugin
+binds. All violations are collected and raised together.
+
+Escape hatch: ``AREAL_SGLANG_CONTRACT=warn`` downgrades violations to log
+warnings (for bring-up of a new fork); ``off`` skips entirely.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from areal.utils.logging import getLogger
+
+logger = getLogger("SGLangForkContract")
+
+
+def _mode() -> str:
+    return os.environ.get("AREAL_SGLANG_CONTRACT", "strict").strip().lower()
+
+
+def _report(violations: list[str], stage: str) -> None:
+    if not violations:
+        logger.info("[fork-contract] %s: all checks passed", stage)
+        return
+    lines = "\n".join(f"  - {v}" for v in violations)
+    message = (
+        f"[fork-contract] {stage}: {len(violations)} SGLang fork contract "
+        f"violation(s) detected:\n{lines}"
+    )
+    if _mode() == "warn":
+        logger.warning("%s\nAREAL_SGLANG_CONTRACT=warn: continuing anyway.", message)
+        return
+    raise RuntimeError(message)
+
+
+def check_static_contract() -> None:
+    """Class/module-level assumptions; call before Scheduler construction."""
+    if _mode() == "off":
+        return
+    violations: list[str] = []
+
+    # incident 12: /pause_generation must support mode="retract" and the
+    # scheduler must implement the pause handler pair.
+    try:
+        from sglang.srt.managers.io_struct import PauseGenerationReqInput
+
+        try:
+            PauseGenerationReqInput(mode="retract")
+        except Exception as exc:
+            violations.append(
+                f"PauseGenerationReqInput(mode='retract') rejected: {exc!r} "
+                "(incident 12: AReaL pauses with retract before offload)"
+            )
+    except ImportError as exc:
+        violations.append(f"PauseGenerationReqInput import failed: {exc!r}")
+
+    try:
+        from sglang.srt.managers.scheduler import Scheduler
+
+        for method in ("pause_generation", "continue_generation", "flush_cache"):
+            if not callable(getattr(Scheduler, method, None)):
+                violations.append(
+                    f"Scheduler.{method} missing (incident 12/14 depend on it)"
+                )
+        if not callable(getattr(Scheduler, "is_fully_idle", None)):
+            violations.append(
+                "Scheduler.is_fully_idle missing (retract-pause patches "
+                "shadow it; the idle-gate semantics moved again)"
+            )
+    except ImportError as exc:
+        violations.append(f"Scheduler import failed: {exc!r}")
+
+    # incident 13: the release_memory_occupation patch target must exist where
+    # we patch it, or the patch silently no-ops and offload kills servers.
+    try:
+        from sglang.srt.managers.scheduler_components.weight_updater import (
+            SchedulerWeightUpdaterManager,
+        )
+
+        if not callable(
+            getattr(SchedulerWeightUpdaterManager, "release_memory_occupation", None)
+        ):
+            violations.append(
+                "SchedulerWeightUpdaterManager.release_memory_occupation "
+                "missing (incident 13 patch target)"
+            )
+    except ImportError as exc:
+        violations.append(
+            "scheduler_components.weight_updater import failed: "
+            f"{exc!r} (incident 13 patch target moved)"
+        )
+
+    _report(violations, "static")
+
+
+def check_scheduler_contract(scheduler: Any) -> None:
+    """Instance-level assumptions; call when the plugin binds a Scheduler."""
+    if _mode() == "off":
+        return
+    violations: list[str] = []
+
+    # incident 12: the patched overlap loop gates on _engine_paused.
+    if not hasattr(scheduler, "_engine_paused"):
+        violations.append(
+            "scheduler._engine_paused missing (incident 12: paused branch of the "
+            "AWEX overlap loop never runs; decode races weight transfer)"
+        )
+
+    # incident 15: tp_rank must be resolvable without a silent default. This is
+    # the exact lookup chain awex_colocate_reader._build_model_context uses.
+    tp_rank = getattr(scheduler, "tp_rank", None)
+    if tp_rank is None:
+        tp_rank = getattr(getattr(scheduler, "tp_worker", None), "tp_rank", None)
+    if tp_rank is None:
+        violations.append(
+            "tp_rank not found on scheduler or scheduler.tp_worker (incident 15: "
+            "a silent 0 here routes train shard 0 to every inference rank)"
+        )
+
+    # incident 13/14 patch preconditions.
+    running_batch = getattr(scheduler, "running_batch", None)
+    if running_batch is None or not callable(getattr(running_batch, "is_empty", None)):
+        violations.append(
+            "scheduler.running_batch.is_empty missing (retract-pause patches "
+            "use it to distinguish retract from in_place)"
+        )
+    if not hasattr(scheduler, "waiting_queue"):
+        violations.append("scheduler.waiting_queue missing (patch logging/guards)")
+    if getattr(scheduler, "weight_updater", None) is None:
+        violations.append(
+            "scheduler.weight_updater missing (incident 13: release patch target "
+            "not bound to this scheduler)"
+        )
+
+    # Reader model access (AWEX weight write target).
+    model_runner = getattr(getattr(scheduler, "tp_worker", None), "model_runner", None)
+    if model_runner is None or getattr(model_runner, "model", None) is None:
+        violations.append(
+            "scheduler.tp_worker.model_runner.model unreachable (AWEX reader "
+            "cannot bind weight tensors)"
+        )
+
+    _report(violations, "scheduler-bind")

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -3,6 +3,8 @@
 import os
 import subprocess
 import sys
+import threading
+import time
 import uuid
 from collections.abc import Callable, Mapping
 from concurrent.futures import Future
@@ -34,6 +36,7 @@ from areal.api.io_struct import (
 from areal.infra import RemoteInfEngine, RolloutController, WorkflowExecutor
 from areal.infra.platforms import current_platform
 from areal.infra.utils.launcher import TRITON_CACHE_PATH
+from areal.utils import logging as areal_logging
 from areal.utils import perf_tracer, stats_tracker
 from areal.utils.logging import getLogger
 from areal.utils.network import format_host_for_url
@@ -66,7 +69,7 @@ class SGLangBackend:
 
         sample_params = {
             "top_p": gconfig.top_p,
-            "top_k": gconfig.top_k,
+            "top_k": _normalize_sglang_top_k(gconfig.top_k),
             "max_new_tokens": gconfig.max_new_tokens,
             "temperature": 0.0 if gconfig.greedy else gconfig.temperature,
             "stop_token_ids": stop_token_ids,
@@ -370,8 +373,13 @@ class SGLangBackend:
         return HttpRequest(endpoint="/abort_request", payload={"abort_all": True})
 
     def get_health_check_request(self) -> HttpRequest:
-        """Get SGLang health check request."""
-        return HttpRequest(endpoint="/health", payload={}, method="GET")
+        """Get SGLang readiness check request."""
+        # SGLang's /health is a functional 1-token generation probe in recent
+        # versions. During AWEX colocated startup, generation can legitimately
+        # wait for the first train-side weight publication, so using /health for
+        # launch readiness deadlocks rollout initialization. /model_info only
+        # requires the HTTP server and model metadata to be ready.
+        return HttpRequest(endpoint="/model_info", payload={}, method="GET")
 
     def get_offload_request(self, tags: list[str] | None = None) -> HttpRequest:
         """Get SGLang offload request."""
@@ -416,7 +424,51 @@ class SGLangBackend:
                     base_gpu_id,
                 )
         cmd = SGLangConfig.build_cmd_from_args(server_args)
-        _env = self.build_server_env(os.environ)
+        _env = os.environ.copy()
+        triton_cache_path = _env.get("TRITON_CACHE_PATH", TRITON_CACHE_PATH)
+        _env["TRITON_CACHE_PATH"] = os.path.join(triton_cache_path, str(uuid.uuid4()))
+        _env.setdefault("PYTHONFAULTHANDLER", "1")
+
+        drop_ld_preload_default = "1" if (awex_colocate or awex_meta_addr) else "0"
+        if _env.get(
+            "AREAL_SGLANG_DROP_LD_PRELOAD", drop_ld_preload_default
+        ).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+            "on",
+        }:
+            dropped = _env.pop("LD_PRELOAD", "")
+            logger.info("Dropping LD_PRELOAD for SGLang child: %s", dropped)
+
+        if not awex_meta_addr:
+            awex_meta_addr = os.environ.get("AWEX_META_SERVER_ADDR")
+        if awex_colocate or awex_meta_addr:
+            launch_module = _env.get(
+                "AREAL_SGLANG_FORCE_LAUNCH_MODULE",
+                "areal.engine.awex_sglang_plugin",
+            ).strip()
+            if not launch_module:
+                launch_module = "areal.engine.awex_sglang_plugin"
+            # gh launches SGLang via its v2 wrapper module; the internal
+            # stack launches via sglang.launch_server. Swap either for the
+            # AWEX plugin entry (which itself execs sglang.launch_server
+            # semantics with the colocate patches applied).
+            _sglang_entries = (
+                "sglang.launch_server",
+                "areal.v2.inference_service.sglang.launch_server",
+            )
+            cmd = [launch_module if c in _sglang_entries else c for c in cmd]
+            if awex_meta_addr:
+                _env["AWEX_META_SERVER_ADDR"] = awex_meta_addr
+            if awex_physical_base_gpu_id is not None and export_physical_base:
+                _env["AREAL_AWEX_PHYSICAL_BASE_GPU_ID"] = str(awex_physical_base_gpu_id)
+            logger.info(
+                "AWEX mode: using SGLang launch module %s, cmd=%s",
+                launch_module,
+                cmd[:4],
+            )
 
         if not awex_meta_addr:
             awex_meta_addr = os.environ.get("AWEX_META_SERVER_ADDR")
@@ -439,6 +491,15 @@ class SGLangBackend:
             stdout=sys.stdout,
             stderr=sys.stdout,
         )
+        logger.info("Launched SGLang child process pid=%s", process.pid)
+        _start_process_monitor(
+            process,
+            interval_s=_float_env(
+                "AREAL_SGLANG_PROCESS_MONITOR_INTERVAL_SECONDS",
+                0.0,
+            ),
+        )
+        return process
 
 
 class RemoteSGLangEngine(InferenceEngine):
@@ -569,6 +630,7 @@ class RemoteSGLangEngine(InferenceEngine):
         proxy_addr: str | None = None,
         reward_normalization: bool = False,
         drop_incomplete_group: bool = False,
+        keep_partial_group_on_error: bool = False,
     ) -> int:
         """Submit a request to the inference engine."""
         return self._engine.submit(
@@ -583,6 +645,7 @@ class RemoteSGLangEngine(InferenceEngine):
             proxy_addr=proxy_addr,
             reward_normalization=reward_normalization,
             drop_incomplete_group=drop_incomplete_group,
+            keep_partial_group_on_error=keep_partial_group_on_error,
         )
 
     def wait(

--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -106,7 +106,11 @@ from areal.utils.data import (
 from areal.utils.functional import gather_logprobs, gather_logprobs_entropy
 from areal.utils.hf_utils import load_hf_tokenizer
 from areal.utils.lock import DistributedLock
-from areal.utils.offload import is_tms_enabled, torch_memory_saver
+from areal.utils.offload import (
+    is_tms_enabled,
+    normalize_tms_ld_preload,
+    torch_memory_saver,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -824,6 +828,7 @@ class ArchonEngine(TrainEngine):
         self.get_device_stats().log("before offload model")
 
         current_platform.clear_memory()
+        normalize_tms_ld_preload()
         torch_memory_saver.pause()
 
         current_platform.synchronize()

--- a/areal/infra/launcher/local.py
+++ b/areal/infra/launcher/local.py
@@ -37,7 +37,7 @@ from areal.infra.utils.launcher import (
 )
 from areal.utils import logging, name_resolve, names
 from areal.utils.network import find_free_ports
-from areal.utils.offload import get_tms_env_vars
+from areal.utils.offload import apply_tms_env_vars
 from areal.utils.recover import check_if_recover
 
 logger = logging.getLogger("LocalLauncher")
@@ -378,10 +378,7 @@ def local_main(config, run_id: int = 0):
                 run_post_exit_hook(config)
             raise e
 
-    if config.get("enable_offload", False):
-        tms_env_vars = get_tms_env_vars()
-    else:
-        tms_env_vars = {}
+    enable_tms_offload = config.get("enable_offload", False)
     # Launch trainer entrypoint
     if alloc_mode.type_ != AllocationType.LLM_SERVER_ONLY:
         gpu = nprocs = alloc_mode.train.world_size
@@ -408,18 +405,20 @@ def local_main(config, run_id: int = 0):
             cpus_per_task=actor_cpus_per_task,
             existing_env_vars=actor_env_vars,
         )
+        env_vars = {
+            **BASE_ENVIRONS,
+            **thread_env,
+            **actor_env_vars,
+            **_env_vars,
+            "AREAL_SPMD_MODE": "1",
+        }
+        if enable_tms_offload:
+            apply_tms_env_vars(env_vars)
         launcher.submit(
             job_name="trainer",
             cmd=f"torchrun --nnodes 1 --nproc-per-node {nprocs} --master-addr localhost --master-port {find_free_ports(1, (10000, 32767))[0]} {' '.join(sys.argv[1:])}",
             gpu=gpu,
-            env_vars={
-                **BASE_ENVIRONS,
-                **thread_env,
-                **actor_env_vars,
-                **_env_vars,
-                **tms_env_vars,
-                "AREAL_SPMD_MODE": "1",
-            },
+            env_vars=env_vars,
         )
 
     try:

--- a/areal/infra/launcher/slurm.py
+++ b/areal/infra/launcher/slurm.py
@@ -41,7 +41,7 @@ from areal.infra.utils.slurm import (
     query_jobs,
 )
 from areal.utils import name_resolve, names
-from areal.utils.offload import get_tms_env_vars
+from areal.utils.offload import apply_tms_env_vars
 from areal.utils.recover import check_if_recover
 
 logger = logging.getLogger("SlurmLauncher")
@@ -619,10 +619,7 @@ def slurm_main(config, run_id: int = 0):
             logger.warning("No trainer commands")
         return trainer_cmds
 
-    if config.get("enable_offload", False):
-        tms_env_vars = get_tms_env_vars()
-    else:
-        tms_env_vars = {}
+    enable_tms_offload = config.get("enable_offload", False)
 
     if allocation_mode.type_ != AllocationType.LLM_SERVER_ONLY:
         # launch trainers
@@ -650,6 +647,15 @@ def slurm_main(config, run_id: int = 0):
             cpus_per_task=actor_spec.cpu,
             existing_env_vars=actor_spec.env_vars,
         )
+        env_vars = {
+            **BASE_ENVIRONS,
+            **thread_env,
+            **actor_spec.env_vars,
+            **_env_vars,
+            "AREAL_SPMD_MODE": "1",
+        }
+        if enable_tms_offload:
+            apply_tms_env_vars(env_vars)
         launcher.submit_array(
             job_name="trainer",
             cmd=_build_trainer_cmds(
@@ -665,14 +671,7 @@ def slurm_main(config, run_id: int = 0):
             container_image=actor_spec.image,
             srun_additional_args=actor_spec.srun_additional_args,
             container_mounts=actor_spec.mount,
-            env_vars={
-                **BASE_ENVIRONS,
-                **thread_env,
-                **actor_spec.env_vars,
-                **_env_vars,
-                **tms_env_vars,
-                "AREAL_SPMD_MODE": "1",
-            },
+            env_vars=env_vars,
         )
 
     try:

--- a/areal/infra/rpc/guard/app.py
+++ b/areal/infra/rpc/guard/app.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import json
 import os
 import signal
 import subprocess
+import tempfile
+import time
 import traceback
 from collections.abc import Callable
 from pathlib import Path
@@ -36,6 +39,66 @@ from areal.utils import logging
 from areal.utils.network import find_free_ports, format_hostport
 
 logger = logging.getLogger("Guard")
+
+_PORT_RESERVATION_TTL_S = 3600.0
+
+
+def _port_registry_path() -> Path:
+    return Path(
+        os.environ.get(
+            "AREAL_GUARD_PORT_REGISTRY",
+            f"/tmp/areal_guard_ports_{os.getuid()}.json",
+        )
+    )
+
+
+def _reserve_free_ports(count: int, exclude_ports: set[int]) -> list[int]:
+    """Reserve free ports across all guard processes on the same node."""
+    import fcntl
+
+    registry_path = _port_registry_path()
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = registry_path.with_suffix(registry_path.suffix + ".lock")
+    now = time.time()
+
+    with open(lock_path, "a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            try:
+                with open(registry_path) as f:
+                    raw_registry = json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                raw_registry = {}
+
+            registry = {
+                str(port): float(ts)
+                for port, ts in raw_registry.items()
+                if now - float(ts) < _PORT_RESERVATION_TTL_S
+            }
+            reserved_ports = {int(port) for port in registry}
+            ports = find_free_ports(
+                count, exclude_ports=set(exclude_ports) | reserved_ports
+            )
+
+            for port in ports:
+                registry[str(port)] = now
+
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=registry_path.name + ".",
+                suffix=".tmp",
+                dir=registry_path.parent,
+            )
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(registry, f, sort_keys=True)
+                os.replace(tmp_path, registry_path)
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+            return ports
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 class GuardState:
@@ -215,7 +278,7 @@ def create_app(state: GuardState) -> Flask:
 
             s = get_state()
             with s.allocated_ports_lock:
-                ports = find_free_ports(count, exclude_ports=s.allocated_ports)
+                ports = _reserve_free_ports(count, exclude_ports=s.allocated_ports)
                 s.allocated_ports.update(ports)
 
             return jsonify({"status": "success", "ports": ports, "host": s.server_host})
@@ -290,7 +353,7 @@ def create_app(state: GuardState) -> Flask:
                 / (s.trial_name or "default")
             )
             log_dir.mkdir(parents=True, exist_ok=True)
-            log_file = log_dir / f"{role}.log"
+            log_file = log_dir / f"{role}-{worker_index}.log"
             merged_log = log_dir / "merged.log"
 
             logger.info(f"Forked worker logs will be written to: {log_file}")

--- a/areal/infra/rpc/rpc_server.py
+++ b/areal/infra/rpc/rpc_server.py
@@ -15,17 +15,64 @@ Usage::
 from __future__ import annotations
 
 import logging as stdlib_logging
+import os
+import sys
 
-from areal.infra.rpc.guard.app import (
+
+def _early_set_alloc_conf() -> None:
+    """Set the CUDA allocator config by role before any CUDA-initializing import.
+
+    The ``from areal...`` import chain below initializes CUDA at import time,
+    which locks in the allocator config; setting ``PYTORCH_CUDA_ALLOC_CONF`` in
+    ``main()`` is too late (expandable_segments would never take effect). So we
+    pre-parse ``--role`` from argv and set the env var here, before any areal
+    import. Only configs that explicitly set ``AWEX_ACTOR_ALLOC_CONF`` opt in
+    (AWEX colocate); plain training runs are not implicitly affected. Inference
+    roles (rollout/sglang) stay disabled: enabling expandable segments breaks
+    SGLang engine initialization.
+    """
+    role = ""
+    for i, a in enumerate(sys.argv):
+        if a == "--role" and i + 1 < len(sys.argv):
+            role = sys.argv[i + 1]
+        elif a.startswith("--role="):
+            role = a.split("=", 1)[1]
+    is_inference = ("rollout" in role.lower()) or ("sglang" in role.lower())
+    conf = os.environ.get("AWEX_ACTOR_ALLOC_CONF", "").strip()
+    if role and not is_inference and conf:
+        existing = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "").strip()
+        if existing:
+            existing_keys = {
+                part.split(":", 1)[0].split("=", 1)[0].strip()
+                for part in existing.split(",")
+                if part.strip()
+            }
+            extra_parts = []
+            for part in conf.split(","):
+                part = part.strip()
+                key = part.split(":", 1)[0].split("=", 1)[0].strip()
+                if part and key not in existing_keys:
+                    extra_parts.append(part)
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = ",".join([existing, *extra_parts])
+        else:
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = conf
+
+
+_early_set_alloc_conf()
+
+from areal.infra.rpc.guard.app import (  # noqa: E402
     GuardState,
     configure_state_from_args,
     create_app,
     make_base_parser,
     run_server,
 )
-from areal.infra.rpc.guard.data_blueprint import data_bp
-from areal.infra.rpc.guard.engine_blueprint import engine_bp, register_engine_hooks
-from areal.utils import logging, perf_tracer
+from areal.infra.rpc.guard.data_blueprint import data_bp  # noqa: E402
+from areal.infra.rpc.guard.engine_blueprint import (  # noqa: E402
+    engine_bp,
+    register_engine_hooks,
+)
+from areal.utils import logging, perf_tracer  # noqa: E402
 
 logger = logging.getLogger("SyncRPCServer")
 
@@ -49,6 +96,30 @@ def main():
 
     state = GuardState()
     bind_host = configure_state_from_args(state, args)
+
+    is_inference_role = "rollout" in args.role.lower() or "sglang" in args.role.lower()
+    try:
+        import torch
+
+        expandable_segments = torch.cuda.memory._snapshot()["allocator_settings"][
+            "expandable_segments"
+        ]
+    except Exception:
+        expandable_segments = "unknown"
+    if is_inference_role:
+        logger.info(
+            "[role=%s] inference role: allocator actual expandable_segments=%s",
+            args.role,
+            expandable_segments,
+        )
+    else:
+        logger.info(
+            "[role=%s] training role: allocator actual expandable_segments=%s "
+            "(env PYTORCH_CUDA_ALLOC_CONF=%r)",
+            args.role,
+            expandable_segments,
+            os.environ.get("PYTORCH_CUDA_ALLOC_CONF", ""),
+        )
 
     app = create_app(state)
     app.register_blueprint(data_bp)

--- a/areal/infra/scheduler/local.py
+++ b/areal/infra/scheduler/local.py
@@ -52,7 +52,7 @@ from areal.utils.network import (
     format_hostport,
     gethostip,
 )
-from areal.utils.offload import get_tms_env_vars
+from areal.utils.offload import apply_tms_env_vars
 
 logger = logging.getLogger("LocalScheduler")
 
@@ -87,6 +87,21 @@ def _get_device_count_safely() -> int | None:
                     return len(devices)
     except (OSError, ValueError):
         return None
+
+
+def _worker_device_control_env_var() -> str:
+    """Return the visibility env var to set on GPU workers.
+
+    When the controller has hidden its own accelerators (see
+    ``AREAL_HIDE_CONTROLLER_DEVICES`` in ``areal/__init__.py``), ``current_platform``
+    degrades to the CPU platform and its ``device_control_env_var`` is empty. In that
+    case the real accelerator env var is read from the value the controller stashed
+    before blanking, so workers still receive the correct assignment.
+    """
+    hidden = os.environ.get("AREAL_CONTROLLER_HIDDEN_DEVICE_ENV")
+    if hidden:
+        return hidden
+    return current_platform.device_control_env_var
 
 
 class LocalScheduler(Scheduler):
@@ -186,6 +201,30 @@ class LocalScheduler(Scheduler):
         return len(self.gpu_devices)
 
     def _detect_gpus(self) -> list[int]:
+        # If the controller has hidden its own accelerators
+        # (AREAL_HIDE_CONTROLLER_DEVICES), enumerate the worker device pool from the
+        # stashed original visibility rather than this process's (now empty) view.
+        hidden_env = os.environ.get("AREAL_CONTROLLER_HIDDEN_DEVICE_ENV")
+        if hidden_env:
+            if os.environ.get("AREAL_CONTROLLER_ORIG_DEVICES_SET") == "1":
+                # The original visibility was explicitly set; honor it exactly. An
+                # empty string means "no devices visible" (e.g. a CPU-only controller
+                # or one given no GPU allocation), which must NOT be confused with an
+                # unset variable that conventionally exposes all devices.
+                orig = os.environ.get("AREAL_CONTROLLER_ORIG_DEVICES", "")
+                if orig == "":
+                    return []
+                try:
+                    return [int(x) for x in orig.split(",")]
+                except ValueError:
+                    logger.warning(
+                        f"Invalid stashed {hidden_env}: {orig}, using default [0]"
+                    )
+                    return [0]
+            # Original visibility was unset -> all physical devices are available.
+            cnt = _get_device_count_safely()
+            return list(range(cnt)) if cnt is not None else [0]
+
         cuda_visible = os.environ.get(current_platform.device_control_env_var)
         if current_platform.device_control_env_var and cuda_visible:
             try:
@@ -740,10 +779,9 @@ class LocalScheduler(Scheduler):
                 env = get_env_vars(
                     ",".join([f"{k}={v}" for k, v in scheduling.env_vars.items()]),
                 )
-                if current_platform.device_control_env_var:
-                    env[current_platform.device_control_env_var] = ",".join(
-                        map(str, gpu_devices)
-                    )
+                worker_device_env_var = _worker_device_control_env_var()
+                if worker_device_env_var:
+                    env[worker_device_env_var] = ",".join(map(str, gpu_devices))
 
                 thread_env = get_thread_env_vars(
                     cpus_per_task=scheduling.cpu,
@@ -752,7 +790,7 @@ class LocalScheduler(Scheduler):
                 env.update(thread_env)
 
                 if self.enable_tms_offload:
-                    env.update(get_tms_env_vars())
+                    apply_tms_env_vars(env)
 
                 if scheduling.env_vars:
                     env.update(scheduling.env_vars)

--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -926,11 +926,16 @@ class RayScheduler(Scheduler):
                 existing_env_vars=sch.env_vars,
             )
             sch.env_vars.update(thread_env)
+            # Ray worker launchers are device-owning workers, not controllers, and
+            # they carry no --role in argv. Mark them so areal/__init__.py does not
+            # hide the devices Ray assigned if the controller opt-in env is inherited.
+            sch.env_vars.setdefault("AREAL_ROLE_WORKER", "1")
 
         if len(schedulings) == 1:
             # Expand single spec to all workers
             return [schedulings[0]] * num_workers
-        elif len(schedulings) == num_workers:
+
+        if len(schedulings) == num_workers:
             return list(schedulings)
         else:
             raise ValueError(
@@ -1549,6 +1554,7 @@ class RayScheduler(Scheduler):
                 options = create_resource_spec(
                     self.ray_device_resource, cpu_count, gpu_count, mem_gb * 1024**3
                 )
+                options["runtime_env"] = {"env_vars": {"AREAL_ROLE_WORKER": "1"}}
                 options["scheduling_strategy"] = PlacementGroupSchedulingStrategy(
                     placement_group=pg,
                     placement_group_bundle_index=item["bundle_index"],

--- a/areal/infra/utils/proc.py
+++ b/areal/infra/utils/proc.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
     from typing import IO
 
 
+def _env_has_preload_runtime(env: dict[str, str] | None) -> bool:
+    if env is None:
+        env = os.environ
+    return bool(env.get("LD_PRELOAD")) or env.get("TMS_INIT_ENABLE") == "1"
+
+
 def build_streaming_log_cmd(
     cmd: str | list[str],
     log_file: str | Path,
@@ -30,6 +36,7 @@ def build_streaming_log_cmd(
     role: str,
     *,
     env_vars: dict[str, str] | None = None,
+    use_stdbuf: bool = True,
 ) -> str:
     """Build a shell command that streams output to stdout and log files.
 
@@ -50,6 +57,8 @@ def build_streaming_log_cmd(
         Role name for log prefix (e.g., "actor", "master")
     env_vars : dict[str, str] | None
         Optional environment variables to prefix the command with KEY=VALUE
+    use_stdbuf : bool
+        Whether to wrap the command with stdbuf for line-buffered output.
 
     Returns
     -------
@@ -63,7 +72,7 @@ def build_streaming_log_cmd(
         cmd_str = cmd
 
     # Check if stdbuf is available (not present on macOS by default)
-    _has_stdbuf = shutil.which("stdbuf") is not None
+    _has_stdbuf = use_stdbuf and shutil.which("stdbuf") is not None
 
     # Build prefix with env vars if provided
     prefix_parts = []
@@ -123,8 +132,20 @@ def run_with_streaming_logs(
     subprocess.Popen
         The spawned process
     """
+    if env_vars_in_cmd is not None and _env_has_preload_runtime(env_vars_in_cmd):
+        use_stdbuf = False
+    elif env is not None:
+        use_stdbuf = not _env_has_preload_runtime(env)
+    else:
+        use_stdbuf = not _env_has_preload_runtime(None)
+
     shell_cmd = build_streaming_log_cmd(
-        cmd, str(log_file), str(merged_log), role, env_vars=env_vars_in_cmd
+        cmd,
+        str(log_file),
+        str(merged_log),
+        role,
+        env_vars=env_vars_in_cmd,
+        use_stdbuf=use_stdbuf,
     )
 
     return subprocess.Popen(

--- a/areal/infra/utils/python.py
+++ b/areal/infra/utils/python.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+
+def get_python_executable() -> str:
+    return os.environ.get("AREAL_PYTHON_EXECUTABLE") or sys.executable

--- a/areal/infra/workflow_executor.py
+++ b/areal/infra/workflow_executor.py
@@ -346,14 +346,24 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
 
         def post():
             try:
+                self.logger.info(
+                    f"[ROLLOUT-CB] send callback task_id={task_id} addr={addr} "
+                    f"result_is_none={result is None}"
+                )
                 resp = requests.post(
                     addr,
                     json={"task_id": task_id},
                     timeout=30,
                 )
                 resp.raise_for_status()
+                self.logger.info(
+                    f"[ROLLOUT-CB] callback ok task_id={task_id} "
+                    f"addr={addr} status={resp.status_code}"
+                )
             except requests.RequestException as e:
-                self.logger.error(f"Callback to {addr} failed: {e}")
+                self.logger.error(
+                    f"[ROLLOUT-CB] callback failed task_id={task_id} addr={addr}: {e}"
+                )
 
         get_executor().submit(post)
 
@@ -417,6 +427,12 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
                         self._pending_results[result.task_id] = result
                         # Trigger callback if registered
                         cb_addr = self._task_callbacks.pop(result.task_id, None)
+                        self.logger.info(
+                            f"[ROLLOUT-CB] fetch result task_id={result.task_id} "
+                            f"has_callback={cb_addr is not None} "
+                            f"result_is_none={result.data is None} "
+                            f"pending_results={len(self._pending_results)}"
+                        )
                         if cb_addr:
                             self._send_callback(cb_addr, result.task_id, result.data)
                     self._result_cv.notify_all()

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -132,6 +132,7 @@ class PPOTrainer:
             logging.setup_file_logging(StatsLogger.get_log_path(config.stats_logger))
 
         self.config = config
+        self._apply_dte_config_envvars()
         self.processor, self.tokenizer = load_hf_processor_and_tokenizer(
             config.tokenizer_path
         )
@@ -150,9 +151,29 @@ class PPOTrainer:
         self.rollout_alloc = ModelAllocation.from_str(
             config.rollout.backend, name="rollout"
         )
-        self._should_offload_rollout = self._is_actor_rollout_colocated(config)
-        self._should_offload_actor = (
-            self._should_offload_rollout or config.actor.offload
+        (
+            self._should_offload_rollout,
+            self._should_offload_actor,
+        ) = self._resolve_actor_rollout_offload(config)
+        self._release_initial_rollout_weights = (
+            self._resolve_release_initial_rollout_weights(config)
+        )
+        # Delta transfer patches the receiver in place, so the rollout weights
+        # are the delta BASE and must survive every train-phase offload. A
+        # plain release drops them and the next DELTA payload only rewrites
+        # the changed slice: observed 0706 long run — v2 [inversion] changed
+        # 0.03%, every post-v2 rollout was uniform-logit token soup. FULL
+        # payloads mask this by rebuilding everything. Preferred base home is
+        # the sglang weights CPU backup (release stays cheap on GPU; measured
+        # resident cost is the full TP-sharded replica, 48.5GB/GPU at d16t4p1,
+        # which does not fit next to the train peak). Only fall back to GPU
+        # residency when the backup is off.
+        dte_cfg = getattr(config.actor, "dte", None)
+        sglang_cfg = getattr(config, "sglang", None)
+        self._keep_rollout_weights_resident = bool(
+            getattr(dte_cfg, "enabled", False)
+            and getattr(dte_cfg, "transfer", None) == "delta"
+            and not getattr(sglang_cfg, "enable_weights_cpu_backup", False)
         )
         self._should_offload_critic = (
             config.critic is not None and config.critic.offload
@@ -328,15 +349,11 @@ class PPOTrainer:
         # Save initial LoRA weights if enabled (for inference server pre-loading)
         initial_lora_path = self._save_initial_lora_weights()
 
-        # Offload actor before rollout init so sglang can use the GPU memory
-        if self._should_offload_actor:
-            self._offload_model(self.actor, role="actor")
-
         # In colocate (awex) mode, offload training weights before SGLang starts
         # so that GPU memory is available for inference engine allocation.
         # Uses adapter-based manual offload (not TMS), so enable_offload is not required.
         self._awex_meta_server_addr: str | None = None
-        if self._is_v1_awex_colocate(config):
+        if self._uses_awex_weight_update(config):
             from awex.meta.meta_server import start_meta_server
 
             from areal.utils.network import gethostip
@@ -351,6 +368,9 @@ class PPOTrainer:
             )
             self.actor.init_awex_adapter(meta_server_addr=self._awex_meta_server_addr)
             self.actor.offload()
+        elif self._should_offload_actor:
+            # Offload actor before rollout init so sglang can use the GPU memory.
+            self._offload_model(self.actor, role="actor")
 
         # Initialize inference with LoRA path
         self.rollout = self._init_rollout(
@@ -358,7 +378,7 @@ class PPOTrainer:
         )
 
         self.eval_rollout = None
-        if not self._online_mode:
+        if not self._online_mode and self._is_eval_enabled(config):
             self.eval_rollout = self._init_rollout(
                 config.rollout, is_eval=True, lora_path=initial_lora_path
             )
@@ -394,7 +414,9 @@ class PPOTrainer:
                 }
                 self.weight_update_meta = WeightUpdateMeta.from_disk(**disk_kwargs)
             else:
-                self.weight_update_meta = WeightUpdateMeta.from_awex()
+                self.weight_update_meta = WeightUpdateMeta.from_awex(
+                    meta_server_addr=self._awex_meta_server_addr,
+                )
         elif self.config.actor.weight_update_mode == "disk":
             disk_kwargs = {
                 "experiment_name": config.experiment_name,
@@ -504,6 +526,23 @@ class PPOTrainer:
             self._is_colocation(rollout_s) and rollout_s.target == "actor"
         )
 
+    def _resolve_actor_rollout_offload(self, config: PPOConfig) -> tuple[bool, bool]:
+        offload_rollout = self._is_actor_rollout_colocated(config)
+        return offload_rollout, offload_rollout or config.actor.offload
+
+    def _resolve_release_initial_rollout_weights(self, config: PPOConfig) -> bool:
+        dte_cfg = getattr(config.actor, "dte", None)
+        configured = getattr(dte_cfg, "release_initial_rollout_weights", None)
+        if configured is not None:
+            return bool(configured)
+
+        dte_awex_colocate = (
+            self._should_offload_rollout
+            and self._uses_awex_weight_update(config)
+            and getattr(dte_cfg, "enabled", None) is True
+        )
+        return not dte_awex_colocate
+
     def _is_v1_awex_colocate(self, config: PPOConfig) -> bool:
         """Whether this run is the v1 AWEX colocated actor-rollout setup.
 
@@ -522,6 +561,14 @@ class PPOTrainer:
         return (
             config.actor._version == "v1" and config.actor.weight_update_mode == "awex"
         )
+
+    def _uses_awex_weight_update(self, config: PPOConfig) -> bool:
+        if config.actor._version == "v2":
+            return not config.actor.use_lora
+        return self._is_v1_awex_colocate(config)
+
+    def _should_save_before_weight_update(self, config: PPOConfig) -> bool:
+        return self._uses_awex_weight_update(config)
 
     def _onload_model(self, engine, role: str) -> None:
         with (
@@ -543,7 +590,7 @@ class PPOTrainer:
         ):
             engine.offload()
 
-    def _offload_rollout(self, is_eval: bool = False):
+    def _offload_rollout(self, is_eval: bool = False, *, release_weights: bool = True):
         rollout = self.rollout if not is_eval else self.eval_rollout
         if rollout is None:
             return
@@ -573,7 +620,19 @@ class PPOTrainer:
                 category=Category.IO,
             ),
         ):
-            rollout.offload()
+            if isinstance(rollout, RolloutControllerV2):
+                logger.info("colocate: offloading rollout kv_cache")
+                rollout.offload(tags=["kv_cache"])
+                if release_weights:
+                    logger.info("colocate: offloading rollout weights")
+                    rollout.offload(tags=["weights"])
+                else:
+                    logger.info(
+                        "colocate: keeping rollout weights resident "
+                        "(DTE delta base must survive the offload cycle)"
+                    )
+            else:
+                rollout.offload()
 
     def _onload_rollout(self, is_eval: bool = False) -> None:
         cleanup_error: Exception | None = None
@@ -590,7 +649,13 @@ class PPOTrainer:
                     category=Category.IO,
                 ),
             ):
-                rollout.onload()
+                if isinstance(rollout, RolloutControllerV2):
+                    logger.info("colocate: onloading rollout weights")
+                    rollout.onload(tags=["weights"])
+                    logger.info("colocate: onloading rollout kv_cache")
+                    rollout.onload(tags=["kv_cache"])
+                else:
+                    rollout.onload()
         except Exception as exc:  # noqa: BLE001
             cleanup_error = exc
 
@@ -625,7 +690,12 @@ class PPOTrainer:
 
     def _apply_initial_offload_policy(self) -> None:
         if self._should_offload_rollout:
-            self._offload_rollout()
+            self._offload_rollout(release_weights=self._release_initial_rollout_weights)
+            if self.eval_rollout is not None:
+                self._offload_rollout(
+                    is_eval=True,
+                    release_weights=self._release_initial_rollout_weights,
+                )
         if self._should_offload_ref:
             self._offload_model(self.ref, role="ref")
         if self._should_offload_critic:
@@ -645,6 +715,7 @@ class PPOTrainer:
         total_epochs: int | None = None,
     ):
         config = self.config
+        dynamic_filter_mode = config.dynamic_filter_mode
         start_step = (
             self.recover_info.last_step_info.next().global_step
             if self.recover_info is not None
@@ -657,6 +728,16 @@ class PPOTrainer:
             raise ValueError(f"Total epochs must be positive: {total_epochs}")
         steps_per_epoch = len(self.train_dataloader)
         max_steps = total_epochs * steps_per_epoch
+
+        # SPMD engines' prepare_batch does not accept this workflow-only
+        # kwarg; only pass it on the single-controller path. In SPMD mode the
+        # option is already disabled with a warning by
+        # GenerationHyperparameters.__post_init__.
+        keep_partial_kwargs = (
+            {"keep_partial_group_on_error": config.gconfig.keep_partial_group_on_error}
+            if is_single_controller()
+            else {}
+        )
 
         # Initialize proxy workers if not using RolloutWorkflow
         if workflow is None:
@@ -698,14 +779,26 @@ class PPOTrainer:
                     self.train_dataloader,
                     workflow=workflow,
                     workflow_kwargs=workflow_kwargs,
-                    should_accept_fn=dynamic_filter_fn,
+                    # In "post_batch" mode filtering is applied below,
+                    # after the whole batch has been collected.
+                    should_accept_fn=(
+                        dynamic_filter_fn if dynamic_filter_mode == "rollout" else None
+                    ),
                     group_size=config.gconfig.n_samples,
                     dynamic_bs=self.config.dynamic_bs,
                     reward_normalization=config.gconfig.reward_normalization,
                     drop_incomplete_group=config.gconfig.drop_incomplete_group,
+                    **keep_partial_kwargs,
                 )
             if self._should_offload_rollout:
-                self._offload_rollout()
+                self._offload_rollout(
+                    release_weights=not self._keep_rollout_weights_resident
+                )
+
+            if dynamic_filter_mode == "post_batch" and dynamic_filter_fn is not None:
+                rollout_batch = self._post_batch_dynamic_filter(
+                    rollout_batch, dynamic_filter_fn
+                )
 
             if self.critic is not None:
                 if self._should_offload_critic:
@@ -861,7 +954,7 @@ class PPOTrainer:
             # needed) and MegatronEngine.save() drops the dead fp32 grad
             # buffers to fund the transient. Weights are identical on both
             # sides of the transfer, so the checkpoint content is unchanged.
-            if self._is_v1_awex_colocate(config):
+            if self._should_save_before_weight_update(config):
                 self._save_training_state(
                     epoch=epoch,
                     epoch_step=step,
@@ -870,9 +963,6 @@ class PPOTrainer:
 
             # pause inference for updating weights, save, and evaluation
             self.rollout.pause()
-
-            # Actor already onloaded; engine-internal _offload_aware_context
-            # calls in update_weights/save are no-ops.
 
             with (
                 stats_tracker.record_timing("update_weights"),
@@ -894,7 +984,7 @@ class PPOTrainer:
                 if self.eval_rollout is not None:
                     self.eval_rollout.set_version(new_version)
 
-            if not self._is_v1_awex_colocate(config):
+            if not self._should_save_before_weight_update(config):
                 self._save_training_state(
                     epoch=epoch,
                     epoch_step=step,
@@ -958,8 +1048,26 @@ class PPOTrainer:
                     epoch=epoch, epoch_step=step, global_step=global_step
                 )
 
-            # Resume rollout
-            self.rollout.resume()
+            # Resume rollout only when another train step will consume it.
+            #
+            # The dispatcher may have queued overlap rollouts while producing
+            # the current batch. Resuming it after the final step lets those
+            # stale tasks hit the inference server while close() is already
+            # tearing workers down, producing noisy ConnectionRefused errors.
+            if not self._is_final_train_step(
+                global_step=global_step, max_steps=max_steps
+            ):
+                # In colocated offload mode, keep rollout paused until the
+                # next _onload_rollout() restores weights/kv_cache and resumes
+                # dispatch.
+                if not self._should_offload_rollout:
+                    self.rollout.resume()
+            else:
+                logger.info(
+                    "Skipping rollout resume after final training step "
+                    "(global_step=%s)",
+                    global_step,
+                )
 
             self._save_perf_tracer(step=global_step)
 
@@ -995,24 +1103,47 @@ class PPOTrainer:
             )
 
     def close(self):
-        self.saver.finalize()
-        if hasattr(self, "_train_rdataset") and self._train_rdataset is not None:
-            self._train_rdataset.close()
-        if hasattr(self, "_valid_rdataset") and self._valid_rdataset is not None:
-            self._valid_rdataset.close()
-        if hasattr(self, "data_controller") and self.data_controller is not None:
-            self.data_controller.destroy()
-        self.stats_logger.close()
-        if self.eval_rollout is not None:
-            self.eval_rollout.destroy()
-        self.rollout.destroy()
-        if self.teacher is not None:
-            self.teacher.destroy()
-        if self.ref is not None:
-            self.ref.destroy()
-        if self.critic is not None:
-            self.critic.destroy()
-        self.actor.destroy()
+        # P87: must tolerate a partially-constructed trainer (called from
+        # __init__'s failure path), and one engine's destroy() failure must
+        # not keep the remaining workers alive.
+        saver = getattr(self, "saver", None)
+        if saver is not None:
+            try:
+                saver.finalize()
+            except Exception:
+                logger.warning("saver.finalize() failed during close", exc_info=True)
+        for attr in ("_train_rdataset", "_valid_rdataset"):
+            rdataset = getattr(self, attr, None)
+            if rdataset is not None:
+                try:
+                    rdataset.close()
+                except Exception:
+                    logger.warning(f"{attr}.close() failed during close", exc_info=True)
+        data_controller = getattr(self, "data_controller", None)
+        if data_controller is not None:
+            try:
+                data_controller.destroy()
+            except Exception:
+                logger.warning(
+                    "data_controller.destroy() failed during close", exc_info=True
+                )
+        stats_logger = getattr(self, "stats_logger", None)
+        if stats_logger is not None:
+            try:
+                stats_logger.close()
+            except Exception:
+                logger.warning(
+                    "stats_logger.close() failed during close", exc_info=True
+                )
+        for attr in ("eval_rollout", "rollout", "teacher", "ref", "critic", "actor"):
+            engine = getattr(self, attr, None)
+            if engine is not None:
+                try:
+                    engine.destroy()
+                except Exception:
+                    logger.warning(
+                        f"{attr}.destroy() failed during close", exc_info=True
+                    )
         perf_tracer.save(force=True)
 
     def _config_perf_tracer(self):
@@ -1055,6 +1186,109 @@ class PPOTrainer:
         elif cfg.type == "slurm":
             return SlurmScheduler(exp_config=self.config)
         raise NotImplementedError(f"Unknown scheduler type: {cfg.type}")
+
+    def _apply_dte_config_envvars(self) -> None:
+        """Export actor.dte.* config to worker-visible runtime switches.
+
+        The public control surface is now CLI/config (``actor.dte.*``). The
+        train and rollout workers are separate processes, so the selected values
+        still need to be inherited through the environment until the AWEX adapter
+        APIs grow an explicit config payload. Old AWEX_* variables remain a
+        fallback in the readers; values set here use the DTE_* names and take
+        precedence.
+        """
+        dte_cfg = getattr(self.config.actor, "dte", None)
+        if dte_cfg is None:
+            return
+
+        exported_env: dict[str, str] = {}
+
+        def set_env(name: str, value: Any) -> None:
+            if value is None:
+                return
+            if isinstance(value, bool):
+                env_value = "1" if value else "0"
+            else:
+                env_value = str(value)
+            os.environ[name] = env_value
+            exported_env[name] = env_value
+
+        transfer = dte_cfg.transfer
+        delta_transfer = None
+        if transfer is not None:
+            transfer = transfer.strip().lower()
+            if transfer not in {"full", "delta"}:
+                raise ValueError(
+                    "actor.dte.transfer must be 'full' or 'delta', "
+                    f"got {dte_cfg.transfer!r}"
+                )
+            delta_transfer = transfer == "delta"
+
+        delta_method = dte_cfg.delta_method
+        detector = None
+        if delta_method is not None:
+            delta_method = delta_method.strip().lower()
+            if delta_method == "adamw":
+                detector = "inversion"
+            elif delta_method == "snapshot":
+                detector = "snapshot"
+            else:
+                raise ValueError(
+                    "actor.dte.delta_method must be 'snapshot' or 'adamw', "
+                    f"got {dte_cfg.delta_method!r}"
+                )
+        elif delta_transfer:
+            detector = "inversion"
+
+        enabled = dte_cfg.enabled
+        if enabled is False and delta_transfer:
+            raise ValueError(
+                "actor.dte.enabled=false conflicts with actor.dte.transfer='delta'. "
+                "Use actor.dte.enabled=true for delta transfer, or set "
+                "actor.dte.transfer=full."
+            )
+        if enabled is None and delta_transfer:
+            enabled = True
+        set_env("DTE_COLOCATE_WEIGHT_UPDATE", enabled)
+
+        config_controls_dte = enabled is not None
+        if config_controls_dte:
+            set_env("DTE_DELTA_TRANSFER", delta_transfer)
+            set_env("DTE_DELTA_DETECTOR", detector)
+            set_env("DTE_DELTA_ANCHOR_INTERVAL", dte_cfg.anchor_interval)
+            set_env("DTE_DELTA_BYTES_RATIO", dte_cfg.bytes_ratio)
+            set_env("DTE_DELTA_VERIFY_SNAPSHOT", dte_cfg.verify_snapshot)
+        set_env(
+            "DTE_RELEASE_TRAIN_WEIGHTS_AFTER_UPDATE",
+            dte_cfg.release_train_weights_after_update,
+        )
+        set_env(
+            "DTE_SYNC_MODEL_PARAMS_BEFORE_PAYLOAD",
+            dte_cfg.sync_model_params_before_payload,
+        )
+        set_env("DTE_DELTA_INVERSION_DEBUG", dte_cfg.inversion_debug)
+        set_env(
+            "DTE_DELTA_INVERSION_BF16_MARGIN_REL",
+            dte_cfg.inversion_bf16_margin_rel,
+        )
+
+        if exported_env:
+            for cfg_part in (
+                getattr(self.config, "actor", None),
+                getattr(self.config, "rollout", None),
+            ):
+                specs = getattr(cfg_part, "scheduling_spec", None)
+                if not specs:
+                    continue
+                for spec in specs:
+                    if isinstance(spec, dict):
+                        spec.setdefault("env_vars", {}).update(exported_env)
+                        continue
+                    env_vars = getattr(spec, "env_vars", None)
+                    if env_vars is None:
+                        env_vars = {}
+                        setattr(spec, "env_vars", env_vars)
+                    env_vars.update(exported_env)
 
     def _create_dataloader(
         self,
@@ -1191,6 +1425,20 @@ class PPOTrainer:
             )
             for spec in config.scheduling_spec:
                 spec.gpu = 0
+        if config._version == "v2" and self._is_colocation(config.scheduling_strategy):
+            target = config.scheduling_strategy.target
+            if target == "actor" and self.config.actor._version == "v2":
+                config.scheduling_strategy = SchedulingStrategy(
+                    type=config.scheduling_strategy.type,
+                    target="actor-guard",
+                    fork=config.scheduling_strategy.fork,
+                )
+            elif target == "rollout":
+                config.scheduling_strategy = SchedulingStrategy(
+                    type=config.scheduling_strategy.type,
+                    target="rollout-inf",
+                    fork=config.scheduling_strategy.fork,
+                )
 
         # Determine engine class and server args based on backend
         rollout_backend = self.rollout_alloc.backend
@@ -1565,6 +1813,72 @@ class PPOTrainer:
 
         # Everything else requires proxy workers
         return True
+
+    @staticmethod
+    def _post_batch_dynamic_filter(
+        rollout_batch: list[dict[str, Any]],
+        dynamic_filter_fn: Callable[[dict[str, Any]], bool] | str,
+    ) -> list[dict[str, Any]]:
+        """Apply dynamic filtering after the whole batch has been collected.
+
+        Runs ``dynamic_filter_fn`` on each collected group trajectory and
+        keeps only the accepted ones. Semantics of the filter function are
+        identical to rollout-time filtering (``dynamic_filter_mode="rollout"``);
+        only the execution point differs: the decision is made in the trainer
+        process once the entire batch is ready. Rejected groups are dropped
+        without re-sampling, so the batch may shrink (same contract as
+        ``dynamic_bs=True``).
+        """
+        from areal.infra.rpc.rtensor import RTensor
+        from areal.utils.dynamic_import import import_from_string
+
+        if isinstance(dynamic_filter_fn, str):
+            dynamic_filter_fn = import_from_string(dynamic_filter_fn)
+
+        accepted: list[dict[str, Any]] = []
+        n_rejected = 0
+        tracker = stats_tracker.get("rollout")
+        for group_traj in rollout_batch:
+            # Localize only the small reward tensors the filter relies on.
+            # In single-controller mode trajectory values may be RTensor
+            # handles; large tensors (input_ids, logprobs, ...) are
+            # intentionally left remote to avoid fetching the whole batch.
+            filter_view = dict(group_traj)
+            for key in ("rewards", "original_rewards"):
+                if key in filter_view:
+                    filter_view[key] = RTensor.localize(filter_view[key])
+            accept = bool(dynamic_filter_fn(filter_view))
+            # Track rejection statistics with the same metric names and
+            # per-group 0/1 semantics as rollout-time filtering (see
+            # areal/examples/filter_function.py). Note that the denominator
+            # differs: rollout-time filtering also evaluates re-sampled
+            # groups, while here exactly the collected batch is evaluated.
+            if not accept:
+                tracker.scalar(rejected_by_failed_or_perfect=1)
+                rewards = filter_view.get(
+                    "original_rewards", filter_view.get("rewards")
+                )
+                if rewards is not None:
+                    # Distinguish all-correct vs all-wrong
+                    all_positive = bool(all(r > 0 for r in rewards))
+                    tracker.scalar(rejected_by_all_correct=int(all_positive))
+                    tracker.scalar(rejected_by_all_wrong=int(not all_positive))
+            else:
+                tracker.scalar(rejected_by_failed_or_perfect=0)
+                tracker.scalar(rejected_by_all_correct=0)
+                tracker.scalar(rejected_by_all_wrong=0)
+            if accept:
+                accepted.append(group_traj)
+            else:
+                n_rejected += 1
+
+        if n_rejected > 0:
+            logger.warning(
+                f"Post-batch dynamic filter rejected {n_rejected}/"
+                f"{len(rollout_batch)} groups; continuing with "
+                f"{len(accepted)} groups."
+            )
+        return accepted
 
     def _ensure_proxy_started(self) -> None:
         """Lazily initialize proxy workers when agent workflows are used.

--- a/areal/utils/logging.py
+++ b/areal/utils/logging.py
@@ -44,6 +44,7 @@ LOGGER_COLORS_EXACT = {
     # Launchers - blue
     "LocalLauncher": "blue",
     "RayLauncher": "blue",
+    "RayBootstrap": "blue",
     "SlurmLauncher": "blue",
     "InfCli": "blue",
     # Workflows - purple

--- a/areal/utils/offload.py
+++ b/areal/utils/offload.py
@@ -47,5 +47,33 @@ def get_tms_env_vars() -> dict[str, str]:
     return env_vars
 
 
+def apply_tms_env_vars(env_vars: dict[str, str]) -> None:
+    """Add default TMS env vars without overriding explicit user settings."""
+    tms_init = env_vars.get("TMS_INIT_ENABLE")
+    ld_preload = env_vars.get("LD_PRELOAD")
+
+    if tms_init is not None and tms_init != "1":
+        return
+    if ld_preload == "":
+        return
+
+    for key, value in get_tms_env_vars().items():
+        env_vars.setdefault(key, value)
+
+
 def is_tms_enabled() -> bool:
     return os.environ.get("TMS_INIT_ENABLE", "0") == "1"
+
+
+def normalize_tms_ld_preload() -> None:
+    """Keep only the TMS preload library in LD_PRELOAD before TMS initializes."""
+    ld_preload = os.environ.get("LD_PRELOAD")
+    if not ld_preload or ":" not in ld_preload:
+        return
+
+    for path in ld_preload.split(":"):
+        if os.path.basename(path) == "torch_memory_saver_hook_mode_preload.abi3.so":
+            # torch_memory_saver loads this value with ctypes.CDLL(), which
+            # cannot parse a colon-separated LD_PRELOAD list.
+            os.environ["LD_PRELOAD"] = path
+            return

--- a/areal/utils/stats_logger.py
+++ b/areal/utils/stats_logger.py
@@ -7,7 +7,6 @@ from dataclasses import asdict
 
 import swanlab
 import torch.distributed as dist
-import trackio
 import wandb
 from tensorboardX import SummaryWriter
 
@@ -18,6 +17,16 @@ from areal.utils.printing import tabulate_stats
 from areal.version import version_info
 
 logger = logging.getLogger("StatsLogger", "system")
+trackio = None
+
+
+def _get_trackio():
+    global trackio
+    if trackio is None:
+        import trackio as trackio_module
+
+        trackio = trackio_module
+    return trackio
 
 
 class StatsLogger:
@@ -98,7 +107,8 @@ class StatsLogger:
         self._trackio_enabled = False
         trackio_config = self.config.trackio
         if trackio_config.mode != "disabled":
-            trackio.init(
+            trackio_module = _get_trackio()
+            trackio_module.init(
                 project=trackio_config.project or self.config.experiment_name,
                 name=trackio_config.name or self.config.trial_name,
                 config=exp_config_dict,
@@ -128,7 +138,7 @@ class StatsLogger:
         wandb.finish()
         swanlab.finish()
         if getattr(self, "_trackio_enabled", False):
-            trackio.finish()
+            _get_trackio().finish()
         if self.summary_writer is not None:
             self.summary_writer.close()
 
@@ -152,7 +162,7 @@ class StatsLogger:
             wandb.log(item, step=log_step + i)
             swanlab.log(item, step=log_step + i)
             if getattr(self, "_trackio_enabled", False):
-                trackio.log(item, step=log_step + i)
+                _get_trackio().log(item, step=log_step + i)
             if self.summary_writer is not None:
                 for key, val in item.items():
                     self.summary_writer.add_scalar(f"{key}", val, log_step + i)

--- a/areal/utils/stats_tracker.py
+++ b/areal/utils/stats_tracker.py
@@ -385,12 +385,19 @@ class DistributedStatsTracker:
             # `.get`: a rank may learn about this key via key/metadata sync
             # without holding any local values for it.
             stats = self.stats.get(key, [])
-            value = self._placeholder_scalar(
-                fill=float(sum(stats)), group=effective_group
-            )
-            cnt = self._placeholder_scalar(
-                fill=float(len(stats)), group=effective_group
-            )
+            # Only place tensors on the accelerator when a collective actually
+            # needs them; a GPU-side allocation here can OOM colocated setups
+            # whose device is fully budgeted by training + inference engines.
+            if effective_group is not None:
+                value = self._placeholder_scalar(
+                    fill=float(sum(stats)), group=effective_group
+                )
+                cnt = self._placeholder_scalar(
+                    fill=float(len(stats)), group=effective_group
+                )
+            else:
+                value = torch.tensor(float(sum(stats)), dtype=torch.float32)
+                cnt = torch.tensor(float(len(stats)), dtype=torch.float32)
             if effective_group is not None:
                 dist.all_reduce(value, group=effective_group)
                 dist.all_reduce(cnt, group=effective_group)

--- a/areal/v2/inference_service/backend.py
+++ b/areal/v2/inference_service/backend.py
@@ -71,7 +71,7 @@ class InfBridgeBackend(Protocol):
         """Return the HTTP request that resumes generation on the backend."""
         ...
 
-    def get_offload_request(self) -> HttpRequest:
+    def get_offload_request(self, tags: list[str] | None = None) -> HttpRequest:
         """Return the HTTP request that offloads model memory on the backend."""
         ...
 

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import os
-import sys
 import threading
 import time
 import traceback
@@ -28,6 +27,7 @@ import httpx
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from areal.infra.utils.http import async_http_retry, create_httpx_client
+from areal.infra.utils.python import get_python_executable
 
 if TYPE_CHECKING:
     from areal.api.scheduler_api import Scheduler, Worker
@@ -38,6 +38,33 @@ from areal.utils import logging, stats_tracker
 from areal.utils.network import format_hostport
 
 logger = logging.getLogger("RolloutControllerV2")
+
+
+def _prepare_inference_server_args(
+    server_args: dict[str, Any] | None, backend: str
+) -> dict[str, Any]:
+    """Prepare backend CLI args without leaking AReaL-private controls.
+
+    The trainer uses these fields to select the AWEX colocated path for the
+    legacy remote engine.  The v2 SGLang launcher installs its own AWEX
+    scheduler bridge and does not define corresponding SGLang CLI options.
+    Keep the controls in the controller layer instead of serializing them as
+    ``--awex-*`` flags to ``prepare_server_args``.
+    """
+    args = dict(server_args or {})
+    if backend == "sglang":
+        args.pop("awex_colocate_mode", None)
+        args.pop("awex_meta_server_addr", None)
+    return args
+
+
+def _get_inference_base_gpu_id(
+    workers: list[Any], worker_index: int, gpus_per_worker: int
+) -> int:
+    worker_ip = workers[worker_index].ip
+    local_slot = sum(1 for worker in workers[:worker_index] if worker.ip == worker_ip)
+    return local_slot * gpus_per_worker
+
 
 _MAX_COMPLETED_ONLINE_RESULTS = 1024
 _DEFAULT_SERVICE_LOG_LEVEL = "warning"
@@ -314,7 +341,7 @@ class RolloutControllerV2:
     ) -> None:
         from dataclasses import asdict
 
-        from areal.api.cli_args import SchedulingSpec, SchedulingStrategy
+        from areal.api.cli_args import SchedulingSpec
         from areal.api.scheduler_api import Job
 
         cfg = self.config
@@ -363,7 +390,7 @@ class RolloutControllerV2:
         inf_job = Job(
             replicas=total_workers,
             tasks=[inf_spec for _ in range(total_workers)],
-            scheduling_strategy=SchedulingStrategy(),
+            scheduling_strategy=cfg.scheduling_strategy,
             role=inf_role,
         )
 
@@ -390,7 +417,7 @@ class RolloutControllerV2:
         # Router does not depend on inference servers.
         # ==================================================================
         router_cmd = [
-            sys.executable,
+            get_python_executable(),
             "-m",
             "areal.v2.inference_service.router",
             "--admin-api-key",
@@ -449,7 +476,7 @@ class RolloutControllerV2:
         # Data Proxies need _inf_addrs (ready); Gateway needs _router_addr (ready).
         # ==================================================================
         data_proxy_base_cmd = [
-            sys.executable,
+            get_python_executable(),
             "-m",
             "areal.v2.inference_service.data_proxy",
             "--tokenizer-path",
@@ -505,7 +532,7 @@ class RolloutControllerV2:
             return host, port, guard_addr
 
         gw_cmd = [
-            sys.executable,
+            get_python_executable(),
             "-m",
             "areal.v2.inference_service.gateway",
             "--admin-api-key",
@@ -551,6 +578,11 @@ class RolloutControllerV2:
         nnodes_per_instance: int,
         server_args: dict[str, Any] | None,
     ) -> None:
+        instance_size = int(getattr(alloc.parallel, "tp_size", 1)) * int(
+            getattr(alloc.parallel, "pp_size", 1)
+        )
+        gpus_per_worker = instance_size // nnodes_per_instance
+
         if inf_backend == "sglang":
             from areal.api.cli_args import SGLangConfig
 
@@ -573,7 +605,13 @@ class RolloutControllerV2:
             client = await self._get_async_client()
 
             dist_init_addr = None
-            if nnodes_per_instance > 1:
+            parallel_size = int(getattr(alloc.parallel, "tp_size", 1)) * int(
+                getattr(alloc.parallel, "pp_size", 1)
+            )
+            needs_dist_init = nnodes_per_instance > 1 or (
+                inf_backend == "sglang" and parallel_size > 1
+            )
+            if needs_dist_init:
                 resp = await client.post(
                     f"{head_guard_addr}/alloc_ports",
                     json={"count": 1},
@@ -601,12 +639,17 @@ class RolloutControllerV2:
                 inf_port: int = port_data["ports"][0]
 
                 local_args = {
-                    **(server_args or {}),
+                    **_prepare_inference_server_args(server_args, inf_backend),
                     "host": inf_host,
                     "port": inf_port,
                     "nnodes": nnodes_per_instance,
                     "node_rank": node_rank,
                     "dist_init_addr": dist_init_addr,
+                    "base_gpu_id": _get_inference_base_gpu_id(
+                        inf_workers,
+                        group_idx * nnodes_per_instance + node_rank,
+                        gpus_per_worker,
+                    ),
                 }
                 cmd = _build_launch_cmd(local_args)
 
@@ -1120,6 +1163,7 @@ class RolloutControllerV2:
         batch_size: int | None = None,
         reward_normalization: bool = False,
         drop_incomplete_group: bool = False,
+        keep_partial_group_on_error: bool = False,
     ) -> list[dict[str, Any]]:
         """Submit a batch of data items and wait for all results.
 
@@ -1152,10 +1196,10 @@ class RolloutControllerV2:
             A list of trajectory dicts (one per completed rollout).
         """
         self._ensure_initialized()
-        if reward_normalization or drop_incomplete_group:
+        if reward_normalization or drop_incomplete_group or keep_partial_group_on_error:
             raise ValueError(
-                "RolloutControllerV2 does not support reward_normalization or "
-                "drop_incomplete_group yet."
+                "RolloutControllerV2 does not support reward_normalization, "
+                "drop_incomplete_group, or keep_partial_group_on_error yet."
             )
         if not self._gateway_addr:
             raise RuntimeError("RolloutControllerV2.initialize() must be called first")
@@ -1196,6 +1240,7 @@ class RolloutControllerV2:
         batch_size: int | None = None,
         reward_normalization: bool = False,
         drop_incomplete_group: bool = False,
+        keep_partial_group_on_error: bool = False,
     ) -> list[dict[str, Any]]:
         """Prepare a full training batch by consuming data from a dataloader.
 
@@ -1229,10 +1274,10 @@ class RolloutControllerV2:
             A list of trajectory dicts (matching ``RolloutController`` API).
         """
         self._ensure_initialized()
-        if reward_normalization or drop_incomplete_group:
+        if reward_normalization or drop_incomplete_group or keep_partial_group_on_error:
             raise ValueError(
-                "RolloutControllerV2 does not support reward_normalization or "
-                "drop_incomplete_group yet."
+                "RolloutControllerV2 does not support reward_normalization, "
+                "drop_incomplete_group, or keep_partial_group_on_error yet."
             )
         if not self._gateway_addr:
             raise RuntimeError("RolloutControllerV2.initialize() must be called first")
@@ -1380,19 +1425,20 @@ class RolloutControllerV2:
         assert self._workflow_executor is not None
         self._workflow_executor.resume()
 
-    def offload(self) -> None:
+    def offload(self, tags: list[str] | None = None) -> None:
         """Offload model memory on all inference workers."""
         from areal.infra.utils.concurrent import run_async_task
 
         self._ensure_initialized()
-        run_async_task(self._async_offload)
+        run_async_task(self._async_offload, tags)
 
-    async def _async_offload(self) -> None:
+    async def _async_offload(self, tags: list[str] | None = None) -> None:
         if not self._data_proxy_addrs:
             return
+        payload: dict = {"tags": tags} if tags is not None else {}
         results = await asyncio.gather(
             *(
-                self._async_data_proxy_post(addr, "/release_memory_occupation", {})
+                self._async_data_proxy_post(addr, "/release_memory_occupation", payload)
                 for addr in self._data_proxy_addrs
             ),
             return_exceptions=True,
@@ -1434,6 +1480,10 @@ class RolloutControllerV2:
         self._ensure_initialized()
         run_async_task(self._async_pause_generation)
 
+    def pause_generation_sync(self) -> None:
+        """Compatibility alias for controllers whose pause API is asynchronous."""
+        self.pause_generation()
+
     async def _async_pause_generation(self) -> None:
         if not self._data_proxy_addrs:
             return
@@ -1449,6 +1499,12 @@ class RolloutControllerV2:
             logger.error("Failed to pause generation on a worker: %s", r)
         if failed and len(failed) == len(results):
             raise RuntimeError(f"pause_generation failed on ALL {len(failed)} workers")
+        if self.config.pause_grace_period > 0:
+            logger.info(
+                "Waiting %.1fs after pause_generation for in-flight requests to drain",
+                self.config.pause_grace_period,
+            )
+            await asyncio.sleep(self.config.pause_grace_period)
 
     def continue_generation(self) -> None:
         """Continue generation on all workers."""

--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -410,14 +410,18 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         return PauseGenerationResponse(status="ok", paused=False)
 
     @app.post("/release_memory_occupation")
-    async def release_memory_occupation():
+    async def release_memory_occupation(request: Request):
         inf_bridge: InfBridge | None = app.state.inf_bridge
         if inf_bridge is None:
             raise HTTPException(
                 status_code=503,
                 detail="No inference backend configured (external model mode).",
             )
-        await inf_bridge.offload()
+        body = await request.json() if await request.body() else {}
+        tags = body.get("tags")
+        if tags is not None and not isinstance(tags, list):
+            raise HTTPException(status_code=400, detail="'tags' must be a list")
+        await inf_bridge.offload(tags=tags)
         return {"status": "ok"}
 
     @app.post("/resume_memory_occupation")

--- a/areal/v2/inference_service/inf_bridge.py
+++ b/areal/v2/inference_service/inf_bridge.py
@@ -105,11 +105,11 @@ class InfBridge:
         await self.pause_state.set_paused(False)
         logger.info("Resume request sent to %s", self.backend_addr)
 
-    async def offload(self) -> None:
+    async def offload(self, tags: list[str] | None = None) -> None:
         """Offload model memory on the backend inference server."""
-        http_req = self.backend.get_offload_request()
+        http_req = self.backend.get_offload_request(tags=tags)
         await self._send_request(http_req, timeout=30.0)
-        logger.info("Offload request sent to %s", self.backend_addr)
+        logger.info("Offload request sent to %s with tags=%s", self.backend_addr, tags)
 
     async def onload(self, tags: list[str] | None = None) -> None:
         """Reload model memory on the backend inference server."""
@@ -172,15 +172,15 @@ class InfBridge:
                 f"InfBridge only supports n_samples=1, got {req.gconfig.n_samples}"
             )
 
-        # Build the initial HTTP request via the backend
-        http_req = self.backend.build_generation_request(
+        # Extract effective max_new_tokens from the payload the backend built.
+        # The actual request is rebuilt per attempt below so the version used for
+        # LoRA routing and token stamping is fixed at send time.
+        initial_req = self.backend.build_generation_request(
             req,
             with_lora=False,
-            version=self._version,
+            version=self.get_version(),
         )
-
-        # Extract effective max_new_tokens from the payload the backend built
-        ori_max_new_tokens = self.backend.get_generation_max_new_tokens(http_req)
+        ori_max_new_tokens = self.backend.get_generation_max_new_tokens(initial_req)
         if ori_max_new_tokens <= 0:
             raise ValueError(
                 f"max_new_tokens must be > 0, got {ori_max_new_tokens} "
@@ -208,6 +208,13 @@ class InfBridge:
                 stop_reason = "length"
                 break
 
+            attempt_version = self.get_version()
+            http_req = self.backend.build_generation_request(
+                req,
+                with_lora=False,
+                version=attempt_version,
+            )
+
             # Patch the payload for this iteration (extend input, shrink budget)
             self.backend.patch_generation_request(
                 http_req,
@@ -221,7 +228,7 @@ class InfBridge:
 
             accumulated_tokens.extend(result.output_tokens)
             accumulated_logprobs.extend(result.output_logprobs)
-            accumulated_versions.extend([self._version] * len(result.output_tokens))
+            accumulated_versions.extend([attempt_version] * len(result.output_tokens))
             stop_reason = cast(_StopReason, result.stop_reason)
 
             if result.routed_experts is not None:

--- a/areal/v2/inference_service/sglang/awex.py
+++ b/areal/v2/inference_service/sglang/awex.py
@@ -118,6 +118,17 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
             logger.error("Failed to execute colocate weight update: %s", e)
             return JSONResponse(status_code=500, content={"error": str(e)})
 
+    @app.post("/awex/seed_delta_base")
+    async def seed_delta_base(request: Request) -> JSONResponse:
+        try:
+            data = await request.json()
+            version = data.get("version", 0)
+            rpc_proxy.collective_rpc("awex_seed_delta_base", version=version)
+            return JSONResponse(content={"status": "ok", "version": version})
+        except Exception as e:
+            logger.error("Failed to seed delta base: %s", e)
+            return JSONResponse(status_code=500, content={"error": str(e)})
+
     @app.post("/awex/release_memory")
     async def release_memory(request: Request) -> JSONResponse:
         try:

--- a/areal/v2/inference_service/sglang/bridge.py
+++ b/areal/v2/inference_service/sglang/bridge.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -13,9 +14,24 @@ from areal.api.io_struct import (
     HttpRequest,
     get_versioned_lora_name,
 )
+from areal.utils import logging
 
 if TYPE_CHECKING:
     from areal.api.io_struct import ModelRequest
+
+logger = logging.getLogger("SGLangBridge")
+
+# Probe switch for the qwen3 behav-logp investigation: log what the server
+# actually returned at the parse point, before any downstream aggregation.
+_DEBUG_LOGPROBS = os.environ.get("AREAL_DEBUG_BRIDGE_LOGPROBS", "0") == "1"
+_SGLANG_TOP_K_ALL_THRESHOLD = 1_000_000
+
+
+def _normalize_sglang_top_k(top_k: int) -> int:
+    """Translate AReaL's large "all vocab" top-k sentinel to SGLang's -1."""
+    if top_k >= _SGLANG_TOP_K_ALL_THRESHOLD:
+        return -1
+    return top_k
 
 
 class SGLangBridgeBackend:
@@ -24,6 +40,19 @@ class SGLangBridgeBackend:
     Mirrors the relevant subset of
     :class:`areal.engine.sglang_remote.SGLangBackend`.
     """
+
+    def __init__(self, use_awex_memory_endpoints: bool | None = None) -> None:
+        if use_awex_memory_endpoints is None:
+            raw = os.environ.get("DTE_USE_AWEX_MEMORY_ENDPOINTS")
+            if raw is None or raw.strip() == "":
+                raw = os.environ.get("AWEX_USE_MEMORY_ENDPOINTS", "0")
+            use_awex_memory_endpoints = raw.strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+        self.use_awex_memory_endpoints = use_awex_memory_endpoints
 
     # -- generation ---------------------------------------------------------
 
@@ -49,7 +78,7 @@ class SGLangBridgeBackend:
 
         sampling_params: dict[str, Any] = {
             "top_p": gconfig.top_p,
-            "top_k": gconfig.top_k,
+            "top_k": _normalize_sglang_top_k(gconfig.top_k),
             "max_new_tokens": max_new_tokens,
             "temperature": 0.0 if gconfig.greedy else gconfig.temperature,
             "stop_token_ids": gconfig.stop_token_ids,
@@ -67,6 +96,13 @@ class SGLangBridgeBackend:
             "return_logprob": True,
             "stream": False,
         }
+
+        if _DEBUG_LOGPROBS:
+            logger.info(
+                "bridge request: input_len=%d sampling_params=%s",
+                len(req.input_ids),
+                sampling_params,
+            )
 
         if req.metadata.get("return_routed_experts", False):
             payload["return_routed_experts"] = True
@@ -125,6 +161,15 @@ class SGLangBridgeBackend:
         output_tokens = [x[1] for x in output_token_logprobs]
         output_logprobs = [x[0] for x in output_token_logprobs]
 
+        if _DEBUG_LOGPROBS and output_logprobs:
+            logger.info(
+                "bridge parse: n=%d mean_logp=%.4f first5=%s stop=%s",
+                len(output_logprobs),
+                sum(output_logprobs) / len(output_logprobs),
+                [round(x, 4) for x in output_logprobs[:5]],
+                stop_reason,
+            )
+
         return HttpGenerationResult(
             output_tokens=output_tokens,
             output_logprobs=output_logprobs,
@@ -140,11 +185,16 @@ class SGLangBridgeBackend:
     def get_resume_request(self) -> HttpRequest:
         return HttpRequest(endpoint="/continue_generation", payload={})
 
-    def get_offload_request(self) -> HttpRequest:
-        return HttpRequest(endpoint="/release_memory_occupation", payload={})
+    def get_offload_request(self, tags: list[str] | None = None) -> HttpRequest:
+        payload = {"tags": tags} if tags is not None else {}
+        if self.use_awex_memory_endpoints:
+            return HttpRequest(endpoint="/awex/release_memory", payload=payload)
+        return HttpRequest(endpoint="/release_memory_occupation", payload=payload)
 
     def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
         payload = {"tags": tags} if tags is not None else {}
+        if self.use_awex_memory_endpoints:
+            return HttpRequest(endpoint="/awex/resume_memory", payload=payload)
         return HttpRequest(endpoint="/resume_memory_occupation", payload=payload)
 
     def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:

--- a/areal/v2/inference_service/sglang/launch_server.py
+++ b/areal/v2/inference_service/sglang/launch_server.py
@@ -15,11 +15,11 @@ import sys
 
 
 def areal_launch_server(server_args) -> None:
-    from sglang.srt.entrypoints.engine import Engine, init_tokenizer_manager
+    from sglang.srt.entrypoints.engine import init_tokenizer_manager
     from sglang.srt.entrypoints.http_server import (
         _execute_server_warmup,
-        _setup_and_run_http_server,
         app,
+        launch_server,
     )
     from sglang.srt.managers.detokenizer_manager import run_detokenizer_process
 
@@ -36,46 +36,33 @@ def areal_launch_server(server_args) -> None:
 
     # ---- BEGIN AREAL ----
     result_ipc = create_result_ipc()
-    # ---- END AREAL ----
-
-    (
-        tokenizer_manager,
-        template_manager,
-        port_args,
-        scheduler_init_result,
-        subprocess_watchdog,
-    ) = Engine._launch_subprocesses(
-        server_args=server_args,
-        init_tokenizer_manager_func=init_tokenizer_manager,
-        # ---- BEGIN AREAL ----
-        run_scheduler_process_func=areal_run_scheduler_process,
-        # ---- END AREAL ----
-        run_detokenizer_process_func=run_detokenizer_process,
-    )
-
-    # ---- BEGIN AREAL ----
-    if tokenizer_manager is None:
-        return
+    rpc_proxies = []
     # ---- END AREAL ----
 
     # ---- BEGIN AREAL ----
-    rpc_proxy = RpcProxy(port_args, result_ipc)
-    register_awex_endpoints(app, rpc_proxy)
+    def areal_init_tokenizer_manager(server_args, port_args):
+        tokenizer_manager, template_manager = init_tokenizer_manager(
+            server_args, port_args
+        )
+        rpc_proxy = RpcProxy(port_args, result_ipc)
+        register_awex_endpoints(app, rpc_proxy)
+        rpc_proxies.append(rpc_proxy)
+        return tokenizer_manager, template_manager
+
     # ---- END AREAL ----
 
     try:
-        _setup_and_run_http_server(
+        launch_server(
             server_args,
-            tokenizer_manager,
-            template_manager,
-            port_args,
-            scheduler_init_result.scheduler_infos,
-            subprocess_watchdog,
+            init_tokenizer_manager_func=areal_init_tokenizer_manager,
+            run_scheduler_process_func=areal_run_scheduler_process,
+            run_detokenizer_process_func=run_detokenizer_process,
             execute_warmup_func=_execute_server_warmup,
         )
     finally:
         # ---- BEGIN AREAL ----
-        rpc_proxy.close()
+        for rpc_proxy in rpc_proxies:
+            rpc_proxy.close()
         # ---- END AREAL ----
 
 

--- a/areal/v2/inference_service/sglang/rpc_proxy.py
+++ b/areal/v2/inference_service/sglang/rpc_proxy.py
@@ -22,7 +22,10 @@ class RpcProxy:
     """
 
     def __init__(self, port_args: PortArgs, result_ipc: str) -> None:
-        from sglang.srt.utils.network import get_zmq_socket
+        try:
+            from sglang.srt.utils import get_zmq_socket
+        except ImportError:
+            from sglang.srt.utils.network import get_zmq_socket
 
         self._rpc_ctx = zmq.Context(1)
         self._rpc_socket = get_zmq_socket(

--- a/areal/v2/inference_service/sglang/scheduler.py
+++ b/areal/v2/inference_service/sglang/scheduler.py
@@ -15,6 +15,7 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 from areal.infra.rpc.serialization import serialize_value
 
 RESULT_IPC_ENV = "AREAL_AWEX_RESULT_IPC"
+logger = logging.getLogger(__name__)
 
 
 class AwexSchedulerBridge:
@@ -64,6 +65,7 @@ class AwexSchedulerBridge:
             "awex_randomize_parameters",
             "awex_init_colocate_weight_update",
             "awex_execute_colocate_weight_update",
+            "awex_seed_delta_base",
             "awex_release_memory",
             "awex_resume_memory",
         ]
@@ -122,10 +124,17 @@ class AwexSchedulerBridge:
         self._require_adapter().randomize_parameters()
 
     def awex_init_colocate_weight_update(self, **kwargs: Any) -> None:
-        self._require_adapter().init_colocate_weight_update(**kwargs)
+        try:
+            self._require_adapter().init_colocate_weight_update(**kwargs)
+        except Exception:
+            logger.exception("awex_init_colocate_weight_update failed")
+            raise
 
     def awex_execute_colocate_weight_update(self, version: int = 0) -> None:
         self._require_adapter().execute_colocate_weight_update(version)
+
+    def awex_seed_delta_base(self, version: int = 0) -> None:
+        self._require_adapter().seed_delta_base(version)
 
     def awex_release_memory(self, tags: list[str] | None = None) -> None:
         self._require_adapter().release_memory(tags)

--- a/areal/v2/inference_service/vllm/bridge.py
+++ b/areal/v2/inference_service/vllm/bridge.py
@@ -99,7 +99,8 @@ class VLLMBridgeBackend:
     def get_resume_request(self) -> HttpRequest:
         return HttpRequest(endpoint="/areal_continue_generation", payload={})
 
-    def get_offload_request(self) -> HttpRequest:
+    def get_offload_request(self, tags: list[str] | None = None) -> HttpRequest:
+        del tags
         return HttpRequest(endpoint="/sleep", payload={}, method="POST")
 
     def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-import sys
+import os
 import threading
 import time
 import traceback
@@ -16,6 +16,7 @@ import aiohttp
 
 from areal.infra.utils.concurrent import get_executor, run_async_task
 from areal.infra.utils.http import create_httpx_client
+from areal.infra.utils.python import get_python_executable
 from areal.utils import logging
 from areal.utils.network import format_hostport, gethostip
 
@@ -56,6 +57,7 @@ class GatewayTrainController:
         self._own_process_group = False
         self.rollout: Any | None = None
         self._weight_update_ctrl: Any | None = None
+        self._colocate_weight_update = False
 
         # Version management
         self._version_lock = Lock()
@@ -241,7 +243,7 @@ class GatewayTrainController:
             async def _fork_worker(rank: int) -> str:
                 guard = _guard_addr(guard_workers[rank])
                 worker_cmd = [
-                    sys.executable,
+                    get_python_executable(),
                     "-m",
                     "areal.v2.training_service.worker",
                     "--admin-api-key",
@@ -325,7 +327,7 @@ class GatewayTrainController:
             # Step 4: Fork Router on guard 0
             # ==============================================================
             router_cmd = [
-                sys.executable,
+                get_python_executable(),
                 "-m",
                 "areal.v2.training_service.router",
                 "--admin-api-key",
@@ -349,7 +351,7 @@ class GatewayTrainController:
             # Step 5: Fork Data Proxy on a guard
             # ==============================================================
             data_proxy_cmd = [
-                sys.executable,
+                get_python_executable(),
                 "-m",
                 "areal.v2.training_service.data_proxy",
                 "--worker-addrs",
@@ -375,7 +377,7 @@ class GatewayTrainController:
             # Step 6: Fork Gateway on guard 0
             # ==============================================================
             gw_cmd = [
-                sys.executable,
+                get_python_executable(),
                 "-m",
                 "areal.v2.training_service.gateway",
                 "--admin-api-key",
@@ -819,6 +821,67 @@ class GatewayTrainController:
     def onload(self) -> None:
         self._gateway_post("/onload")
 
+    def init_awex_adapter(self, meta_server_addr: str | None = None) -> None:
+        """Initialize the engine's AWEX adapter before colocated offload."""
+        self._ensure_initialized()
+        import requests
+
+        payload = {"meta_server_addr": meta_server_addr}
+
+        def post(url: str) -> None:
+            resp = requests.post(
+                f"{url}/awex/init_adapter",
+                json=payload,
+                timeout=max(float(self.config.request_timeout), 120.0),
+            )
+            resp.raise_for_status()
+
+        max_workers = min(len(self._worker_addrs), 64)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(post, self._worker_addrs))
+        logger.info(
+            "Initialized AWEX adapter on %d train workers (meta_server=%s)",
+            len(self._worker_addrs),
+            meta_server_addr,
+        )
+
+    def _awex_memory_transition(
+        self, endpoint: str, tags: list[str] | None = None
+    ) -> None:
+        self._ensure_initialized()
+        import requests
+
+        urls = list(self._worker_addrs)
+        if not urls:
+            return
+
+        timeout = max(float(self.config.request_timeout), 120.0)
+        payload = {"tags": tags}
+
+        def post(url: str) -> None:
+            resp = requests.post(
+                f"{url}/awex/{endpoint}",
+                json=payload,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+
+        max_workers = min(len(urls), 64)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(post, urls))
+        logger.info(
+            "AWEX %s completed on %d train workers (tags=%s)",
+            endpoint,
+            len(urls),
+            tags,
+        )
+
+    def awex_release_memory(self, tags: list[str] | None = None) -> None:
+        self._awex_memory_transition("release_memory", tags)
+
+    def awex_resume_memory(self, tags: list[str] | None = None) -> None:
+        self._awex_memory_transition("resume_memory", tags)
+
     def step_lr_scheduler(self) -> None:
         self._gateway_post("/step_lr_scheduler")
 
@@ -961,6 +1024,10 @@ class GatewayTrainController:
                 f"updates, got '{meta.type}'"
             )
 
+        weight_update_timeout = max(
+            float(self.config.request_timeout),
+            float(self.config.setup_timeout),
+        )
         ctrl = WeightUpdateController(
             WeightUpdateControllerConfig(
                 # Bind gateway to this node's outbound IP so cross-host
@@ -969,12 +1036,26 @@ class GatewayTrainController:
                 host=gethostip(),
                 admin_api_key=self.config.admin_api_key,
                 log_level=self.config.log_level,
+                setup_timeout=float(self.config.setup_timeout),
+                request_timeout=weight_update_timeout,
+                init_timeout_s=weight_update_timeout,
+                update_timeout_s=weight_update_timeout,
             )
         )
         ctrl.initialize()
 
         inference_urls: list[str] = rollout.inference_worker_urls
         pair_name = f"{self._role}-rollout"
+        colocate_env = os.environ.get("DTE_COLOCATE_WEIGHT_UPDATE")
+        if colocate_env is None or colocate_env.strip() == "":
+            colocate_env = os.environ.get("AWEX_COLOCATE_WEIGHT_UPDATE", "0")
+        colocate_enabled = colocate_env.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        self._colocate_weight_update = meta.type == "awex" and colocate_enabled
 
         if meta.type == "awex":
             # NCCL rendezvous master must live on the rank-0 process's node.
@@ -995,6 +1076,7 @@ class GatewayTrainController:
                 mode="awex",
                 nccl_master_addr=port_data["host"],
                 nccl_master_port=port_data["ports"][0],
+                colocate=self._colocate_weight_update,
             )
         else:  # disk
             ctrl.connect(
@@ -1009,10 +1091,12 @@ class GatewayTrainController:
             )
         self._weight_update_ctrl = ctrl
         logger.info(
-            "WeightUpdateController connected (pair=%s, train=%d, inf=%d)",
+            "WeightUpdateController connected (pair=%s, mode=%s, train=%d, inf=%d, colocate=%s)",
             pair_name,
+            meta.type,
             len(self._worker_addrs),
             len(inference_urls),
+            self._colocate_weight_update,
         )
 
     def update_weights(self, meta: Any) -> None:
@@ -1024,14 +1108,70 @@ class GatewayTrainController:
         assert meta.version is not None and meta.version > 0, (
             f"meta.version must be a positive integer, got {meta.version}"
         )
-        result = self._weight_update_ctrl.update_weights(version=meta.version)
-        self.rollout.continue_generation()
+        try:
+            result = self._weight_update_ctrl.update_weights(version=meta.version)
+        finally:
+            if self._colocate_weight_update:
+                import requests
+
+                for url in self._worker_addrs:
+                    resp = requests.post(
+                        f"{url}/awex/resume_memory",
+                        json={"tags": ["weights", "optimizer"]},
+                        timeout=120,
+                    )
+                    resp.raise_for_status()
+            # Colocated RL owns rollout onload/resume ordering in the trainer.
+            if not self._colocate_weight_update:
+                self.rollout.continue_generation()
         logger.info(
             "Weight update v%d completed (%s, %.0fms)",
             meta.version,
             result.status,
             result.duration_ms,
         )
+
+    async def _async_seed_delta_base(self, version: int) -> None:
+        if self.rollout is None:
+            raise RuntimeError(
+                "connect_engine() must be called before seed_delta_base()"
+            )
+        timeout = max(float(self.config.request_timeout), 120.0)
+        client = await self._get_async_client()
+        inference_urls: list[str] = self.rollout.inference_worker_urls
+
+        async def _post_seed(url: str) -> None:
+            resp = await client.post(
+                f"{url}/awex/seed_delta_base",
+                json={"version": version},
+                timeout=timeout,
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"{url}/awex/seed_delta_base returned "
+                    f"{resp.status_code}: {resp.text}"
+                )
+
+        await asyncio.gather(
+            *[_post_seed(url) for url in self._worker_addrs],
+            *[_post_seed(url) for url in inference_urls],
+        )
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        if self._weight_update_ctrl is None or self.rollout is None:
+            raise RuntimeError(
+                "connect_engine() must be called before seed_delta_base()"
+            )
+        if not self._colocate_weight_update:
+            logger.info("seed_delta_base skipped: colocate weight update disabled")
+            return
+
+        self.rollout.pause_generation()
+        try:
+            run_async_task(self._async_seed_delta_base, version)
+        finally:
+            self.rollout.continue_generation()
+        logger.info("Colocate delta base seeded at version %d", version)
 
     def prepare_batch(
         self,
@@ -1043,6 +1183,7 @@ class GatewayTrainController:
         dynamic_bs: bool = False,
         reward_normalization: bool = False,
         drop_incomplete_group: bool = False,
+        keep_partial_group_on_error: bool = False,
     ) -> list[dict[str, Any]]:
         if self.rollout is None:
             raise RuntimeError("connect_engine() must be called before prepare_batch()")
@@ -1055,6 +1196,7 @@ class GatewayTrainController:
             dynamic_bs=dynamic_bs,
             reward_normalization=reward_normalization,
             drop_incomplete_group=drop_incomplete_group,
+            keep_partial_group_on_error=keep_partial_group_on_error,
         )
 
     def rollout_batch(
@@ -1066,6 +1208,7 @@ class GatewayTrainController:
         group_size: int = 1,
         reward_normalization: bool = False,
         drop_incomplete_group: bool = False,
+        keep_partial_group_on_error: bool = False,
     ) -> list[dict[str, Any]]:
         if self.rollout is None:
             raise RuntimeError("connect_engine() must be called before rollout_batch()")
@@ -1077,6 +1220,7 @@ class GatewayTrainController:
             group_size=group_size,
             reward_normalization=reward_normalization,
             drop_incomplete_group=drop_incomplete_group,
+            keep_partial_group_on_error=keep_partial_group_on_error,
         )
 
     def create_process_group(self, parallel_strategy: ParallelStrategy | None = None):
@@ -1156,6 +1300,17 @@ class GatewayTrainController:
                 )
             except Exception:
                 logger.error("Failed to unregister model: %s", traceback.format_exc())
+
+        if self._weight_update_ctrl is not None:
+            try:
+                self._weight_update_ctrl.destroy()
+            except Exception:
+                logger.error(
+                    "Failed to destroy weight update controller: %s",
+                    traceback.format_exc(),
+                )
+            finally:
+                self._weight_update_ctrl = None
 
         self._graceful_shutdown_workers()
 

--- a/areal/v2/training_service/gateway/engine.py
+++ b/areal/v2/training_service/gateway/engine.py
@@ -77,6 +77,10 @@ def register_engine_routes(
             use_admin_auth_for_upstream=True,
         )
 
+    @app.post("/init_awex_adapter")
+    async def init_awex_adapter(request: Request):
+        return await _forward_post(request, "/init_awex_adapter", config)
+
     @app.post("/step_lr_scheduler")
     async def step_lr_scheduler(request: Request):
         return await _forward_post(request, "/step_lr_scheduler", config)

--- a/areal/v2/training_service/guard/__main__.py
+++ b/areal/v2/training_service/guard/__main__.py
@@ -4,12 +4,33 @@
 
 from __future__ import annotations
 
-from areal.infra.rpc.guard.app import (
+import os
+
+# Consume DTE_ACTOR_ALLOC_CONF before any torch/CUDA import. The submit
+# scripts cannot put PYTORCH_CUDA_ALLOC_CONF into actor.scheduling_spec
+# env_vars directly: rollout.scheduling_spec interpolates ${actor.scheduling_spec},
+# so the value would leak into the SGLang server env, where torch_memory_saver
+# rejects expandable_segments at startup. Only the train guard (this entrypoint)
+# applies it; forked engine workers inherit it.
+_alloc_conf = os.environ.get("DTE_ACTOR_ALLOC_CONF", "").strip()
+if _alloc_conf:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = _alloc_conf
+
+# Same per-role trick for NCCL_CUMEM_ENABLE. The shared yaml env sets it to 0
+# (SGLang side requires 0 with torch_memory_saver), but the actor needs cuMem
+# support when expandable_segments is on: NCCL collectives over VMM-backed
+# buffers with NCCL_CUMEM_ENABLE=0 hit cudaErrorIllegalAddress (observed at
+# awex colocate connect, first TP collective, run 0704_..._expseg2 937706).
+_nccl_cumem = os.environ.get("DTE_ACTOR_NCCL_CUMEM_ENABLE", "").strip()
+if _nccl_cumem:
+    os.environ["NCCL_CUMEM_ENABLE"] = _nccl_cumem
+
+from areal.infra.rpc.guard.app import (  # noqa: E402
     configure_state_from_args,
     make_base_parser,
     run_server,
 )
-from areal.v2.training_service.guard.app import _state, app
+from areal.v2.training_service.guard.app import _state, app  # noqa: E402
 
 
 def main() -> None:

--- a/areal/v2/training_service/worker/awex.py
+++ b/areal/v2/training_service/worker/awex.py
@@ -48,13 +48,39 @@ def create_awex_blueprint(
 
     @bp.route("/report_weight_meta", methods=["POST"])
     def report_weight_meta():
+        data = flask_module.request.get_json(silent=True) or {}
+        infer_conf = data.get("infer_conf")
+
         def action():
             adapter = _require_adapter()
+            if infer_conf is not None:
+                return adapter.get_weight_metadata(infer_conf=infer_conf)
             return adapter.get_weight_metadata()
 
         return run_endpoint(
             "report_weight_meta",
             lambda: submit_to_engine_thread("report_weight_meta", action),
+        )
+
+    @bp.route("/init_adapter", methods=["POST"])
+    def init_adapter():
+        data = flask_module.request.get_json(silent=True) or {}
+
+        def action():
+            engine = get_engine()
+            if engine is None:
+                raise RuntimeError("Engine not initialized")
+            init_fn = getattr(engine, "init_awex_adapter", None)
+            if not callable(init_fn):
+                raise RuntimeError(
+                    "Engine does not implement method 'init_awex_adapter'"
+                )
+            init_fn(meta_server_addr=data.get("meta_server_addr"))
+
+        return run_endpoint(
+            "init_adapter",
+            lambda: submit_to_engine_thread("init_adapter", action),
+            return_result=False,
         )
 
     @bp.route("/init_weights_update_group", methods=["POST"])
@@ -139,6 +165,38 @@ def create_awex_blueprint(
         return run_endpoint(
             "execute_colocate_weight_update",
             lambda: submit_to_engine_thread("execute_colocate_weight_update", action),
+            return_result=False,
+        )
+
+    @bp.route("/precompute_delta_masks", methods=["POST"])
+    def precompute_delta_masks():
+        data = flask_module.request.get_json(force=True)
+        version = data.get("version", 0)
+
+        def action():
+            adapter = _require_adapter()
+            fn = getattr(adapter, "precompute_delta_masks", None)
+            if fn is None:
+                return {"precomputed": False}
+            return {"precomputed": bool(fn(version))}
+
+        return run_endpoint(
+            "precompute_delta_masks",
+            lambda: submit_to_engine_thread("precompute_delta_masks", action),
+        )
+
+    @bp.route("/seed_delta_base", methods=["POST"])
+    def seed_delta_base():
+        data = flask_module.request.get_json(force=True)
+        version = data.get("version", 0)
+
+        def action():
+            adapter = _require_adapter()
+            adapter.seed_delta_base(version)
+
+        return run_endpoint(
+            "seed_delta_base",
+            lambda: submit_to_engine_thread("seed_delta_base", action),
             return_result=False,
         )
 

--- a/areal/v2/training_service/worker/engine.py
+++ b/areal/v2/training_service/worker/engine.py
@@ -180,6 +180,12 @@ def create_engine_module(
                 kwargs,
                 require_broadcast=True,
             )
+            engine = require_engine()
+            if engine.initialized and not engine.is_data_parallel_head():
+                # DataProxy only consumes DP-head results. Non-head ranks still
+                # execute the method for collectives, but remotizing their large
+                # tensor results stores unreachable shards in local _storage.
+                return None
             return RTensor.remotize(result, node_addr=get_node_addr())
 
         ep_name = (
@@ -261,6 +267,7 @@ def create_engine_module(
     _register_engine_route("/load", "load")
     _register_engine_route("/offload", "offload")
     _register_engine_route("/onload", "onload")
+    _register_engine_route("/init_awex_adapter", "init_awex_adapter")
     _register_engine_route("/optimizer_zero_grad", "optimizer_zero_grad")
     _register_engine_route("/optimizer_step", "optimizer_step")
     _register_engine_route("/step_lr_scheduler", "step_lr_scheduler")

--- a/areal/v2/weight_update/awex/__init__.py
+++ b/areal/v2/weight_update/awex/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import pickle
 from typing import Any
 
 import aiohttp  # pyright: ignore[reportMissingImports]
@@ -27,6 +28,7 @@ def awex_wu_use_group() -> bool:
 async def _fetch_kv_metadata(
     kv_store_url: str,
     pair_name: str,
+    timeout_s: float = 120.0,
 ) -> tuple[Any, Any]:
     """Fetch infer and training parameter metadata from the gateway KV store.
 
@@ -41,7 +43,8 @@ async def _fetch_kv_metadata(
     infer_url = f"{kv_store_url}/weight_meta/{pair_name}/infer_params_meta"
     train_url = f"{kv_store_url}/weight_meta/{pair_name}/training_params_meta"
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
 
         async def _get(url: str) -> Any:
             async with session.get(url) as resp:
@@ -54,10 +57,28 @@ async def _fetch_kv_metadata(
     return deserialize_value(infer_json), deserialize_value(train_json)
 
 
-def fetch_kv_metadata(kv_store_url: str, pair_name: str) -> tuple[Any, Any]:
+def fetch_kv_metadata(
+    kv_store_url: str,
+    pair_name: str,
+    timeout_s: float = 120.0,
+) -> tuple[Any, Any]:
     """Sync wrapper around :func:`_fetch_kv_metadata`.
 
     Bridges async ``aiohttp`` into the synchronous adapter context using
     :func:`~areal.infra.utils.concurrent.run_async_task`.
     """
-    return run_async_task(_fetch_kv_metadata, kv_store_url, pair_name)
+    return run_async_task(_fetch_kv_metadata, kv_store_url, pair_name, timeout_s)
+
+
+def load_kv_metadata_file(metadata_path: str) -> tuple[Any, Any]:
+    """Load serialized infer/train metadata from a colocate side-channel file."""
+    with open(metadata_path, "rb") as f:
+        payload = pickle.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid metadata file payload: {type(payload).__name__}")
+    try:
+        infer_json = payload["infer_params_meta"]
+        train_json = payload["training_params_meta"]
+    except KeyError as exc:
+        raise ValueError(f"Metadata file missing key: {exc}") from exc
+    return deserialize_value(infer_json), deserialize_value(train_json)

--- a/areal/v2/weight_update/awex/colocate_device.py
+++ b/areal/v2/weight_update/awex/colocate_device.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import re
+import socket
+
+
+def get_colocate_ip_address() -> str:
+    try:
+        from awex.util.common import get_ip_address
+
+        return str(get_ip_address())
+    except Exception:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect(("8.8.8.8", 80))
+                return sock.getsockname()[0]
+        except Exception:
+            return socket.gethostbyname(socket.gethostname())
+
+
+def get_physical_cuda_device_id(local_index: int | None = None) -> str:
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    visible_devices = [x.strip() for x in visible.split(",") if x.strip()]
+    if visible_devices:
+        if len(visible_devices) == 1:
+            return visible_devices[0]
+        if local_index is None:
+            try:
+                import torch
+
+                local_index = int(torch.cuda.current_device())
+            except Exception:
+                local_index = 0
+        if 0 <= local_index < len(visible_devices):
+            return visible_devices[local_index]
+
+    if local_index is not None:
+        return str(local_index)
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return str(torch.cuda.current_device())
+    except Exception:
+        pass
+    return "0"
+
+
+def device_mapping_key(ip_address: str, device_id: str) -> str:
+    raw = f"{ip_address}_{device_id}"
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", raw)

--- a/areal/v2/weight_update/awex/delta_config.py
+++ b/areal/v2/weight_update/awex/delta_config.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration gates + factories for colocate delta weight transfer.
+
+The delta algorithm itself lives in the standalone ``dte`` package; this module
+only decides *whether* and *how* the awex colocate adapters invoke it, and
+constructs the dte objects (with a clear error if dte is not installed). It
+accepts the new ``DTE_*`` runtime environment emitted from ``actor.dte.*`` CLI
+config, while preserving the old ``AWEX_*`` names as a compatibility fallback.
+
+dte is imported lazily inside the factories: a default AReaL install does not
+require dte unless ``DTE_DELTA_TRANSFER=1`` actually exercises a colocate
+transfer, OR the receiver detects a delta payload on the wire (see
+``payload_carries_delta``).
+
+Switches:
+    DTE_DELTA_TRANSFER        enable sparse incremental transfer (default off)
+    DTE_DELTA_ANCHOR_INTERVAL force a full sync every N deltas (0 = never)
+    DTE_DELTA_BYTES_RATIO     per-tensor sparse-vs-dense fallback threshold
+"""
+
+from __future__ import annotations
+
+import os
+
+_DTE_MISSING_MSG = (
+    "DTE_DELTA_TRANSFER=1 (or a delta payload on the wire) requires the 'dte' "
+    "package (delta-transfer-engine), which the awex colocate adapters import "
+    "lazily. Install it with `pip install -e <path>/delta-transfer-engine` "
+    "(local dev) or `uv sync --extra delta`."
+)
+
+# Mirror of ``dte.core.DELTA_HEADER_NAME`` so the receiver can detect a delta
+# payload WITHOUT importing dte (dte is an optional lazy dependency, and a plain
+# full-weight transfer must not require it). The factories below assert this
+# stays in sync with dte's own constant once dte is actually imported.
+DELTA_HEADER_NAME = "__awex_delta_header__"
+
+
+def _env_value(name: str, legacy_name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is not None and value.strip() != "":
+        return value
+    value = os.environ.get(legacy_name)
+    if value is not None and value.strip() != "":
+        return value
+    return default
+
+
+def _env_bool(name: str, legacy_name: str, default: bool = False) -> bool:
+    value = _env_value(name, legacy_name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def delta_transfer_enabled() -> bool:
+    """Master switch: enable sparse incremental colocate weight transfer."""
+    return _env_bool("DTE_DELTA_TRANSFER", "AWEX_DELTA_TRANSFER")
+
+
+def delta_anchor_interval() -> int:
+    """Force a full sync every N deltas (0 = never; rely on seed + chain-break)."""
+    return int(
+        _env_value(
+            "DTE_DELTA_ANCHOR_INTERVAL",
+            "AWEX_DELTA_ANCHOR_INTERVAL",
+            "0",
+        )
+    )
+
+
+def delta_bytes_ratio() -> float:
+    """Per-tensor sparse-vs-dense fallback threshold (bf16 break-even ~0.33)."""
+    return float(_env_value("DTE_DELTA_BYTES_RATIO", "AWEX_DELTA_BYTES_RATIO", "0.9"))
+
+
+def payload_carries_delta(names) -> bool:
+    """Whether a deserialized payload's names carry a dte delta header.
+
+    Lets the inference adapter defensively reconstruct a delta payload even when
+    its own ``DTE_DELTA_TRANSFER`` is unset (e.g. the env var did not propagate
+    to the sglang worker while the trainer enabled delta) — a mismatch would
+    otherwise feed the sparse ``...@delta_idx``/header names straight into the
+    weight apply and corrupt/crash it. Pure string check: never imports dte, so
+    plain full-weight transfers stay dte-free.
+    """
+    return DELTA_HEADER_NAME in names
+
+
+def _check_header_constant() -> None:
+    """Guard against ``DELTA_HEADER_NAME`` drifting from dte's own definition.
+
+    Called from the factories (dte already imported there). If dte ever renames
+    its wire header, this surfaces immediately instead of silently breaking
+    ``payload_carries_delta``'s dte-free detection.
+    """
+    from dte.core import DELTA_HEADER_NAME as _dte_name
+
+    if _dte_name != DELTA_HEADER_NAME:
+        raise RuntimeError(
+            f"delta_config.DELTA_HEADER_NAME ({DELTA_HEADER_NAME!r}) is out of "
+            f"sync with dte.core.DELTA_HEADER_NAME ({_dte_name!r}); update the "
+            f"mirror in delta_config.py."
+        )
+
+
+def make_delta_tracker():
+    """Sender-side dte ``DeltaTracker``, configured from env.
+
+    Raises a clear ``ImportError`` if dte is not installed.
+    """
+    try:
+        from dte.core import DeltaTracker
+    except ImportError as e:  # pragma: no cover - exercised only without dte
+        raise ImportError(_DTE_MISSING_MSG) from e
+    _check_header_constant()
+    return DeltaTracker(delta_anchor_interval(), delta_bytes_ratio())
+
+
+def make_delta_engine(device):
+    """Receiver-side dte ``DeltaEngine`` (transport-free, IPC-fed), from env.
+
+    Raises a clear ``ImportError`` if dte is not installed.
+    """
+    try:
+        from dte.engine import DeltaEngine
+    except ImportError as e:  # pragma: no cover - exercised only without dte
+        raise ImportError(_DTE_MISSING_MSG) from e
+    _check_header_constant()
+    return DeltaEngine(
+        transport=None,
+        mode="delta",
+        anchor_interval=delta_anchor_interval(),
+        sparse_bytes_ratio=delta_bytes_ratio(),
+        device=device,
+    )
+
+
+def cuda_mem_stats_mb(reset_peak: bool = True) -> tuple[float, float]:
+    """Return ``(allocated_mb, peak_mb)`` for the current CUDA device.
+
+    ``peak_mb`` is the high-water mark since the previous call (the peak
+    counter is reset afterwards by default), which lets [dte-perf] stage
+    marks attribute allocation spikes to individual weight-sync stages.
+    Returns ``(-1.0, -1.0)`` when CUDA is unavailable (CPU tests).
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        return -1.0, -1.0
+    allocated = torch.cuda.memory_allocated() / (1024.0 * 1024.0)
+    peak = torch.cuda.max_memory_allocated() / (1024.0 * 1024.0)
+    if reset_peak:
+        torch.cuda.reset_peak_memory_stats()
+    return allocated, peak

--- a/areal/v2/weight_update/awex/delta_detect.py
+++ b/areal/v2/weight_update/awex/delta_detect.py
@@ -1,0 +1,1951 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pluggable change detectors for AWEX colocate delta weight transfer.
+
+A *detector* answers one question each weight-update step: which bf16 elements
+of the converted HF payload changed since the previous version? It returns
+``{hf_name: bool mask | int32/int64 flat indices}`` consumed by
+``DeltaTracker.encode(masks=...)``.
+
+Implementations are selected by ``DTE_DELTA_DETECTOR``:
+
+- ``snapshot`` (fallback): the change mask comes from ``DeltaTracker``'s own CPU
+  bf16 baseline (a full-model snapshot). This detector is a no-op marker — it
+  returns ``None`` so the writer keeps using ``encode(masks=None)`` (the
+  snapshot path). Always available, no optimizer needed, but costs a resident
+  full-model CPU snapshot per rank.
+
+- ``inversion`` (design mainline, the actual win): reconstruct the *pre-step*
+  weights from the optimizer's resident AdamW moments (``exp_avg`` /
+  ``exp_avg_sq``) — **zero extra snapshot memory** — convert them to HF space,
+  and bitwise-compare against the current HF payload to get the masks.
+
+- ``dirty_bit`` (B2 integration point): consume optimizer-produced mcore shard
+  dirty bitsets and remap them to HF sparse-index masks. This detector is
+  default-off until a fused optimizer/kernel records complete per-step bitsets.
+
+AdamW inversion (decoupled AdamW, the mcore default):
+
+    theta_t = theta_{t-1}·(1 - lr·wd) - (lr/bc1)·m / (sqrt(v)/sqrt(bc2) + eps)
+
+is element-wise invertible because ``m=exp_avg`` / ``v=exp_avg_sq`` stay resident
+after ``optimizer.step()``:
+
+    theta_{t-1} = (theta_t + (lr/bc1)·m / (sqrt(v)/sqrt(bc2) + eps)) / (1 - lr·wd)
+
+with ``bc1 = 1 - beta1^step``, ``bc2 = 1 - beta2^step``.
+
+Megatron specifics (confirmed against mcore distrib_optimizer):
+
+- Moments live ONLY in mcore main-param space (HF space has QKV already split,
+  gate/expert converted) so the mask MUST be computed AFTER convert.
+- The distributed optimizer shards the fp32 main param + moments across DP, but
+  the FULL bf16 model param (theta_t) is resident on every DP rank (post-step
+  all-gather). So inversion is a per-rank, shard-local fp32 compute scattered
+  into a full-param buffer, then ONE DP all-reduce(SUM) of the *correction*
+  (zero outside the owned slice) assembles the full pre-step param.
+
+Hard gates (any failure -> return None -> writer ships dense this step):
+
+- ``use_precision_aware_optimizer`` (adam_bf16): moments are bf16/TE-fused, not
+  plain fp32 ``exp_avg`` -> inversion infeasible.
+- non-decoupled AdamW (L2-Adam folds wd into grad): the ``/(1-lr·wd)`` form is
+  wrong.
+- no reconstructable moment state for the whole step, or ``step < 1`` on every
+  usable shard (first step, recover): division blow-up. Per-param/per-rank
+  missing state contributes zeros to DP reduction so ranks do not deadlock.
+- compact per-shard fingerprints are only a guard for ``step`` unchanged or
+  missing-watermark recovery. A known one-step AdamW transition is always
+  reconstructed; the fingerprint is not trusted as proof of no payload change.
+- more than one distributed-optimizer instance: the DP group identity differs
+  from the all-gather group. Multiple optimizer DP topologies in one model are
+  allowed; MoE expert params can use a smaller expert-DP group while dense
+  params use the regular DP group, so reconstruction reduces each param on its
+  own optimizer DP group.
+
+Migration note (origin/gh AWEX): the detector now drives the new adapter's
+convert path — ``adapter._get_inner_optimizers()`` for the moments and
+``adapter._convert_hf_with_overrides(theta_by_id)`` to push reconstructed
+pre-step weights through the same all_gather + convert_to_hf as the live
+payload (the old awex ``_make_weight_converter`` / ``_convert_parameters_with``
+are gone). The mcore reconstruction below is GPU-only and must be validated on
+the cluster; ``dte.core.invert_adamw`` itself is CPU-unit-tested.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import torch
+
+from areal.utils import logging
+from areal.v2.weight_update.awex.delta_config import cuda_mem_stats_mb
+
+logger = logging.getLogger("AwexDeltaDetect")
+
+
+def _env_value(name: str, legacy_name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is not None and value.strip() != "":
+        return value
+    value = os.environ.get(legacy_name)
+    if value is not None and value.strip() != "":
+        return value
+    return default
+
+
+def _env_bool(name: str, legacy_name: str, default: bool = False) -> bool:
+    value = _env_value(name, legacy_name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+EXTERNAL_DELTA_DETECTOR_MODES = frozenset(
+    {"inversion", "dirty_bit", "dirty-bit", "bitset", "fused_dirty_bit"}
+)
+DIRTY_BIT_DETECTOR_MODES = frozenset(
+    {"dirty_bit", "dirty-bit", "bitset", "fused_dirty_bit"}
+)
+
+
+def delta_detector_mode() -> str:
+    """Return the configured detector mode."""
+    return (
+        (_env_value("DTE_DELTA_DETECTOR", "AWEX_DELTA_DETECTOR", "") or "")
+        .strip()
+        .lower()
+    )
+
+
+def _inversion_dense_param_suffixes() -> tuple[str, ...]:
+    """HF parameter suffixes sent dense under AdamW inversion.
+
+    Qwen3 MoE router/gate weights are small and have shown one-element BF16
+    false negatives during snapshot verification, so the conservative default
+    is to send ``.mlp.gate.weight`` densely.
+    """
+    if "DTE_DELTA_INVERSION_DENSE_PARAM_SUFFIXES" in os.environ:
+        value = os.environ["DTE_DELTA_INVERSION_DENSE_PARAM_SUFFIXES"]
+    elif "AWEX_DELTA_INVERSION_DENSE_PARAM_SUFFIXES" in os.environ:
+        value = os.environ["AWEX_DELTA_INVERSION_DENSE_PARAM_SUFFIXES"]
+    else:
+        value = ".mlp.gate.weight"
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _inversion_force_dense_param(name: str) -> bool:
+    return any(name.endswith(suffix) for suffix in _inversion_dense_param_suffixes())
+
+
+def external_delta_detector_enabled(mode: str | None = None) -> bool:
+    """Whether ``mode`` supplies masks outside DeltaTracker's snapshot diff."""
+    if mode is None:
+        mode = delta_detector_mode()
+    return mode.strip().lower() in EXTERNAL_DELTA_DETECTOR_MODES
+
+
+def dirty_bit_detector_enabled(mode: str | None = None) -> bool:
+    """Whether ``mode`` expects optimizer-emitted dirty bitsets."""
+    if mode is None:
+        mode = delta_detector_mode()
+    return mode.strip().lower() in DIRTY_BIT_DETECTOR_MODES
+
+
+def _inversion_debug_enabled() -> bool:
+    return _env_bool("DTE_DELTA_INVERSION_DEBUG", "AWEX_DELTA_INVERSION_DEBUG")
+
+
+def _zero_delta_fastpath_enabled() -> bool:
+    return _env_bool("DTE_DELTA_ZERO_FASTPATH", "AWEX_DELTA_ZERO_FASTPATH", True)
+
+
+def _inversion_allreduce_window_bytes() -> int:
+    """In-flight byte budget for pipelined inversion all-reduces.
+
+    The reconstruct loop posts per-param correction/status all-reduces with
+    ``async_op=True`` and only waits once this many correction bytes are in
+    flight. ``0`` restores the fully synchronous per-param path (A/B knob).
+    """
+    mb = float(
+        _env_value(
+            "DTE_INVERSION_ALLREDUCE_WINDOW_MB",
+            "AWEX_INVERSION_ALLREDUCE_WINDOW_MB",
+            "512",
+        )
+    )
+    return max(int(mb * 1024 * 1024), 0)
+
+
+def _inversion_compute_device(flat_t: torch.Tensor) -> torch.device:
+    """Device used for the AdamW-inversion elementwise math.
+
+    Colocate offloads the fp32 main shards and AdamW moments to CPU before the
+    weight sync runs, so deriving the compute device from ``main_shard`` makes
+    the whole inversion (invert_adamw + mask probes) run on the CPU: ~18s/step
+    for Qwen3-30B versus a few seconds of staged H2D copies. Default to the
+    visible payload's device (GPU under colocate) and stage the offloaded
+    operands there. Set DTE_INVERSION_COMPUTE_ON_CPU=1 to restore the legacy
+    behaviour of computing wherever the fp32 main shard lives.
+    """
+    if _env_bool("DTE_INVERSION_COMPUTE_ON_CPU", "AWEX_INVERSION_COMPUTE_ON_CPU"):
+        return torch.device("cpu")
+    return flat_t.device
+
+
+def _inversion_bf16_margin_rel() -> float:
+    return float(
+        _env_value(
+            "DTE_DELTA_INVERSION_BF16_MARGIN_REL",
+            "AWEX_DELTA_INVERSION_BF16_MARGIN_REL",
+            "1e-4",
+        )
+    )
+
+
+def _dist_rank(group=None) -> int:
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return -1
+    try:
+        return torch.distributed.get_rank(group=group)
+    except Exception:  # pragma: no cover - debug-only best effort
+        return -1
+
+
+def _dist_world_size(group=None) -> int:
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return 1
+    try:
+        return torch.distributed.get_world_size(group=group)
+    except Exception:  # pragma: no cover - debug-only best effort
+        return 1
+
+
+def _adamw_hparams(param_group: dict) -> tuple[float, float, float, float, float]:
+    """Extract (lr, weight_decay, beta1, beta2, eps) from a torch param_group."""
+    betas = param_group.get("betas", (0.9, 0.999))
+    beta1 = float(betas[0])
+    beta2 = float(betas[1])
+    if not param_group.get("bias_correction", True):
+        # Apex FusedAdam stores step on the param group and can disable bias
+        # correction there. invert_adamw uses beta**step only to compute those
+        # correction factors, so beta=0 gives bc1=bc2=1.
+        beta1 = 0.0
+        beta2 = 0.0
+    return (
+        float(param_group.get("_areal_last_step_lr", param_group["lr"])),
+        float(param_group.get("weight_decay", 0.0)),
+        beta1,
+        beta2,
+        float(param_group.get("eps", 1e-8)),
+    )
+
+
+def _resolve_offloaded_state_value(
+    state: dict, offloaded_state: dict, key: str
+) -> object | None:
+    """Return optimizer state value, following AwexMegatronAdapter offload slots."""
+    val = state.get(key)
+    if isinstance(val, torch.Tensor) and val.numel() == 0 and key in offloaded_state:
+        return offloaded_state[key]
+    return val
+
+
+def _state_step_value(state: dict, offloaded_state: dict) -> float | None:
+    step_val = _resolve_offloaded_state_value(state, offloaded_state, "step")
+    return _step_to_float(step_val)
+
+
+def _param_group_step_value(param_group: dict) -> float | None:
+    return _step_to_float(param_group.get("step"))
+
+
+def _step_to_float(step_val: object | None) -> float | None:
+    if step_val is None:
+        return None
+    if isinstance(step_val, torch.Tensor):
+        if step_val.numel() == 0:
+            return None
+        return float(step_val.item())
+    return float(step_val)
+
+
+@torch.no_grad()
+def _tensor_fingerprint(tensor: torch.Tensor) -> tuple:
+    """Small value fingerprint for a tensor slice, not a stored snapshot.
+
+    The detector uses this as a no-full-copy guard to decide whether a local
+    model-visible shard changed since the last successful sync. The actual delta
+    mask still comes from AdamW inversion; this fingerprint only prevents
+    replaying moments for a shard whose synced bf16 payload did not move.
+    """
+    data = tensor.detach().contiguous().view(torch.uint8).reshape(-1)
+    n = data.numel()
+    if n == 0:
+        return (str(tensor.dtype), 0, 0, 0, 0, 0)
+
+    bins = min(4096, n)
+    width = max(n // bins, 1)
+    head_n = bins * width
+    head = data[:head_n].reshape(bins, width)
+    bin_sums = head.sum(dim=1, dtype=torch.int64)
+    weights = torch.arange(1, bins + 1, device=data.device, dtype=torch.int64)
+    total = bin_sums.sum()
+    weighted = (bin_sums * weights).sum()
+    if head_n < n:
+        tail = data[head_n:].sum(dtype=torch.int64)
+        total = total + tail
+        weighted = weighted + tail * (bins + 1)
+
+    sample_count = min(16, n)
+    if sample_count == 1:
+        sample_idx = torch.zeros(1, device=data.device, dtype=torch.long)
+    else:
+        sample_idx = (
+            torch.arange(sample_count, device=data.device, dtype=torch.long)
+            * (n - 1)
+            // (sample_count - 1)
+        )
+    samples = data.index_select(0, sample_idx).to(torch.int64)
+    sample_weights = torch.arange(
+        1, sample_count + 1, device=data.device, dtype=torch.int64
+    )
+    sample_hash = (samples * sample_weights).sum()
+    return (
+        str(tensor.dtype),
+        n,
+        int(total.item()),
+        int(weighted.item()),
+        int(sample_hash.item()),
+        int(data[0].item()),
+        int(data[-1].item()),
+    )
+
+
+@torch.no_grad()
+def _bf16_rounding_boundary_mask(
+    old_fp32: torch.Tensor, cur_bf16: torch.Tensor
+) -> torch.Tensor:
+    """Conservatively include values near a BF16 rounding boundary."""
+    cur_fp32 = cur_bf16.to(torch.float32)
+    old_fp32 = old_fp32.to(torch.float32)
+
+    # BF16 bins are not symmetric at exponent boundaries: for example the lower
+    # neighbor of 1.0 is 0.99609375 while the upper neighbor is 1.0078125.  Using
+    # one spacing for both sides misses values close to the narrower boundary.
+    neg_inf = torch.full_like(cur_bf16, float("-inf"))
+    pos_inf = torch.full_like(cur_bf16, float("inf"))
+    lower = torch.nextafter(cur_bf16, neg_inf).to(torch.float32)
+    upper = torch.nextafter(cur_bf16, pos_inf).to(torch.float32)
+    lower_half_ulp = (cur_fp32 - lower).abs() * 0.5
+    upper_half_ulp = (upper - cur_fp32).abs() * 0.5
+    half_ulp = torch.where(old_fp32 < cur_fp32, lower_half_ulp, upper_half_ulp)
+    threshold = half_ulp * (1.0 - _inversion_bf16_margin_rel())
+    dist = (old_fp32 - cur_fp32).abs()
+    return torch.isfinite(old_fp32) & torch.isfinite(cur_fp32) & (dist >= threshold)
+
+
+class SnapshotDetector:
+    """No-op detector: defers change detection to ``DeltaTracker``'s snapshot.
+
+    ``compute_masks`` returns ``None`` so the writer calls ``encode(masks=None)``
+    (the verified snapshot path). Exists so the writer has one uniform call site
+    regardless of the configured detector.
+    """
+
+    name = "snapshot"
+
+    def compute_masks(self, names, tensors, version):  # noqa: ARG002
+        return None
+
+
+class DirtyBitsetDetector:
+    """Consume optimizer-produced dirty bitsets as HF sparse-index masks."""
+
+    name = "dirty_bit"
+
+    def __init__(self, adapter):
+        self._adapter = adapter
+        self._synced = False
+
+    def has_synced_watermark(self) -> bool:
+        return self._synced
+
+    def capture_synced_state(
+        self, payload_params: dict[str, torch.Tensor] | None = None
+    ):
+        del payload_params
+        return True
+
+    def mark_synced(self, version: int, captured_state=None) -> None:
+        del captured_state
+        self._synced = True
+        clear = getattr(self._adapter, "_clear_optimizer_dirty_bitsets", None)
+        if clear is not None:
+            clear(version)
+
+    def compute_masks(self, names, tensors, version):
+        build_masks = getattr(
+            self._adapter,
+            "_dirty_bitset_masks_from_optimizer",
+            None,
+        )
+        if build_masks is None:
+            logger.warning("Dirty-bit detector: adapter has no provider -> dense.")
+            return None
+        masks = build_masks(names, tensors, version)
+        if masks is None:
+            logger.warning("Dirty-bit detector: no complete bitsets -> dense.")
+        return masks
+
+
+class AdamWInversionDetector:
+    """Compute change masks by inverting the resident AdamW moments.
+
+    Bound to ``AwexMegatronAdapter`` (needs ``_get_inner_optimizers`` for the
+    moments and ``_convert_hf_with_overrides`` to convert reconstructed pre-step
+    params through the live path). All mcore/DP/convert work is GPU-only; any
+    unmet precondition returns ``None`` so the writer falls back to dense for
+    that step (and the snapshot tracker re-seeds), never silently corrupting.
+    """
+
+    name = "inversion"
+
+    def __init__(self, adapter):
+        self._adapter = adapter
+        # All watermark/fingerprint maps are keyed by the mcore param NAME, not
+        # id(param): on EP topologies the optimizer can hold different param
+        # OBJECTS than the live module traversal (observed d2p8e4: one DP
+        # replica's ids never match), and ids are also not stable across
+        # offload/reload cycles. Names are rank- and version-invariant.
+        self._last_synced_steps: dict[str, float | None] = {}
+        self._last_synced_fingerprints: dict[str, tuple] = {}
+        self._last_synced_model_fingerprints: dict[str, tuple] = {}
+        self._last_synced_payload_fingerprints: dict[str, tuple] = {}
+        # Single-slot cache filled by precompute_masks() before the colocate
+        # orchestration offloads the optimizer to CPU; consumed (or discarded)
+        # by the next compute_masks()/mark_synced() call.
+        self._precomputed_masks: (
+            tuple[int, tuple[str, ...], dict[str, torch.Tensor] | None] | None
+        ) = None
+
+    def has_synced_watermark(self) -> bool:
+        """Whether a successful full/delta payload sync recorded optimizer steps."""
+        return bool(self._last_synced_steps)
+
+    # -- gating ------------------------------------------------------------
+    def _inversion_feasible(self, inner_optimizers) -> bool:
+        """All hard gates from the design; any failure -> dense fallback."""
+        if not inner_optimizers:
+            logger.warning("Inversion: no inner optimizers; falling back to dense.")
+            return False
+        for opt in inner_optimizers:
+            base_opt = getattr(opt, "optimizer", opt)
+            adam_w_mode = getattr(base_opt, "adam_w_mode", None)
+            if adam_w_mode is not None and int(adam_w_mode) == 0:
+                logger.warning("Inversion: non-decoupled FusedAdam -> dense.")
+                return False
+            cfg = getattr(opt, "config", None)
+            if cfg is not None:
+                # adam_bf16 / precision-aware: moments are bf16 / TE-fused, not
+                # plain fp32 exp_avg -> inversion infeasible.
+                pa = getattr(
+                    cfg, "use_precision_aware_optimizer_no_fp8_or_ds_fp8", None
+                )
+                if pa is None:
+                    pa = getattr(cfg, "use_precision_aware_optimizer", False)
+                if pa:
+                    logger.warning("Inversion: use_precision_aware_optimizer -> dense.")
+                    return False
+                # decoupled AdamW: the (1-lr*wd) form requires decoupled wd.
+                if not getattr(cfg, "decoupled_weight_decay", True):
+                    logger.warning("Inversion: non-decoupled AdamW -> dense.")
+                    return False
+            # Single distributed-optimizer instance: otherwise the DP group
+            # identity differs from the param all-gather group (design risk #3).
+            n_inst = getattr(opt, "num_distributed_optimizer_instances", 1)
+            if n_inst and n_inst > 1:
+                logger.warning(
+                    "Inversion: %d distributed-optimizer instances -> dense.",
+                    n_inst,
+                )
+                return False
+        return True
+
+    def _module_param_key_maps(
+        self,
+    ) -> tuple[dict[int, str], dict[tuple[int, tuple], str]]:
+        """Map live module params to stable name keys, by id and (data_ptr, shape).
+
+        The (data_ptr, shape) index bridges optimizer-held param objects to the
+        module params when object identities diverge (observed on d2p8e4: one DP
+        replica's optimizer groups hold different objects than the module
+        traversal). Both views alias the same storage while weights are
+        resident, so the pointer identifies the tensor. Pointers are only valid
+        within one call (offload/reload reallocates storage) — never persist
+        them, only the derived names.
+        """
+        id2key: dict[int, str] = {}
+        ptr2key: dict[tuple[int, tuple], str] = {}
+        engine = getattr(self._adapter, "_engine", None)
+        if engine is None or getattr(engine, "model", None) is None:
+            return id2key, ptr2key
+        from areal.engine.megatron_utils.megatron import get_named_parameters
+
+        num_moe_experts = getattr(engine.tf_config, "num_moe_experts", None)
+        for name, param in get_named_parameters(engine.model, num_moe_experts):
+            id2key.setdefault(id(param), name)
+            try:
+                if param.data.numel() > 0:
+                    ptr2key.setdefault(
+                        (param.data.data_ptr(), tuple(param.shape)), name
+                    )
+            except RuntimeError:
+                pass  # released storage has no data_ptr
+        return id2key, ptr2key
+
+    @staticmethod
+    def _param_key(param, id2key, ptr2key) -> str | int | None:
+        key = id2key.get(id(param))
+        if key is not None:
+            return key
+        try:
+            if param.data.numel() > 0:
+                key = ptr2key.get((param.data.data_ptr(), tuple(param.shape)))
+                if key is not None:
+                    return key
+        except RuntimeError:
+            pass
+        if not id2key and not ptr2key:
+            return id(param)
+        return None
+
+    def _collect_current_steps(self, inner_optimizers) -> dict[str, float | None]:
+        """Return optimizer step watermarks keyed by mcore param name.
+
+        A value of ``None`` means this param had no local optimizer state when the
+        payload was synced. On the next step, ``None -> 1`` is still a valid
+        one-step transition.
+        """
+        steps: dict[str, float | None] = {}
+        id2key, ptr2key = self._module_param_key_maps()
+        offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+        for opt in inner_optimizers:
+            base_opt = getattr(opt, "optimizer", opt)
+            state = getattr(base_opt, "state", None)
+            group_index_map = getattr(opt, "model_param_group_index_map", None)
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if state is None or fp32_groups is None or model_groups is None:
+                continue
+            for g, (fp32_group, model_group) in enumerate(
+                zip(fp32_groups, model_groups)
+            ):
+                for main_shard, model_param in zip(fp32_group, model_group):
+                    if main_shard is None:
+                        continue
+                    key = self._param_key(model_param, id2key, ptr2key)
+                    if key is None or key in steps:
+                        continue
+                    gi = (
+                        group_index_map[model_param][0]
+                        if group_index_map is not None
+                        and model_param in group_index_map
+                        else g
+                    )
+                    st = state.get(main_shard)
+                    step = None
+                    if st:
+                        offloaded_state = offloaded_states.get(main_shard, {})
+                        step = _state_step_value(st, offloaded_state)
+                        if step is None:
+                            step = _param_group_step_value(base_opt.param_groups[gi])
+                    steps[key] = step
+        return steps
+
+    def _collect_current_fingerprints(self, inner_optimizers) -> dict[str, tuple]:
+        """Record compact fingerprints of model-visible local shards.
+
+        This is intentionally not a snapshot: it stores a few scalar values per
+        optimizer-owned shard, not tensor contents. The fingerprint gates AdamW
+        replay to slices whose synced payload actually changed.
+        """
+        fingerprints: dict[str, tuple] = {}
+        id2key, ptr2key = self._module_param_key_maps()
+        for opt in inner_optimizers:
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if fp32_groups is None or model_groups is None:
+                continue
+            for fp32_group, model_group in zip(fp32_groups, model_groups):
+                for main_shard, model_param in zip(fp32_group, model_group):
+                    if main_shard is None:
+                        continue
+                    key = self._param_key(model_param, id2key, ptr2key)
+                    if key is None or key in fingerprints:
+                        continue
+                    try:
+                        rng = opt._get_model_param_range_map(model_param)["param"]
+                    except Exception:
+                        continue
+                    visible_slice = model_param.detach().reshape(-1)[
+                        rng.start : rng.end
+                    ]
+                    fingerprints[key] = _tensor_fingerprint(visible_slice)
+        return fingerprints
+
+    def _ordered_model_params(self, fallback_order: list[torch.Tensor]):
+        iter_fn = getattr(self._adapter, "_iter_model_params_for_delta", None)
+        if iter_fn is not None:
+            params = list(iter_fn())
+            if params:
+                return params
+
+        ordered_model_params: list[torch.Tensor] = []
+        engine = getattr(self._adapter, "_engine", None)
+        if engine is not None and getattr(engine, "model", None) is not None:
+            from areal.engine.megatron_utils.megatron import get_named_parameters
+
+            num_moe_experts = getattr(engine.tf_config, "num_moe_experts", None)
+            seen_order: set[int] = set()
+            for _mcore_name, model_param in get_named_parameters(
+                engine.model, num_moe_experts
+            ):
+                pid = id(model_param)
+                if pid in seen_order:
+                    continue
+                ordered_model_params.append(model_param)
+                seen_order.add(pid)
+        else:
+            ordered_model_params = fallback_order
+        return ordered_model_params
+
+    def _collect_current_model_fingerprints(
+        self, fallback_order: list[torch.Tensor] | None = None
+    ) -> dict[str, tuple]:
+        fingerprints: dict[str, tuple] = {}
+        id2key, ptr2key = self._module_param_key_maps()
+        for model_param in self._ordered_model_params(fallback_order or []):
+            key = self._param_key(model_param, id2key, ptr2key)
+            if key is None or key in fingerprints:
+                continue
+            fingerprints[key] = _tensor_fingerprint(model_param.detach().reshape(-1))
+        return fingerprints
+
+    def _collect_payload_fingerprints(
+        self, payload_params: dict[str, torch.Tensor] | None = None
+    ) -> dict[str, tuple]:
+        if not payload_params:
+            return {}
+        return {
+            name: _tensor_fingerprint(tensor) for name, tensor in payload_params.items()
+        }
+
+    def _zero_delta_probe_candidate(self) -> bool:
+        """Whether the cheap zero-delta probe is worth running this step."""
+        if not _zero_delta_fastpath_enabled():
+            return False
+        update_successful = getattr(
+            self._adapter, "_last_optimizer_update_successful", None
+        )
+        if update_successful is False:
+            return True
+        grad_norm = getattr(self._adapter, "_last_optimizer_grad_norm", None)
+        return update_successful is True and grad_norm == 0.0
+
+    @staticmethod
+    def _empty_index_masks(names, tensors) -> dict[str, torch.Tensor]:
+        """Return zero-change external masks without allocating dense bool masks."""
+        return {
+            name: torch.empty(0, dtype=torch.int32, device=tensor.device)
+            for name, tensor in zip(names, tensors)
+        }
+
+    @staticmethod
+    def _mask_to_index_mask(mask: torch.Tensor) -> torch.Tensor:
+        """Convert a temporary bool mask into compact external flat indices."""
+        indices = mask.nonzero(as_tuple=False).squeeze(1)
+        if mask.numel() <= torch.iinfo(torch.int32).max:
+            return indices.to(torch.int32)
+        return indices
+
+    def capture_synced_state(
+        self, payload_params: dict[str, torch.Tensor] | None = None
+    ):
+        """Capture post-step watermarks while model weights are still resident."""
+        inner = self._adapter._get_inner_optimizers()
+        if not self._inversion_feasible(inner):
+            return None
+        return (
+            self._collect_current_steps(inner),
+            self._collect_current_fingerprints(inner),
+            self._collect_current_model_fingerprints(),
+            self._collect_payload_fingerprints(payload_params),
+        )
+
+    def mark_synced(self, version: int, captured_state=None) -> None:
+        """Record optimizer step watermarks after a successful payload sync.
+
+        AdamW inversion only reconstructs the most recent optimizer step. Without
+        this watermark, a later weight sync with no new optimizer step would replay
+        the previous step's moments and report false positives.
+        """
+        # Drop any unconsumed precompute cache (e.g. the sync took the
+        # full-sync branch and never called compute_masks).
+        self._precomputed_masks = None
+        if captured_state is None:
+            captured_state = self.capture_synced_state()
+        if captured_state is None:
+            self._last_synced_steps.clear()
+            self._last_synced_fingerprints.clear()
+            self._last_synced_model_fingerprints.clear()
+            self._last_synced_payload_fingerprints.clear()
+            return
+        if len(captured_state) == 3:
+            (
+                self._last_synced_steps,
+                self._last_synced_fingerprints,
+                self._last_synced_model_fingerprints,
+            ) = captured_state
+            self._last_synced_payload_fingerprints = {}
+        else:
+            (
+                self._last_synced_steps,
+                self._last_synced_fingerprints,
+                self._last_synced_model_fingerprints,
+                self._last_synced_payload_fingerprints,
+            ) = captured_state
+        known = len(self._last_synced_steps)
+        stepped = sum(
+            1 for step in self._last_synced_steps.values() if step is not None
+        )
+        max_step = max(
+            (step for step in self._last_synced_steps.values() if step is not None),
+            default=0.0,
+        )
+        logger.info(
+            "Inversion: recorded optimizer step watermark for %d params "
+            "at version %d (stepped=%d shard_fingerprints=%d "
+            "model_fingerprints=%d payload_fingerprints=%d max_step=%.0f)",
+            known,
+            version,
+            stepped,
+            len(self._last_synced_fingerprints),
+            len(self._last_synced_model_fingerprints),
+            len(self._last_synced_payload_fingerprints),
+            max_step,
+        )
+
+    # -- reconstruction (GPU-only) ----------------------------------------
+    @torch.no_grad()
+    def _reconstruct_pre_step_mcore(
+        self, inner_optimizers
+    ) -> dict[int, torch.Tensor] | None:
+        """Reconstruct theta_{t-1} for every model param the optimizer owns.
+
+        Returns ``{id(model_param): full bf16 pre-step tensor}`` or ``None`` if
+        no parameter has a usable global optimizer-state contribution.
+        """
+        from dte.core import invert_adamw
+
+        theta_old_by_id: dict[int, torch.Tensor] = {}
+        skipped_no_state = 0
+        skipped_bad_state = 0
+        skipped_global_no_state = 0
+        skipped_step_unchanged = 0
+        skipped_missing_watermark = 0
+        skipped_step_jump = 0
+        skipped_missing_fingerprint = 0
+        skipped_tracked_unchanged = 0
+        skipped_payload_changed_without_step = 0
+        skipped_untracked_non_optimizer = 0
+        skipped_changed_non_optimizer = 0
+        skipped_unchanged_non_optimizer = 0
+        skipped_partial_state = 0
+        unkeyed_opt_params = 0
+        force_dense = False
+        debug = _inversion_debug_enabled()
+        global_rank = _dist_rank()
+        id2key, ptr2key = self._module_param_key_maps()
+        # opt_entries is keyed by the stable mcore name (see _param_key): on EP
+        # topologies id(optimizer param) may never match id(module param), and
+        # any rank-local miss must not change which collectives this rank
+        # enters (P-deadlock 2026-07-04: half the ranks fell back to the
+        # default group while their peers used the expert group -> crossed
+        # communicators, all ranks spinning in the first expert-param
+        # all_reduce).
+        opt_entries: dict[object, tuple] = {}
+        fallback_order: list[torch.Tensor] = []
+        seen_fallback: set[int] = set()
+        default_dp_group = None
+        group_by_ranks: dict[tuple, object] = {}
+        for opt_idx, opt in enumerate(inner_optimizers):
+            base_opt = getattr(opt, "optimizer", opt)
+            state = getattr(base_opt, "state", None)
+            if state is None:
+                return None
+            group_index_map = getattr(opt, "model_param_group_index_map", None)
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if fp32_groups is None or model_groups is None:
+                return None
+            dp_group = getattr(opt, "data_parallel_group", None)
+            if default_dp_group is None:
+                default_dp_group = dp_group
+            if dp_group is not None:
+                # Canonicalize group OBJECTS by their actual global-rank
+                # membership: distinct communicators with identical members
+                # must collapse to one object, or peers end up posting the
+                # same logical reduce on different NCCL comms.
+                try:
+                    ranks_key = tuple(
+                        torch.distributed.get_process_group_ranks(dp_group)
+                    )
+                except Exception:
+                    ranks_key = (
+                        "sig",
+                        _dist_rank(dp_group),
+                        _dist_world_size(dp_group),
+                    )
+                group_by_ranks.setdefault(ranks_key, dp_group)
+            if debug:
+                logger.info(
+                    "Inversion debug: rank=%d opt=%d dp_rank=%d/%d "
+                    "fp32_groups=%d model_groups=%d state=%d",
+                    global_rank,
+                    opt_idx,
+                    _dist_rank(dp_group),
+                    _dist_world_size(dp_group),
+                    len(fp32_groups),
+                    len(model_groups),
+                    len(state),
+                )
+            offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+            for g, (fp32_group, model_group) in enumerate(
+                zip(fp32_groups, model_groups)
+            ):
+                if debug:
+                    logger.info(
+                        "Inversion debug: rank=%d opt=%d group=%d "
+                        "fp32_len=%d model_len=%d",
+                        global_rank,
+                        opt_idx,
+                        g,
+                        len(fp32_group),
+                        len(model_group),
+                    )
+                for i, (main_shard, model_param) in enumerate(
+                    zip(fp32_group, model_group)
+                ):
+                    if main_shard is None:
+                        # precision-aware sentinel (should be gated out already)
+                        return None
+                    pid = id(model_param)
+                    if pid not in seen_fallback:
+                        fallback_order.append(model_param)
+                        seen_fallback.add(pid)
+                    key = self._param_key(model_param, id2key, ptr2key)
+                    if key is None:
+                        unkeyed_opt_params += 1
+                        continue
+                    if key in opt_entries:
+                        continue
+                    gi = (
+                        group_index_map[model_param][0]
+                        if group_index_map is not None
+                        and model_param in group_index_map
+                        else g
+                    )
+                    opt_entries[key] = (
+                        opt_idx,
+                        opt,
+                        base_opt,
+                        state,
+                        main_shard,
+                        gi,
+                        model_param,
+                    )
+
+        # Resolve the reduce group(s) once, rank-invariantly. A param's group
+        # must NEVER depend on whether THIS rank found an optimizer entry.
+        expert_group = None
+        if len(group_by_ranks) <= 1:
+            canonical_group = (
+                next(iter(group_by_ranks.values()))
+                if group_by_ranks
+                else default_dp_group
+            )
+        elif len(group_by_ranks) == 2:
+            dense_ranks = None
+            try:
+                from megatron.core import parallel_state as mpu
+
+                try:
+                    dense_group = mpu.get_data_parallel_group(
+                        with_context_parallel=True
+                    )
+                except TypeError:
+                    dense_group = mpu.get_data_parallel_group()
+                dense_ranks = tuple(
+                    torch.distributed.get_process_group_ranks(dense_group)
+                )
+            except Exception:
+                dense_ranks = None
+            if dense_ranks is None or dense_ranks not in group_by_ranks:
+                try:
+                    dense_ranks = tuple(
+                        torch.distributed.get_process_group_ranks(default_dp_group)
+                    )
+                except Exception:
+                    dense_ranks = next(iter(group_by_ranks.keys()))
+            canonical_group = group_by_ranks.get(dense_ranks, default_dp_group)
+            expert_group = next(
+                (grp for k, grp in group_by_ranks.items() if k != dense_ranks),
+                None,
+            )
+        else:
+            logger.warning(
+                "Inversion: %d distinct DP replica sets; only dense+expert "
+                "are supported -> dense.",
+                len(group_by_ranks),
+            )
+            return None
+        logger.info(
+            "Inversion: canonical DP groups resolved (replica_sets=%d "
+            "expert_split=%s entries=%d unkeyed_opt_params=%d)",
+            len(group_by_ranks),
+            expert_group is not None,
+            len(opt_entries),
+            unkeyed_opt_params,
+        )
+
+        ordered_model_params = self._ordered_model_params(fallback_order)
+
+        if debug:
+            logger.info(
+                "Inversion debug: rank=%d ordered_params=%d opt_entries=%d",
+                global_rank,
+                len(ordered_model_params),
+                len(opt_entries),
+            )
+
+        if not ordered_model_params:
+            return None
+
+        offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+
+        # Post-reduce finalization, shared by the synchronous and pipelined
+        # paths. Runs strictly in parameter order on every rank; only local
+        # classification happens here so draining order can never diverge
+        # across ranks.
+        def _finalize_reduced(ctx) -> None:
+            nonlocal force_dense
+            nonlocal skipped_no_state, skipped_global_no_state
+            nonlocal skipped_partial_state, skipped_untracked_non_optimizer
+            nonlocal skipped_changed_non_optimizer
+            nonlocal skipped_unchanged_non_optimizer
+            (
+                param_idx,
+                model_param,
+                param_key,
+                entry,
+                rng,
+                expected_one_step,
+                has_local_update,
+                flat_t,
+                theta_t_full,
+                correction,
+                status,
+                dp_group,
+            ) = ctx
+            # Single host sync for all three counters (was 3x .item()).
+            status_vals = status.tolist()
+            if debug:
+                logger.info(
+                    "Inversion debug: rank=%d param_idx=%d post_reduce "
+                    "contrib=%d bad=%d",
+                    global_rank,
+                    param_idx,
+                    int(status_vals[0]),
+                    int(status_vals[1]),
+                )
+            if int(status_vals[1]) != 0:
+                force_dense = True
+                return
+            if int(status_vals[0]) == 0:
+                # No DP rank could reconstruct this param. For a known one-step
+                # AdamW transition that is unsafe: current-vs-current would hide
+                # a real update, so fall back to dense. If this rank had no
+                # optimizer entry at all, only now (after the DP all-reduce)
+                # classify it as a true non-AdamW payload tensor; a different DP
+                # rank may have owned and contributed the optimizer shard.
+                if entry is None:
+                    last_model_fingerprint = (
+                        self._last_synced_model_fingerprints.get(param_key)
+                        if param_key is not None
+                        else None
+                    )
+                    if last_model_fingerprint is None:
+                        skipped_untracked_non_optimizer += 1
+                    elif _tensor_fingerprint(flat_t) != last_model_fingerprint:
+                        skipped_changed_non_optimizer += 1
+                        force_dense = True
+                    else:
+                        skipped_unchanged_non_optimizer += 1
+                else:
+                    skipped_global_no_state += 1
+                    if expected_one_step:
+                        force_dense = True
+                return
+            covered = int(status_vals[2])
+            if covered != flat_t.numel():
+                # Some DP rank's owned state slice is missing (unkeyed entry or
+                # unusable state on that rank). theta_old would silently equal
+                # theta_t on the uncovered slice and hide real updates there —
+                # never ship a sparse delta built from partial coverage.
+                skipped_partial_state += 1
+                if debug and skipped_partial_state <= 8:
+                    slice_start = -1 if rng is None else rng.start
+                    slice_end = -1 if rng is None else rng.end
+                    logger.warning(
+                        "Inversion debug: partial optimizer coverage "
+                        "rank=%d param_idx=%d key=%s shape=%s covered=%d "
+                        "numel=%d local_slice=%d:%d dp_rank=%d/%d "
+                        "local_update=%d force_dense=%d",
+                        global_rank,
+                        param_idx,
+                        param_key,
+                        tuple(theta_t_full.shape),
+                        covered,
+                        flat_t.numel(),
+                        slice_start,
+                        slice_end,
+                        _dist_rank(dp_group),
+                        _dist_world_size(dp_group),
+                        int(has_local_update),
+                        int(force_dense),
+                    )
+                force_dense = True
+                return
+            theta_old_full = (flat_t.to(torch.float32) + correction).reshape(
+                theta_t_full.shape
+            )
+            theta_old_by_id[id(model_param)] = theta_old_full
+
+        # Pipelined all-reduce window: post async reduces and only drain once
+        # this many correction bytes are in flight. Collective ORDER is
+        # identical to the synchronous path on every rank; only completion is
+        # overlapped ([dte-perf] showed ~18s of reconstruct dominated by
+        # serialized per-param reduce + 3x .item() sync round-trips).
+        window_bytes = _inversion_allreduce_window_bytes()
+        pending: list[tuple] = []
+        pending_bytes = 0
+
+        def _drain_one_pending() -> None:
+            nonlocal pending_bytes
+            ctx, work_c, work_s = pending.pop(0)
+            correction = ctx[9]
+            pending_bytes -= correction.numel() * correction.element_size()
+            work_c.wait()
+            work_s.wait()
+            _finalize_reduced(ctx)
+
+        for param_idx, model_param in enumerate(ordered_model_params):
+            param_key = self._param_key(model_param, id2key, ptr2key)
+            entry = opt_entries.get(param_key) if param_key is not None else None
+            # Group choice is a pure function of the (rank-invariant) param
+            # name — never of local entry state.
+            if (
+                expert_group is not None
+                and isinstance(param_key, str)
+                and (".experts." in param_key)
+            ):
+                dp_group = expert_group
+            else:
+                dp_group = canonical_group
+            # theta_t for the full param is resident on every DP rank.
+            theta_t_full = model_param.detach()
+            flat_t = theta_t_full.reshape(-1)
+            # Every DP rank must enter the same collectives for every model
+            # param in the same order. Ranks without a usable local optimizer
+            # shard contribute an all-zero correction and a zero contribution
+            # count; ranks with moments fill only their owned slice.
+            correction = torch.zeros_like(flat_t, dtype=torch.float32)
+            has_local_update = False
+            expected_one_step = False
+            rng = None
+            opt_idx = -1
+            if entry is None:
+                skipped_no_state += 1
+            else:
+                opt_idx, opt, base_opt, state, main_shard, gi, opt_model_param = entry
+                rng = opt._get_model_param_range_map(opt_model_param)["param"]
+                st = state.get(main_shard)
+                offloaded_state = offloaded_states.get(main_shard, {}) if st else {}
+                step = _state_step_value(st, offloaded_state) if st else None
+                if step is None:
+                    step = _param_group_step_value(base_opt.param_groups[gi])
+                if step is None or step < 1:
+                    skipped_bad_state += 1
+                elif param_key is None or param_key not in self._last_synced_steps:
+                    skipped_missing_watermark += 1
+                    force_dense = True
+                else:
+                    last_step = self._last_synced_steps[param_key]
+                    baseline_step = 0.0 if last_step is None else last_step
+                    step_delta = step - baseline_step
+                    if step_delta == 0:
+                        last_fingerprint = self._last_synced_fingerprints.get(param_key)
+                        if last_fingerprint is not None and (
+                            _tensor_fingerprint(flat_t[rng.start : rng.end])
+                            != last_fingerprint
+                        ):
+                            skipped_payload_changed_without_step += 1
+                            force_dense = True
+                        else:
+                            skipped_step_unchanged += 1
+                    elif step_delta != 1:
+                        skipped_step_jump += 1
+                        force_dense = True
+                    else:
+                        expected_one_step = True
+                        last_fingerprint = self._last_synced_fingerprints.get(param_key)
+                        if last_fingerprint is None:
+                            skipped_missing_fingerprint += 1
+                            force_dense = True
+                        elif not st or "exp_avg" not in st or "exp_avg_sq" not in st:
+                            # A rank may not own this shard in Megatron's
+                            # distributed optimizer; do not force dense locally.
+                            # If no DP rank contributes below, the global status
+                            # check will fall back to dense.
+                            skipped_bad_state += 1
+                        else:
+                            exp_avg = _resolve_offloaded_state_value(
+                                st, offloaded_state, "exp_avg"
+                            )
+                            exp_avg_sq = _resolve_offloaded_state_value(
+                                st, offloaded_state, "exp_avg_sq"
+                            )
+                            main_flat = main_shard.detach().reshape(-1)
+                            if (
+                                not isinstance(exp_avg, torch.Tensor)
+                                or not isinstance(exp_avg_sq, torch.Tensor)
+                                or exp_avg.numel() == 0
+                                or exp_avg_sq.numel() == 0
+                                or exp_avg.numel() != main_flat.numel()
+                                or exp_avg_sq.numel() != main_flat.numel()
+                            ):
+                                skipped_bad_state += 1
+                            else:
+                                lr, wd, b1, b2, eps = _adamw_hparams(
+                                    base_opt.param_groups[gi]
+                                )
+                                # The fp32 main shard and moments may be
+                                # offloaded to CPU under colocate; stage them on
+                                # the inversion compute device (the visible
+                                # payload's device by default) so invert_adamw
+                                # runs on GPU instead of the CPU. Inversion
+                                # still uses the exact post-step optimizer
+                                # weight, not the bf16 model copy. Keep the
+                                # reconstructed previous value in fp32 until
+                                # mask creation so boundary-near BF16 roundoff
+                                # is handled conservatively.
+                                dev = _inversion_compute_device(flat_t)
+                                theta_t_slice = main_flat.to(
+                                    device=dev, dtype=torch.float32
+                                )
+                                theta_old_slice = invert_adamw(
+                                    theta_t_slice,
+                                    exp_avg.to(device=dev, dtype=torch.float32).reshape(
+                                        -1
+                                    ),
+                                    exp_avg_sq.to(
+                                        device=dev, dtype=torch.float32
+                                    ).reshape(-1),
+                                    step,
+                                    lr,
+                                    wd,
+                                    b1,
+                                    b2,
+                                    eps,
+                                )
+                                visible_slice = flat_t[rng.start : rng.end]
+                                visible_fp32 = visible_slice.to(
+                                    device=theta_old_slice.device,
+                                    dtype=torch.float32,
+                                )
+                                correction[rng.start : rng.end] = (
+                                    theta_old_slice - visible_fp32
+                                ).to(
+                                    device=correction.device,
+                                    dtype=correction.dtype,
+                                )
+                                has_local_update = True
+
+            owned_numel = (
+                int(rng.end - rng.start) if has_local_update and rng is not None else 0
+            )
+            status = torch.tensor(
+                [
+                    1 if has_local_update else 0,
+                    1 if force_dense else 0,
+                    owned_numel,
+                ],
+                dtype=torch.int64,
+                device=flat_t.device,
+            )
+            if debug:
+                slice_start = -1 if rng is None else rng.start
+                slice_end = -1 if rng is None else rng.end
+                logger.info(
+                    "Inversion debug: rank=%d param_idx=%d opt=%d "
+                    "pre_reduce numel=%d slice=%d:%d local=%d",
+                    global_rank,
+                    param_idx,
+                    opt_idx,
+                    flat_t.numel(),
+                    slice_start,
+                    slice_end,
+                    int(has_local_update),
+                )
+            ctx = (
+                param_idx,
+                model_param,
+                param_key,
+                entry,
+                rng,
+                expected_one_step,
+                has_local_update,
+                flat_t,
+                theta_t_full,
+                correction,
+                status,
+                dp_group,
+            )
+            if dp_group is None:
+                _finalize_reduced(ctx)
+            elif window_bytes <= 0:
+                torch.distributed.all_reduce(
+                    correction,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                )
+                torch.distributed.all_reduce(
+                    status,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                )
+                _finalize_reduced(ctx)
+            else:
+                work_c = torch.distributed.all_reduce(
+                    correction,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                    async_op=True,
+                )
+                work_s = torch.distributed.all_reduce(
+                    status,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                    async_op=True,
+                )
+                pending.append((ctx, work_c, work_s))
+                pending_bytes += correction.numel() * correction.element_size()
+                while pending and pending_bytes > window_bytes:
+                    _drain_one_pending()
+        while pending:
+            _drain_one_pending()
+        if force_dense:
+            logger.warning(
+                "Inversion: optimizer step replay is ambiguous "
+                "(missing_watermark=%d step_jump=%d missing_fingerprint=%d "
+                "payload_changed_without_step=%d "
+                "untracked_non_optimizer=%d changed_non_optimizer=%d "
+                "partial_state=%d unkeyed_opt_params=%d) "
+                "-> dense.",
+                skipped_missing_watermark,
+                skipped_step_jump,
+                skipped_missing_fingerprint,
+                skipped_payload_changed_without_step,
+                skipped_untracked_non_optimizer,
+                skipped_changed_non_optimizer,
+                skipped_partial_state,
+                unkeyed_opt_params,
+            )
+            return None
+        if not theta_old_by_id:
+            logger.info(
+                "Inversion: no BF16 payload shard changed since last sync "
+                "(step_unchanged=%d tracked_unchanged=%d no_state=%d "
+                "bad_state=%d global_no_state=%d "
+                "unchanged_non_optimizer=%d)",
+                skipped_step_unchanged,
+                skipped_tracked_unchanged,
+                skipped_no_state,
+                skipped_bad_state,
+                skipped_global_no_state,
+                skipped_unchanged_non_optimizer,
+            )
+            return {}
+        if (
+            skipped_no_state
+            or skipped_bad_state
+            or skipped_global_no_state
+            or skipped_step_unchanged
+            or skipped_tracked_unchanged
+            or skipped_missing_fingerprint
+            or skipped_payload_changed_without_step
+            or skipped_unchanged_non_optimizer
+        ):
+            logger.info(
+                "Inversion: reconstructed %d params, skipped no_state=%d "
+                "bad_state=%d global_no_state=%d step_unchanged=%d "
+                "tracked_unchanged=%d missing_fingerprint=%d "
+                "payload_changed_without_step=%d "
+                "unchanged_non_optimizer=%d",
+                len(theta_old_by_id),
+                skipped_no_state,
+                skipped_bad_state,
+                skipped_global_no_state,
+                skipped_step_unchanged,
+                skipped_tracked_unchanged,
+                skipped_missing_fingerprint,
+                skipped_payload_changed_without_step,
+                skipped_unchanged_non_optimizer,
+            )
+        return theta_old_by_id
+
+    @torch.no_grad()
+    def _probe_bf16_payload_unchanged(self, inner_optimizers) -> bool:
+        """Return True if optimizer shards prove the BF16 payload is unchanged.
+
+        This is a zero-delta fast path for steps such as zero-reward RL batches:
+        AdamW may still update fp32 main params through weight decay, but if the
+        resulting BF16 model-visible shard is bitwise unchanged on every owner
+        rank, the HF-converted payload must also be unchanged.  The probe never
+        emits sparse masks for dirty params; any dirty or ambiguous shard falls
+        back to the full AdamW-inversion path.
+        """
+        from dte.core import bitwise_changed_mask, invert_adamw
+
+        perf_start = time.monotonic()
+        checked_params = 0
+        skipped_step_unchanged = 0
+        skipped_unchanged_non_optimizer = 0
+        fingerprint_dirty = 0
+        force_dense_reasons = 0
+        unkeyed_opt_params = 0
+        global_rank = _dist_rank()
+        debug = _inversion_debug_enabled()
+        id2key, ptr2key = self._module_param_key_maps()
+        opt_entries: dict[object, tuple] = {}
+        fallback_order: list[torch.Tensor] = []
+        seen_fallback: set[int] = set()
+        default_dp_group = None
+        group_by_ranks: dict[tuple, object] = {}
+
+        for opt_idx, opt in enumerate(inner_optimizers):
+            base_opt = getattr(opt, "optimizer", opt)
+            state = getattr(base_opt, "state", None)
+            if state is None:
+                return False
+            group_index_map = getattr(opt, "model_param_group_index_map", None)
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if fp32_groups is None or model_groups is None:
+                return False
+            dp_group = getattr(opt, "data_parallel_group", None)
+            if default_dp_group is None:
+                default_dp_group = dp_group
+            if dp_group is not None:
+                try:
+                    ranks_key = tuple(
+                        torch.distributed.get_process_group_ranks(dp_group)
+                    )
+                except Exception:
+                    ranks_key = (
+                        "sig",
+                        _dist_rank(dp_group),
+                        _dist_world_size(dp_group),
+                    )
+                group_by_ranks.setdefault(ranks_key, dp_group)
+            offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+            for g, (fp32_group, model_group) in enumerate(
+                zip(fp32_groups, model_groups)
+            ):
+                for main_shard, model_param in zip(fp32_group, model_group):
+                    if main_shard is None:
+                        return False
+                    pid = id(model_param)
+                    if pid not in seen_fallback:
+                        fallback_order.append(model_param)
+                        seen_fallback.add(pid)
+                    key = self._param_key(model_param, id2key, ptr2key)
+                    if key is None:
+                        unkeyed_opt_params += 1
+                        continue
+                    if key in opt_entries:
+                        continue
+                    gi = (
+                        group_index_map[model_param][0]
+                        if group_index_map is not None
+                        and model_param in group_index_map
+                        else g
+                    )
+                    opt_entries[key] = (
+                        opt_idx,
+                        opt,
+                        base_opt,
+                        state,
+                        main_shard,
+                        gi,
+                        model_param,
+                        offloaded_states,
+                    )
+
+        expert_group = None
+        if len(group_by_ranks) <= 1:
+            canonical_group = (
+                next(iter(group_by_ranks.values()))
+                if group_by_ranks
+                else default_dp_group
+            )
+        elif len(group_by_ranks) == 2:
+            dense_ranks = None
+            try:
+                from megatron.core import parallel_state as mpu
+
+                dense_ranks = tuple(
+                    torch.distributed.get_process_group_ranks(
+                        mpu.get_data_parallel_group()
+                    )
+                )
+            except Exception:
+                dense_ranks = None
+            if dense_ranks is None or dense_ranks not in group_by_ranks:
+                try:
+                    dense_ranks = tuple(
+                        torch.distributed.get_process_group_ranks(default_dp_group)
+                    )
+                except Exception:
+                    dense_ranks = next(iter(group_by_ranks.keys()))
+            canonical_group = group_by_ranks.get(dense_ranks, default_dp_group)
+            expert_group = next(
+                (grp for k, grp in group_by_ranks.items() if k != dense_ranks),
+                None,
+            )
+        else:
+            return False
+
+        ordered_model_params = self._ordered_model_params(fallback_order)
+        if not ordered_model_params:
+            return False
+
+        for param_idx, model_param in enumerate(ordered_model_params):
+            checked_params += 1
+            param_key = self._param_key(model_param, id2key, ptr2key)
+            entry = opt_entries.get(param_key) if param_key is not None else None
+            if (
+                expert_group is not None
+                and isinstance(param_key, str)
+                and (".experts." in param_key)
+            ):
+                dp_group = expert_group
+            else:
+                dp_group = canonical_group
+
+            flat_t = model_param.detach().reshape(-1)
+            accounted_numel = 0
+            local_dirty = False
+            local_dirty_reason = ""
+            local_force_dense = False
+            expected_one_step = False
+            rng = None
+            opt_idx = -1
+
+            if entry is None:
+                pass
+            else:
+                (
+                    opt_idx,
+                    opt,
+                    base_opt,
+                    state,
+                    main_shard,
+                    gi,
+                    opt_model_param,
+                    offloaded_states,
+                ) = entry
+                rng = opt._get_model_param_range_map(opt_model_param)["param"]
+                st = state.get(main_shard)
+                offloaded_state = offloaded_states.get(main_shard, {}) if st else {}
+                step = _state_step_value(st, offloaded_state) if st else None
+                if step is None:
+                    step = _param_group_step_value(base_opt.param_groups[gi])
+                if step is None or step < 1:
+                    local_force_dense = True
+                elif param_key is None or param_key not in self._last_synced_steps:
+                    local_force_dense = True
+                else:
+                    last_step = self._last_synced_steps[param_key]
+                    baseline_step = 0.0 if last_step is None else last_step
+                    step_delta = step - baseline_step
+                    visible_slice = flat_t[rng.start : rng.end]
+                    accounted_numel = int(rng.end - rng.start)
+                    if step_delta == 0:
+                        last_fingerprint = self._last_synced_fingerprints.get(param_key)
+                        if last_fingerprint is not None and (
+                            _tensor_fingerprint(visible_slice) != last_fingerprint
+                        ):
+                            local_force_dense = True
+                        else:
+                            skipped_step_unchanged += 1
+                    elif step_delta != 1:
+                        local_force_dense = True
+                    else:
+                        expected_one_step = True
+                        last_fingerprint = self._last_synced_fingerprints.get(param_key)
+                        if last_fingerprint is None:
+                            local_force_dense = True
+                        elif _tensor_fingerprint(visible_slice) != last_fingerprint:
+                            # A changed model-visible BF16 shard is already
+                            # enough to disprove the zero-delta fast path.
+                            # Avoid reconstructing theta_{t-1} just to return
+                            # dirty for the common miss case.
+                            local_dirty = True
+                            local_dirty_reason = "fingerprint"
+                            fingerprint_dirty += 1
+                        elif not st or "exp_avg" not in st or "exp_avg_sq" not in st:
+                            local_force_dense = True
+                        else:
+                            exp_avg = _resolve_offloaded_state_value(
+                                st, offloaded_state, "exp_avg"
+                            )
+                            exp_avg_sq = _resolve_offloaded_state_value(
+                                st, offloaded_state, "exp_avg_sq"
+                            )
+                            main_flat = main_shard.detach().reshape(-1)
+                            if (
+                                not isinstance(exp_avg, torch.Tensor)
+                                or not isinstance(exp_avg_sq, torch.Tensor)
+                                or exp_avg.numel() == 0
+                                or exp_avg_sq.numel() == 0
+                                or exp_avg.numel() != main_flat.numel()
+                                or exp_avg_sq.numel() != main_flat.numel()
+                            ):
+                                local_force_dense = True
+                            else:
+                                lr, wd, b1, b2, eps = _adamw_hparams(
+                                    base_opt.param_groups[gi]
+                                )
+                                # Stage offloaded operands on the inversion
+                                # compute device (see reconstruct loop above).
+                                dev = _inversion_compute_device(flat_t)
+                                theta_t_slice = main_flat.to(
+                                    device=dev, dtype=torch.float32
+                                )
+                                theta_old_slice = invert_adamw(
+                                    theta_t_slice,
+                                    exp_avg.to(device=dev, dtype=torch.float32).reshape(
+                                        -1
+                                    ),
+                                    exp_avg_sq.to(
+                                        device=dev, dtype=torch.float32
+                                    ).reshape(-1),
+                                    step,
+                                    lr,
+                                    wd,
+                                    b1,
+                                    b2,
+                                    eps,
+                                )
+                                old_on_visible_device = theta_old_slice.to(
+                                    device=visible_slice.device,
+                                    dtype=torch.float32,
+                                )
+                                old_payload = old_on_visible_device.to(
+                                    visible_slice.dtype
+                                )
+                                mask = bitwise_changed_mask(
+                                    visible_slice, old_payload
+                                ).reshape(-1)
+                                if visible_slice.dtype == torch.bfloat16:
+                                    same_payload = ~mask
+                                    boundary = _bf16_rounding_boundary_mask(
+                                        old_on_visible_device, visible_slice
+                                    ).reshape(-1)
+                                    mask = mask | (same_payload & boundary)
+                                local_dirty = bool(mask.any().item())
+                                if local_dirty:
+                                    local_dirty_reason = "adamw_probe"
+
+            status = torch.tensor(
+                [
+                    1 if local_force_dense else 0,
+                    1 if local_dirty else 0,
+                    accounted_numel,
+                ],
+                dtype=torch.int64,
+                device=flat_t.device,
+            )
+            if dp_group is not None:
+                torch.distributed.all_reduce(
+                    status,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                )
+            if debug:
+                logger.info(
+                    "Inversion zero-probe debug: rank=%d param_idx=%d opt=%d "
+                    "force=%d dirty=%d covered=%d",
+                    global_rank,
+                    param_idx,
+                    opt_idx,
+                    int(status[0].item()),
+                    int(status[1].item()),
+                    int(status[2].item()),
+                )
+            if int(status[0].item()) != 0:
+                force_dense_reasons += 1
+                return False
+            if int(status[1].item()) != 0:
+                logger.info(
+                    "[dte-perf][inversion-zero-probe] result=dirty "
+                    "reason=%s param_idx=%d checked_params=%d "
+                    "fingerprint_dirty=%d total_ms=%.1f",
+                    local_dirty_reason or "peer",
+                    param_idx,
+                    checked_params,
+                    fingerprint_dirty,
+                    (time.monotonic() - perf_start) * 1000,
+                )
+                return False
+            covered = int(status[2].item())
+            if covered == 0:
+                if entry is None:
+                    last_model_fingerprint = (
+                        self._last_synced_model_fingerprints.get(param_key)
+                        if param_key is not None
+                        else None
+                    )
+                    if last_model_fingerprint is None:
+                        return False
+                    if _tensor_fingerprint(flat_t) != last_model_fingerprint:
+                        return False
+                    skipped_unchanged_non_optimizer += 1
+                elif expected_one_step:
+                    return False
+            elif covered != flat_t.numel():
+                return False
+
+        logger.info(
+            "[dte-perf][inversion-zero-probe] result=unchanged "
+            "checked_params=%d step_unchanged=%d unchanged_non_optimizer=%d "
+            "fingerprint_dirty=%d force_dense_reasons=%d "
+            "unkeyed_opt_params=%d total_ms=%.1f",
+            checked_params,
+            skipped_step_unchanged,
+            skipped_unchanged_non_optimizer,
+            fingerprint_dirty,
+            force_dense_reasons,
+            unkeyed_opt_params,
+            (time.monotonic() - perf_start) * 1000,
+        )
+        return True
+
+    # -- entry point -------------------------------------------------------
+    @torch.no_grad()
+    def precompute_masks(self, names, tensors, version) -> bool:
+        """Compute and cache masks while optimizer state is still GPU-resident.
+
+        The colocate gateway offloads the optimizer (fp32 main shards + AdamW
+        moments) to CPU right before the weight sync to make room for the
+        inference-side apply. Calling this beforehand lets the inversion run
+        with all operands on GPU and moves the mask computation off the sync
+        critical path. The cached result (including ``None`` = infeasible) is
+        consumed by the next ``compute_masks`` call for the same version and
+        parameter list; any mismatch discards the cache and recomputes.
+
+        All training ranks must call this together: the mask computation runs
+        the same DP/TP collectives as ``compute_masks``.
+        """
+        self._precomputed_masks = None
+        masks = self.compute_masks(names, tensors, version)
+        self._precomputed_masks = (int(version), tuple(names), masks)
+        return masks is not None
+
+    def _pop_precomputed_masks(self, names, version):
+        """Return ``(hit, masks)`` consuming the precompute cache if valid.
+
+        The hit decision must be rank-invariant: a cache hit skips the DP/TP
+        collectives inside the recompute path, so if any training rank misses
+        (e.g. a restarted worker lost its cache, or a stale version), every
+        rank must recompute or the collectives would mismatch and hang. A
+        cheap global MIN-reduce promotes any local miss to a global miss.
+        """
+        cached = self._precomputed_masks
+        self._precomputed_masks = None
+        local_hit = False
+        masks = None
+        if cached is not None:
+            c_version, c_names, c_masks = cached
+            if c_version == int(version) and c_names == tuple(names):
+                local_hit = True
+                masks = c_masks
+            else:
+                logger.warning(
+                    "Inversion: discarding stale precomputed masks "
+                    "(cached v%d/%d params vs requested v%d/%d params)",
+                    c_version,
+                    len(c_names),
+                    int(version),
+                    len(names),
+                )
+        if (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+            and _dist_world_size() > 1
+        ):
+            device = (
+                torch.device("cuda", torch.cuda.current_device())
+                if torch.cuda.is_available()
+                else torch.device("cpu")
+            )
+            hit_t = torch.tensor(
+                [1 if local_hit else 0], dtype=torch.int32, device=device
+            )
+            torch.distributed.all_reduce(hit_t, op=torch.distributed.ReduceOp.MIN)
+            if int(hit_t.item()) == 0:
+                if local_hit:
+                    logger.warning(
+                        "Inversion: dropping precomputed masks for v%d; "
+                        "another rank missed its cache, recomputing on all "
+                        "ranks to keep collectives aligned",
+                        int(version),
+                    )
+                return False, None
+        return (local_hit, masks) if local_hit else (False, None)
+
+    def compute_masks(self, names, tensors, version):
+        """Return sparse index masks or ``None`` to force a dense step."""
+        hit, cached_masks = self._pop_precomputed_masks(names, version)
+        if hit:
+            logger.info(
+                "Inversion: using precomputed masks for v%d (%d params, %s)",
+                int(version),
+                len(names),
+                "feasible" if cached_masks is not None else "dense_infeasible",
+            )
+            return cached_masks
+        perf_start = time.monotonic()
+        # Reset the peak counter so peak_mb below covers inversion only.
+        cuda_mem_stats_mb()
+        adapter = self._adapter
+        t_inner = time.monotonic()
+        inner = adapter._get_inner_optimizers()
+        inner_ms = (time.monotonic() - t_inner) * 1000
+        t_feasible = time.monotonic()
+        if not self._inversion_feasible(inner):
+            logger.info(
+                "[dte-perf][inversion] v%d result=dense_infeasible "
+                "get_optimizers_ms=%.1f feasible_ms=%.1f total_ms=%.1f",
+                version,
+                inner_ms,
+                (time.monotonic() - t_feasible) * 1000,
+                (time.monotonic() - perf_start) * 1000,
+            )
+            return None
+        feasible_ms = (time.monotonic() - t_feasible) * 1000
+
+        if self._zero_delta_probe_candidate():
+            t_zero_probe = time.monotonic()
+            if self._probe_bf16_payload_unchanged(inner):
+                zero_probe_ms = (time.monotonic() - t_zero_probe) * 1000
+                logger.info(
+                    "Inversion: zero-delta fast path proved unchanged BF16 "
+                    "payload for %d HF params at version %d",
+                    len(names),
+                    version,
+                )
+                logger.info(
+                    "[dte-perf][inversion] v%d result=zero_fastpath "
+                    "params=%d get_optimizers_ms=%.1f feasible_ms=%.1f "
+                    "zero_probe_ms=%.1f reconstruct_mcore_ms=0.0 "
+                    "convert_hf_ms=0.0 mask_loop_ms=0.0 total_ms=%.1f",
+                    version,
+                    len(names),
+                    inner_ms,
+                    feasible_ms,
+                    zero_probe_ms,
+                    (time.monotonic() - perf_start) * 1000,
+                )
+                return self._empty_index_masks(names, tensors)
+            logger.info(
+                "[dte-perf][inversion] v%d result=zero_probe_miss "
+                "get_optimizers_ms=%.1f feasible_ms=%.1f "
+                "zero_probe_ms=%.1f",
+                version,
+                inner_ms,
+                feasible_ms,
+                (time.monotonic() - t_zero_probe) * 1000,
+            )
+
+        t_reconstruct = time.monotonic()
+        theta_old_by_id = self._reconstruct_pre_step_mcore(inner)
+        reconstruct_ms = (time.monotonic() - t_reconstruct) * 1000
+        if theta_old_by_id is None:
+            logger.warning("Inversion: reconstruction unavailable -> dense step.")
+            logger.info(
+                "[dte-perf][inversion] v%d result=dense_reconstruct_unavailable "
+                "get_optimizers_ms=%.1f feasible_ms=%.1f "
+                "reconstruct_mcore_ms=%.1f total_ms=%.1f",
+                version,
+                inner_ms,
+                feasible_ms,
+                reconstruct_ms,
+                (time.monotonic() - perf_start) * 1000,
+            )
+            return None
+
+        cur = dict(zip(names, tensors))
+        masks: dict[str, torch.Tensor] = {}
+        from dte.core import bitwise_changed_mask
+
+        # Convert reconstructed pre-step params through the SAME all_gather +
+        # convert_to_hf path as the live payload. Prefer the streaming adapter
+        # interface so AdamW inversion does not materialize a second full HF
+        # payload (current HF payload + old HF payload) before mask creation.
+        iter_hf = getattr(adapter, "_iter_hf_with_overrides", None)
+        old_items = None
+        stream_old_hf = iter_hf is not None
+        convert_hf_ms = 0.0
+        # The streaming iterator consumes (pops) theta_old_by_id entry by
+        # entry so reconstructed fp32 tensors free as the mask loop advances;
+        # capture the count for logging before it drains.
+        theta_old_param_count = len(theta_old_by_id)
+        if stream_old_hf:
+            old_items = iter(iter_hf(theta_old_by_id))
+        else:
+            t_convert = time.monotonic()
+            hf_old = adapter._convert_hf_with_overrides(theta_old_by_id)
+            convert_hf_ms = (time.monotonic() - t_convert) * 1000
+            old_items = iter(hf_old.items())
+
+        mask_loop_ms = 0.0
+        full_changed_masks = 0
+        shape_mismatch_masks = 0
+        forced_dense_params = 0
+        forced_dense_elements = 0
+        seen_names: set[str] = set()
+        while True:
+            if stream_old_hf:
+                t_next = time.monotonic()
+            try:
+                name, old_t = next(old_items)
+            except StopIteration:
+                break
+            if stream_old_hf:
+                convert_hf_ms += (time.monotonic() - t_next) * 1000
+
+            cur_t = cur.get(name)
+            if cur_t is None:
+                continue
+            seen_names.add(name)
+            t_mask = time.monotonic()
+            if _inversion_force_dense_param(name):
+                masks[name] = torch.ones(
+                    cur_t.numel(), dtype=torch.bool, device=cur_t.device
+                )
+                forced_dense_params += 1
+                forced_dense_elements += cur_t.numel()
+                full_changed_masks += 1
+                mask_loop_ms += (time.monotonic() - t_mask) * 1000
+                continue
+            if old_t is None or old_t.shape != cur_t.shape:
+                # No pre-step counterpart -> treat as fully changed (dense).
+                masks[name] = torch.ones(
+                    cur_t.numel(), dtype=torch.bool, device=cur_t.device
+                )
+                full_changed_masks += 1
+                if old_t is not None:
+                    shape_mismatch_masks += 1
+                mask_loop_ms += (time.monotonic() - t_mask) * 1000
+                continue
+            old_payload = old_t.to(cur_t.dtype)
+            mask = bitwise_changed_mask(cur_t, old_payload).reshape(-1)
+            if cur_t.dtype == torch.bfloat16 and old_t.dtype != cur_t.dtype:
+                same_payload = ~mask
+                boundary = _bf16_rounding_boundary_mask(old_t, cur_t).reshape(-1)
+                mask = mask | (same_payload & boundary)
+            if not bool(mask.any().item()) and self._last_synced_payload_fingerprints:
+                last_payload_fingerprint = self._last_synced_payload_fingerprints.get(
+                    name
+                )
+                if last_payload_fingerprint is None:
+                    logger.warning(
+                        "Inversion: payload %s has no synced fingerprint while "
+                        "detector mask is empty -> dense step.",
+                        name,
+                    )
+                    return None
+                cur_payload_fingerprint = _tensor_fingerprint(cur_t)
+                if cur_payload_fingerprint != last_payload_fingerprint:
+                    logger.warning(
+                        "Inversion: payload %s changed since last sync but "
+                        "detector mask is empty -> dense step.",
+                        name,
+                    )
+                    return None
+            masks[name] = self._mask_to_index_mask(mask)
+            mask_loop_ms += (time.monotonic() - t_mask) * 1000
+
+        for name, cur_t in cur.items():
+            if name in seen_names:
+                continue
+            t_mask = time.monotonic()
+            masks[name] = torch.ones(
+                cur_t.numel(), dtype=torch.bool, device=cur_t.device
+            )
+            full_changed_masks += 1
+            mask_loop_ms += (time.monotonic() - t_mask) * 1000
+        logger.info(
+            "Inversion: computed masks for %d HF params at version %d "
+            "(forced_dense_params=%d forced_dense_elements=%d)",
+            len(masks),
+            version,
+            forced_dense_params,
+            forced_dense_elements,
+        )
+        alloc_mb, peak_mb = cuda_mem_stats_mb()
+        logger.info(
+            "[dte-perf][inversion] v%d result=sparse params=%d "
+            "theta_old_params=%d full_changed_masks=%d "
+            "shape_mismatch_masks=%d get_optimizers_ms=%.1f "
+            "feasible_ms=%.1f reconstruct_mcore_ms=%.1f "
+            "convert_hf_ms=%.1f mask_loop_ms=%.1f stream_old_hf=%d "
+            "total_ms=%.1f alloc_mb=%.0f peak_mb=%.0f",
+            version,
+            len(masks),
+            theta_old_param_count,
+            full_changed_masks,
+            shape_mismatch_masks,
+            inner_ms,
+            feasible_ms,
+            reconstruct_ms,
+            convert_hf_ms,
+            mask_loop_ms,
+            int(stream_old_hf),
+            (time.monotonic() - perf_start) * 1000,
+            alloc_mb,
+            peak_mb,
+        )
+        return masks
+
+
+def build_detector(mode: str, adapter):
+    """Construct the detector for ``mode``."""
+    if mode == "inversion":
+        return AdamWInversionDetector(adapter)
+    if dirty_bit_detector_enabled(mode):
+        return DirtyBitsetDetector(adapter)
+    return SnapshotDetector()

--- a/areal/v2/weight_update/awex/delta_index_remap.py
+++ b/areal/v2/weight_update/awex/delta_index_remap.py
@@ -1,0 +1,607 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from typing import NamedTuple
+
+import torch
+
+
+class Qwen3MoeIndexRemapConfig(NamedTuple):
+    hidden_size: int
+    num_attention_heads: int
+    num_query_groups: int
+    head_dim: int
+    num_moe_experts: int | None = None
+    expert_model_parallel_size: int = 1
+    expert_model_parallel_rank: int = 0
+
+
+class RemappedIndices(NamedTuple):
+    name: str
+    indices: torch.Tensor
+
+
+class MCoreShardDirtyBitset(NamedTuple):
+    name: str
+    packed_bitset: torch.Tensor
+    shape: tuple[int, ...]
+    shard_start: int
+    shard_numel: int
+
+
+_BIT_OFFSET_LOOKUP: dict[str, torch.Tensor] = {}
+
+
+def _numel(shape: tuple[int, ...]) -> int:
+    result = 1
+    for dim in shape:
+        result *= dim
+    return result
+
+
+def _bit_offset_lookup(device: torch.device) -> torch.Tensor:
+    key = str(device)
+    table = _BIT_OFFSET_LOOKUP.get(key)
+    if table is None:
+        rows = []
+        for value in range(256):
+            offsets = [bit for bit in range(8) if value & (1 << bit)]
+            offsets.extend([8] * (8 - len(offsets)))
+            rows.append(offsets)
+        table = torch.tensor(rows, dtype=torch.uint8, device=device)
+        _BIT_OFFSET_LOOKUP[key] = table
+    return table
+
+
+def _iter_packed_bitset_indices(
+    packed: torch.Tensor,
+    numel: int,
+    *,
+    chunk_bytes: int = 1 << 20,
+) -> Iterable[torch.Tensor]:
+    """Yield sorted int64 set-bit index chunks from a packed dirty bitset."""
+    if chunk_bytes <= 0:
+        raise ValueError(f"chunk_bytes must be positive, got {chunk_bytes}")
+    if numel < 0:
+        raise ValueError(f"numel must be non-negative, got {numel}")
+    if packed.dtype != torch.uint8:
+        raise TypeError(f"packed bitset must be torch.uint8, got {packed.dtype}")
+
+    needed = (numel + 7) // 8
+    flat = packed.reshape(-1)
+    if flat.numel() < needed:
+        raise ValueError(
+            f"Packed bitset is too short for {numel} bits: "
+            f"need {needed} bytes, got {flat.numel()}"
+        )
+    if numel == 0:
+        return
+
+    lookup: torch.Tensor | None = None
+    shifts: torch.Tensor | None = None
+    for byte_start in range(0, needed, chunk_bytes):
+        byte_end = min(byte_start + chunk_bytes, needed)
+        chunk = flat[byte_start:byte_end]
+        nonzero_bytes = chunk.nonzero(as_tuple=False).squeeze(1)
+        if nonzero_bytes.numel() == 0:
+            continue
+
+        if nonzero_bytes.numel() > chunk.numel() // 2:
+            if shifts is None:
+                shifts = torch.arange(8, dtype=torch.int16, device=packed.device).view(
+                    1, 8
+                )
+            bits = (
+                ((chunk.to(torch.int16).view(-1, 1) >> shifts) & 1)
+                .to(torch.bool)
+                .reshape(-1)
+            )
+            base = byte_start * 8
+            valid_bits = min(bits.numel(), numel - base)
+            local = bits[:valid_bits].nonzero(as_tuple=False).squeeze(1)
+            if local.numel() > 0:
+                yield local.to(torch.int64) + base
+            continue
+
+        if lookup is None:
+            lookup = _bit_offset_lookup(flat.device)
+        byte_values = chunk.index_select(0, nonzero_bytes).to(torch.long)
+        offsets = lookup.index_select(0, byte_values)
+        valid = offsets < 8
+        byte_indices = nonzero_bytes + byte_start
+        candidates = byte_indices.view(-1, 1).to(torch.long) * 8 + offsets.to(
+            torch.long
+        )
+        valid &= candidates < numel
+        selected = candidates[valid]
+        if selected.numel() > 0:
+            yield selected
+
+
+def _append(
+    output: dict[str, list[torch.Tensor]],
+    name: str,
+    indices: torch.Tensor,
+) -> None:
+    if indices.numel() > 0:
+        output[name].append(indices.to(torch.int64))
+
+
+def _flatten_grouped(output: dict[str, list[torch.Tensor]]) -> list[RemappedIndices]:
+    result: list[RemappedIndices] = []
+    for name, parts in output.items():
+        if not parts:
+            continue
+        merged = torch.cat(parts, dim=0)
+        order = torch.argsort(merged)
+        result.append(RemappedIndices(name=name, indices=merged[order].to(torch.int32)))
+    return result
+
+
+def _layer_rest(name: str) -> tuple[str, str] | None:
+    match = re.match(r"module\.module\.decoder\.layers\.(\d+)\.(.+)", name)
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _expert_id(local_expert_idx: str, cfg: Qwen3MoeIndexRemapConfig) -> int:
+    idx = int(local_expert_idx)
+    ep_size = max(1, int(cfg.expert_model_parallel_size))
+    if cfg.num_moe_experts is None or ep_size <= 1:
+        return idx
+    experts_per_partition = int(cfg.num_moe_experts) // ep_size
+    if experts_per_partition <= 0:
+        return idx
+    if idx >= experts_per_partition:
+        return idx
+    return idx + int(cfg.expert_model_parallel_rank) * experts_per_partition
+
+
+def _remap_row_split_2d(
+    hf_names: tuple[str, str],
+    dirty_indices: torch.Tensor,
+    shape: tuple[int, ...],
+) -> list[RemappedIndices]:
+    if len(shape) != 2:
+        raise ValueError(f"row split expects 2D shape, got {shape}")
+    rows, cols = shape
+    if rows % 2 != 0:
+        raise ValueError(f"row split expects even row count, got {rows}")
+    half = rows // 2
+    idx = dirty_indices.to(torch.int64).reshape(-1)
+    row = idx // cols
+    col = idx % cols
+    output: dict[str, list[torch.Tensor]] = defaultdict(list)
+
+    first = row < half
+    _append(output, hf_names[0], row[first] * cols + col[first])
+    second = ~first
+    _append(output, hf_names[1], (row[second] - half) * cols + col[second])
+    return _flatten_grouped(output)
+
+
+def _remap_qkv_weight(
+    layer_idx: str,
+    dirty_indices: torch.Tensor,
+    shape: tuple[int, ...],
+    cfg: Qwen3MoeIndexRemapConfig,
+) -> list[RemappedIndices]:
+    if len(shape) != 2:
+        raise ValueError(f"qkv weight expects 2D shape, got {shape}")
+    rows, cols = shape
+    value_num_per_group = cfg.num_attention_heads // cfg.num_query_groups
+    group_span = (value_num_per_group + 2) * cfg.head_dim
+    if rows % group_span != 0:
+        raise ValueError(
+            f"qkv rows mismatch: rows={rows}, expected a multiple of {group_span}"
+        )
+    num_groups = rows // group_span
+    if num_groups <= 0 or cfg.num_query_groups % num_groups != 0:
+        raise ValueError(
+            f"qkv group mismatch: local_groups={num_groups}, "
+            f"total_groups={cfg.num_query_groups}"
+        )
+    if cols != cfg.hidden_size:
+        raise ValueError(f"qkv hidden mismatch: cols={cols}, hidden={cfg.hidden_size}")
+
+    idx = dirty_indices.to(torch.int64).reshape(-1)
+    row = idx // cols
+    col = idx % cols
+    group = row // group_span
+    offset = row % group_span
+    slot = offset // cfg.head_dim
+    head_offset = offset % cfg.head_dim
+
+    output: dict[str, list[torch.Tensor]] = defaultdict(list)
+    q_mask = slot < value_num_per_group
+    q_row = ((group[q_mask] * value_num_per_group + slot[q_mask]) * cfg.head_dim) + (
+        head_offset[q_mask]
+    )
+    _append(
+        output,
+        f"model.layers.{layer_idx}.self_attn.q_proj.weight",
+        q_row * cols + col[q_mask],
+    )
+
+    k_mask = slot == value_num_per_group
+    k_row = group[k_mask] * cfg.head_dim + head_offset[k_mask]
+    _append(
+        output,
+        f"model.layers.{layer_idx}.self_attn.k_proj.weight",
+        k_row * cols + col[k_mask],
+    )
+
+    v_mask = slot == value_num_per_group + 1
+    v_row = group[v_mask] * cfg.head_dim + head_offset[v_mask]
+    _append(
+        output,
+        f"model.layers.{layer_idx}.self_attn.v_proj.weight",
+        v_row * cols + col[v_mask],
+    )
+    return _flatten_grouped(output)
+
+
+def _remap_qkv_bias(
+    layer_idx: str,
+    dirty_indices: torch.Tensor,
+    shape: tuple[int, ...],
+    cfg: Qwen3MoeIndexRemapConfig,
+) -> list[RemappedIndices]:
+    if len(shape) != 1:
+        raise ValueError(f"qkv bias expects 1D shape, got {shape}")
+    value_num_per_group = cfg.num_attention_heads // cfg.num_query_groups
+    q_span = value_num_per_group * cfg.head_dim
+    group_span = q_span + 2 * cfg.head_dim
+    if shape[0] % group_span != 0:
+        raise ValueError(
+            f"qkv bias length mismatch: length={shape[0]}, "
+            f"expected a multiple of {group_span}"
+        )
+    num_groups = shape[0] // group_span
+    if num_groups <= 0 or cfg.num_query_groups % num_groups != 0:
+        raise ValueError(
+            f"qkv bias group mismatch: local_groups={num_groups}, "
+            f"total_groups={cfg.num_query_groups}"
+        )
+
+    idx = dirty_indices.to(torch.int64).reshape(-1)
+    group = idx // group_span
+    offset = idx % group_span
+    output: dict[str, list[torch.Tensor]] = defaultdict(list)
+
+    q_mask = offset < q_span
+    _append(
+        output,
+        f"model.layers.{layer_idx}.self_attn.q_proj.bias",
+        group[q_mask] * q_span + offset[q_mask],
+    )
+
+    k_mask = (offset >= q_span) & (offset < q_span + cfg.head_dim)
+    _append(
+        output,
+        f"model.layers.{layer_idx}.self_attn.k_proj.bias",
+        group[k_mask] * cfg.head_dim + (offset[k_mask] - q_span),
+    )
+
+    v_mask = offset >= q_span + cfg.head_dim
+    _append(
+        output,
+        f"model.layers.{layer_idx}.self_attn.v_proj.bias",
+        group[v_mask] * cfg.head_dim + (offset[v_mask] - q_span - cfg.head_dim),
+    )
+    return _flatten_grouped(output)
+
+
+def remap_qwen3_moe_mcore_indices_to_hf(
+    name: str,
+    dirty_indices: torch.Tensor,
+    shape: tuple[int, ...],
+    cfg: Qwen3MoeIndexRemapConfig,
+) -> list[RemappedIndices]:
+    """Map Qwen3-MoE mcore dirty flat indices into HF payload flat indices."""
+    if dirty_indices.numel() == 0:
+        return []
+
+    if name == "module.module.embedding.word_embeddings.weight":
+        return [
+            RemappedIndices("model.embed_tokens.weight", dirty_indices.to(torch.int32))
+        ]
+    if name == "module.module.output_layer.weight":
+        return [RemappedIndices("lm_head.weight", dirty_indices.to(torch.int32))]
+    if name == "module.module.decoder.final_layernorm.weight":
+        return [RemappedIndices("model.norm.weight", dirty_indices.to(torch.int32))]
+
+    layer = _layer_rest(name)
+    if layer is None:
+        raise ValueError(f"Unsupported Qwen3-MoE mcore parameter name: {name}")
+    layer_idx, rest = layer
+
+    expert_match = re.match(r"mlp\.experts\.(.+)\.weight(\d+)", rest)
+    if expert_match:
+        expert_rest, local_expert_idx = expert_match.groups()
+        expert_idx = _expert_id(local_expert_idx, cfg)
+        if expert_rest == "linear_fc1":
+            return _remap_row_split_2d(
+                (
+                    f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.gate_proj.weight",
+                    f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.up_proj.weight",
+                ),
+                dirty_indices,
+                shape,
+            )
+        if expert_rest == "linear_fc2":
+            return [
+                RemappedIndices(
+                    f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.down_proj.weight",
+                    dirty_indices.to(torch.int32),
+                )
+            ]
+        raise ValueError(f"Unsupported Qwen3-MoE expert parameter name: {name}")
+
+    if rest == "self_attention.linear_qkv.weight":
+        return _remap_qkv_weight(layer_idx, dirty_indices, shape, cfg)
+    if rest == "self_attention.linear_qkv.bias":
+        return _remap_qkv_bias(layer_idx, dirty_indices, shape, cfg)
+    if rest == "self_attention.linear_proj.weight":
+        return [
+            RemappedIndices(
+                f"model.layers.{layer_idx}.self_attn.o_proj.weight",
+                dirty_indices.to(torch.int32),
+            )
+        ]
+    if rest == "mlp.linear_fc1.weight":
+        return _remap_row_split_2d(
+            (
+                f"model.layers.{layer_idx}.mlp.gate_proj.weight",
+                f"model.layers.{layer_idx}.mlp.up_proj.weight",
+            ),
+            dirty_indices,
+            shape,
+        )
+    if rest == "mlp.linear_fc2.weight":
+        return [
+            RemappedIndices(
+                f"model.layers.{layer_idx}.mlp.down_proj.weight",
+                dirty_indices.to(torch.int32),
+            )
+        ]
+    direct_layer_names = {
+        "self_attention.linear_qkv.layer_norm_weight": "input_layernorm.weight",
+        "mlp.linear_fc1.layer_norm_weight": "post_attention_layernorm.weight",
+        "pre_mlp_layernorm.weight": "post_attention_layernorm.weight",
+        "mlp.router.weight": "mlp.gate.weight",
+        "mlp.router.expert_bias": "mlp.gate.e_score_correction_bias",
+        "self_attention.q_layernorm.weight": "self_attn.q_norm.weight",
+        "self_attention.k_layernorm.weight": "self_attn.k_norm.weight",
+    }
+    if rest in direct_layer_names:
+        return [
+            RemappedIndices(
+                f"model.layers.{layer_idx}.{direct_layer_names[rest]}",
+                dirty_indices.to(torch.int32),
+            )
+        ]
+
+    raise ValueError(f"Unsupported Qwen3-MoE mcore parameter name: {name}")
+
+
+def remap_qwen3_moe_mcore_param_to_hf_names(
+    name: str,
+    cfg: Qwen3MoeIndexRemapConfig,
+) -> tuple[str, ...]:
+    """Return HF payload names structurally covered by one local mcore param."""
+    if name == "module.module.embedding.word_embeddings.weight":
+        return ("model.embed_tokens.weight",)
+    if name == "module.module.output_layer.weight":
+        return ("lm_head.weight",)
+    if name == "module.module.decoder.final_layernorm.weight":
+        return ("model.norm.weight",)
+
+    layer = _layer_rest(name)
+    if layer is None:
+        raise ValueError(f"Unsupported Qwen3-MoE mcore parameter name: {name}")
+    layer_idx, rest = layer
+
+    expert_match = re.match(r"mlp\.experts\.(.+)\.weight(\d+)", rest)
+    if expert_match:
+        expert_rest, local_expert_idx = expert_match.groups()
+        expert_idx = _expert_id(local_expert_idx, cfg)
+        if expert_rest == "linear_fc1":
+            return (
+                f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.gate_proj.weight",
+                f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.up_proj.weight",
+            )
+        if expert_rest == "linear_fc2":
+            return (
+                f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.down_proj.weight",
+            )
+        raise ValueError(f"Unsupported Qwen3-MoE expert parameter name: {name}")
+
+    if rest == "self_attention.linear_qkv.weight":
+        return (
+            f"model.layers.{layer_idx}.self_attn.q_proj.weight",
+            f"model.layers.{layer_idx}.self_attn.k_proj.weight",
+            f"model.layers.{layer_idx}.self_attn.v_proj.weight",
+        )
+    if rest == "self_attention.linear_qkv.bias":
+        return (
+            f"model.layers.{layer_idx}.self_attn.q_proj.bias",
+            f"model.layers.{layer_idx}.self_attn.k_proj.bias",
+            f"model.layers.{layer_idx}.self_attn.v_proj.bias",
+        )
+    if rest == "self_attention.linear_proj.weight":
+        return (f"model.layers.{layer_idx}.self_attn.o_proj.weight",)
+    if rest == "mlp.linear_fc1.weight":
+        return (
+            f"model.layers.{layer_idx}.mlp.gate_proj.weight",
+            f"model.layers.{layer_idx}.mlp.up_proj.weight",
+        )
+    if rest == "mlp.linear_fc2.weight":
+        return (f"model.layers.{layer_idx}.mlp.down_proj.weight",)
+
+    direct_layer_names = {
+        "self_attention.linear_qkv.layer_norm_weight": "input_layernorm.weight",
+        "mlp.linear_fc1.layer_norm_weight": "post_attention_layernorm.weight",
+        "pre_mlp_layernorm.weight": "post_attention_layernorm.weight",
+        "mlp.router.weight": "mlp.gate.weight",
+        "mlp.router.expert_bias": "mlp.gate.e_score_correction_bias",
+        "self_attention.q_layernorm.weight": "self_attn.q_norm.weight",
+        "self_attention.k_layernorm.weight": "self_attn.k_norm.weight",
+    }
+    if rest in direct_layer_names:
+        return (f"model.layers.{layer_idx}.{direct_layer_names[rest]}",)
+
+    raise ValueError(f"Unsupported Qwen3-MoE mcore parameter name: {name}")
+
+
+def remap_qwen3_moe_mcore_bitset_to_hf(
+    name: str,
+    packed_bitset: torch.Tensor,
+    shape: tuple[int, ...],
+    cfg: Qwen3MoeIndexRemapConfig,
+    *,
+    numel: int | None = None,
+    chunk_bytes: int = 1 << 20,
+) -> list[RemappedIndices]:
+    """Map a packed mcore dirty bitset into HF sparse flat indices.
+
+    B2 fused dirty-bit kernels should produce a compact bitset, not a full
+    mcore-space indices tensor. This adapter preserves the existing Qwen3-MoE
+    remap semantics while expanding the bitset in chunks, so peak CPU memory is
+    bounded by one index chunk plus the final HF sparse outputs.
+    """
+    expected_numel = _numel(shape)
+    actual_numel = expected_numel if numel is None else numel
+    if actual_numel != expected_numel:
+        raise ValueError(
+            f"bitset numel mismatch for {name}: numel={actual_numel}, "
+            f"shape numel={expected_numel}"
+        )
+
+    output: dict[str, list[torch.Tensor]] = defaultdict(list)
+    for dirty_indices in _iter_packed_bitset_indices(
+        packed_bitset,
+        actual_numel,
+        chunk_bytes=chunk_bytes,
+    ):
+        for remapped in remap_qwen3_moe_mcore_indices_to_hf(
+            name,
+            dirty_indices,
+            shape,
+            cfg,
+        ):
+            output[remapped.name].append(remapped.indices)
+    return _flatten_grouped(output)
+
+
+def remap_qwen3_moe_mcore_shard_bitset_to_hf(
+    name: str,
+    packed_bitset: torch.Tensor,
+    shape: tuple[int, ...],
+    cfg: Qwen3MoeIndexRemapConfig,
+    *,
+    shard_start: int,
+    shard_numel: int,
+    chunk_bytes: int = 1 << 20,
+) -> list[RemappedIndices]:
+    """Map an optimizer-owned mcore shard dirty bitset into HF sparse indices.
+
+    A fused optimizer dirty-bit implementation naturally sees only the local
+    distributed-optimizer shard, not the full mcore parameter.  ``shard_start``
+    anchors that local flat bitset in the full mcore flat parameter space before
+    applying the same Qwen3-MoE mcore->HF layout remap as the full-bitset path.
+    """
+    expected_numel = _numel(shape)
+    if shard_start < 0:
+        raise ValueError(f"shard_start must be non-negative, got {shard_start}")
+    if shard_numel < 0:
+        raise ValueError(f"shard_numel must be non-negative, got {shard_numel}")
+    shard_end = shard_start + shard_numel
+    if shard_end > expected_numel:
+        raise ValueError(
+            f"shard range out of bounds for {name}: "
+            f"[{shard_start}, {shard_end}) exceeds numel={expected_numel}"
+        )
+
+    output: dict[str, list[torch.Tensor]] = defaultdict(list)
+    for local_dirty_indices in _iter_packed_bitset_indices(
+        packed_bitset,
+        shard_numel,
+        chunk_bytes=chunk_bytes,
+    ):
+        dirty_indices = local_dirty_indices + shard_start
+        for remapped in remap_qwen3_moe_mcore_indices_to_hf(
+            name,
+            dirty_indices,
+            shape,
+            cfg,
+        ):
+            output[remapped.name].append(remapped.indices)
+    return _flatten_grouped(output)
+
+
+def remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks(
+    shard_bitsets: Iterable[MCoreShardDirtyBitset],
+    cfg: Qwen3MoeIndexRemapConfig,
+    *,
+    hf_names: Iterable[str] | None = None,
+    device_by_hf_name: Mapping[str, torch.device] | None = None,
+    chunk_bytes: int = 1 << 20,
+    fill_all_hf_names: bool = True,
+) -> dict[str, torch.Tensor]:
+    """Merge mcore shard dirty bitsets into HF sparse-index masks.
+
+    The returned mapping is directly consumable by ``DeltaTracker.encode`` as an
+    external mask dictionary: values are sorted ``int32`` flat indices in each HF
+    payload tensor.  Passing ``hf_names`` fills unchanged/covered payload tensors
+    with empty ``int32`` masks so the tracker does not treat them as dense
+    fallback.
+    """
+    output: dict[str, list[torch.Tensor]] = defaultdict(list)
+    covered_names: set[str] = set()
+    for shard in shard_bitsets:
+        if not fill_all_hf_names:
+            covered_names.update(
+                remap_qwen3_moe_mcore_param_to_hf_names(shard.name, cfg)
+            )
+        for remapped in remap_qwen3_moe_mcore_shard_bitset_to_hf(
+            shard.name,
+            shard.packed_bitset,
+            shard.shape,
+            cfg,
+            shard_start=shard.shard_start,
+            shard_numel=shard.shard_numel,
+            chunk_bytes=chunk_bytes,
+        ):
+            output[remapped.name].append(remapped.indices)
+
+    devices = device_by_hf_name or {}
+    masks: dict[str, torch.Tensor] = {}
+    for name, parts in output.items():
+        if not parts:
+            continue
+        merged = torch.cat(parts, dim=0)
+        target_device = devices.get(name)
+        if target_device is not None:
+            merged = merged.to(target_device)
+        order = torch.argsort(merged)
+        masks[name] = merged[order].to(torch.int32)
+
+    if hf_names is not None:
+        if fill_all_hf_names:
+            fill_names = hf_names
+        else:
+            fill_names = [name for name in hf_names if name in covered_names]
+        for name in fill_names:
+            if name not in masks:
+                masks[name] = torch.empty(
+                    0,
+                    dtype=torch.int32,
+                    device=devices.get(name, torch.device("cpu")),
+                )
+    return masks

--- a/areal/v2/weight_update/awex/fsdp_adapter.py
+++ b/areal/v2/weight_update/awex/fsdp_adapter.py
@@ -66,7 +66,10 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
     def _tie_word_embeddings(self) -> bool:
         return getattr(self._engine.model_config, "tie_word_embeddings", False)
 
-    def get_weight_metadata(self) -> list[ParameterMeta]:
+    def get_weight_metadata(
+        self, infer_conf: dict | None = None
+    ) -> list[ParameterMeta]:
+        del infer_conf
         rank_info = self._build_rank_info()
         metadata: list[ParameterMeta] = []
 

--- a/areal/v2/weight_update/awex/megatron_adapter.py
+++ b/areal/v2/weight_update/awex/megatron_adapter.py
@@ -5,7 +5,9 @@ import gc
 import os
 import threading
 import time
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from types import MethodType, SimpleNamespace
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import torch
@@ -22,12 +24,40 @@ from awex.transfer.transfer_plan import TransferPlan, TransferPlanBuilder
 from awex.util.tensor_util import (
     cuda_ipc_serialize,
     group_tensors_by_shape_and_dtype,
+    release_tensors,
 )
 
 from areal.utils import logging
 from areal.v2.weight_update.awex import (
     awex_wu_use_group,
     fetch_kv_metadata,
+)
+from areal.v2.weight_update.awex.colocate_device import (
+    device_mapping_key,
+    get_colocate_ip_address,
+    get_physical_cuda_device_id,
+)
+from areal.v2.weight_update.awex.delta_config import (
+    cuda_mem_stats_mb,
+    delta_transfer_enabled,
+    make_delta_tracker,
+)
+from areal.v2.weight_update.awex.delta_detect import (
+    build_detector,
+    delta_detector_mode,
+    dirty_bit_detector_enabled,
+    external_delta_detector_enabled,
+)
+from areal.v2.weight_update.awex.delta_index_remap import (
+    MCoreShardDirtyBitset,
+    Qwen3MoeIndexRemapConfig,
+    remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks,
+)
+from areal.v2.weight_update.awex.step_dirty_dryrun import (
+    capture_bf16_optimizer_shards,
+    collect_copyback_dirty_bitsets,
+    compare_bf16_optimizer_shards,
+    iter_optimizer_shard_refs,
 )
 from areal.v2.weight_update.nccl_group import (
     init_weights_update_group,
@@ -42,6 +72,47 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("AwexMegatronAdapter")
 
+# Sentinel distinguishing "no precomputed synced state cached" from a cached
+# ``None`` (detector infeasible at capture time), which is a valid state that
+# must reach mark_synced to clear the watermark.
+_CAPTURE_MISS = object()
+
+
+_AWEX_QWEN_ARCHITECTURES = frozenset(
+    {
+        "Qwen2ForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+    }
+)
+
+
+def _install_awex_qwen_converter(architecture: str) -> None:
+    """Align AWEX's generic Qwen converter with SGLang's HF parameter names."""
+    if architecture not in _AWEX_QWEN_ARCHITECTURES:
+        return
+
+    from awex.converter.mcore_converter import McoreToHFWeightConverter
+    from awex.models.registry import ModelRegistry
+
+    class _QwenMcoreToHFWeightConverter(McoreToHFWeightConverter):
+        def _fuse_qkv(self, name: str) -> bool:
+            del name
+            return False
+
+        @staticmethod
+        def _normalize_attn_name(name: str) -> str:
+            return name
+
+    model_config = ModelRegistry.get_model_config(architecture)
+    if isinstance(model_config, dict):
+        updated_config = dict(model_config)
+        updated_config["mcore_converter"] = _QwenMcoreToHFWeightConverter
+        ModelRegistry.models[architecture] = updated_config
+    else:
+        model_config.mcore_converter = _QwenMcoreToHFWeightConverter
+        ModelRegistry.models[architecture] = model_config
+
 
 class AwexMegatronAdapter(AwexTrainingAdapter):
     """Awex training adapter for MegatronEngine supporting DP, TP, and PP.
@@ -49,7 +120,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
     PP: get_named_parameters already yields only the current stage's layers
     (with globally-correct HF layer indices via get_transformer_layer_offset),
     so each rank naturally reports and sends only its own subset of parameters.
-    The gateway's _merge_training_meta_by_name unions disjoint PP stage params
+    The gateway merges metadata by name to union disjoint PP stage params
     by name, so the full model is covered across all PP ranks.
 
     TP: all_gather_param gathers the full tensor on every TP rank before
@@ -59,16 +130,49 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
 
     def __init__(self, engine: MegatronEngine):
         self._engine = engine
+        setattr(engine, "_awex_weight_update_adapter", self)
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
         self._transfer_rank: int | None = None
         self._offloaded_optimizer_states: dict = {}
         self._offloaded_weights: dict[str, torch.Tensor] = {}
         self._released_tags: set[str] = set()
+        # Optimization: the colocate precompute step already ran
+        # _sync_model_params_from_optimizer and captured the detector's synced
+        # state on GPU; the sync path reuses both instead of redoing them on
+        # the critical path (with the optimizer already offloaded to CPU).
+        self._precompute_param_synced_version: int | None = None
+        self._precomputed_synced_state: tuple[int, Any] | None = None
         self._colocate_lock = threading.Lock()
         self._colocate_admin_api_key: str = "areal-admin-key"
         self._colocate_http_client: httpx.Client | None = None
         self._colocate_timeout_s: float = 120.0
+        self._colocate_device_ip: str = ""
+        self._colocate_device_id: str = ""
+        # Lazy dte DeltaTracker (sender side); persists across versions to hold
+        # the CPU snapshot baseline. Created on first delta-enabled transfer.
+        self._delta_tracker = None
+        # Lazy change detector: snapshot (default) | inversion (DTE_DELTA_DETECTOR).
+        self._delta_detector = None
+        self._step_dirty_dry_run_capture = None
+        self._last_optimizer_update_successful: bool | None = None
+        self._last_optimizer_grad_norm: float | None = None
+        self._optimizer_dirty_bitsets: list[MCoreShardDirtyBitset] | None = None
+        self._optimizer_dirty_bitsets_version: int | None = None
+        self._optimizer_dirty_bitsets_complete = False
+        self._copyback_dirty_bitsets: list[dict[str, Any]] | None = None
+        self._copyback_dirty_bitsets_complete = False
+        self._copyback_dirty_collect_ms = 0.0
+        self._copyback_dirty_name_resolver = None
+        self._copyback_dirty_seen_copy = False
+        # AWEX native mcore converter/resolver, used for colocated transfer.
+        # This matches the proven 1.0 colocate path and avoids the hand-written
+        # TP all-gather + HF conversion peak during the first full sync.
+        self._awex_weight_converter = None
+        self._awex_train_meta: list[ParameterMeta] | None = None
+        self._awex_infer_conf: dict[str, Any] | None = None
+        self._awex_rank_info = None
+        self._awex_omit_tied_lm_head = False
 
     @property
     def parallelism_strategy(self) -> dict:
@@ -85,51 +189,84 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             "dp_replicated": tp_size > 1 or cp_size > 1,
         }
 
-    def get_weight_metadata(self) -> list[ParameterMeta]:
-        rank_info = self._build_rank_info()
-        metadata: list[ParameterMeta] = []
+    def get_weight_metadata(
+        self, infer_conf: dict[str, Any] | None = None
+    ) -> list[ParameterMeta]:
+        # Meta/converter init reads live param tensors. After the pre-rollout
+        # release_memory, Megatron DDP param_data storages are resize_(0)'d,
+        # so every param is a dangling view into freed device memory — any
+        # kernel/collective over them is cudaErrorIllegalAddress. Resume
+        # weights first (the transfer path below does the same before reading
+        # payloads); the post-update release re-offloads them afterwards.
+        legacy_adapter = getattr(self._engine, "_awex_adapter", None)
+        legacy_weights_offloaded = (
+            legacy_adapter is not None
+            and legacy_adapter is not self
+            and "weights" in getattr(legacy_adapter, "_released_tags", set())
+        )
+        weights_offloaded = "weights" in self._released_tags
+        if legacy_weights_offloaded:
+            legacy_adapter.resume_memory(tags=["weights"])
+        elif weights_offloaded:
+            self.resume_memory(tags=["weights"])
+        try:
+            if infer_conf is not None:
+                return self._ensure_awex_converter(infer_conf)[0]
+            if self._awex_train_meta is not None:
+                return self._awex_train_meta
 
-        for hf_name, tensor in self._iter_hf_params():
-            shape = tuple(tensor.shape)
-            numel = int(tensor.numel())
-            shard_meta = ParameterShardMeta(
-                tp_rank=rank_info.tp_rank,
-                attn_tp_rank=rank_info.attn_tp_rank,
-                pp_rank=rank_info.pp_rank,
-                ep_rank=rank_info.ep_rank,
-                ep_tp_rank=rank_info.ep_tp_rank,
-                global_rank=rank_info.global_rank,
-                world_size=rank_info.world_size,
-                engine_rank=rank_info.engine_rank,
-                cp_rank=rank_info.cp_rank,
-                cp_size=rank_info.cp_size,
-                cp_mode=rank_info.cp_mode,
-                name=hf_name,
-                shape=shape,
-                numel=numel,
-                dtype=tensor.dtype,
-                global_offset=tuple([0] * len(shape)),
-                sharding_type=ShardingType.NO_SHARDING,
-                num_shards=1,
-                sharding_dim=0,
-            )
-            replica = ParameterReplicaMeta(shards=[shard_meta])
-            metadata.append(
-                ParameterMeta(
+            rank_info = self._build_rank_info()
+            metadata: list[ParameterMeta] = []
+
+            for hf_name, tensor in self._iter_hf_params():
+                shape = tuple(tensor.shape)
+                numel = int(tensor.numel())
+                shard_meta = ParameterShardMeta(
+                    tp_rank=rank_info.tp_rank,
+                    attn_tp_rank=rank_info.attn_tp_rank,
+                    pp_rank=rank_info.pp_rank,
+                    ep_rank=rank_info.ep_rank,
+                    ep_tp_rank=rank_info.ep_tp_rank,
+                    global_rank=rank_info.global_rank,
+                    world_size=rank_info.world_size,
+                    engine_rank=rank_info.engine_rank,
+                    cp_rank=rank_info.cp_rank,
+                    cp_size=rank_info.cp_size,
+                    cp_mode=rank_info.cp_mode,
                     name=hf_name,
-                    global_numel=numel,
-                    global_shape=shape,
+                    shape=shape,
+                    numel=numel,
                     dtype=tensor.dtype,
-                    shards=[shard_meta],
-                    replicas=[replica],
+                    global_offset=tuple([0] * len(shape)),
+                    sharding_type=ShardingType.NO_SHARDING,
+                    num_shards=1,
+                    sharding_dim=0,
                 )
-            )
+                replica = ParameterReplicaMeta(shards=[shard_meta])
+                metadata.append(
+                    ParameterMeta(
+                        name=hf_name,
+                        global_numel=numel,
+                        global_shape=shape,
+                        dtype=tensor.dtype,
+                        shards=[shard_meta],
+                        replicas=[replica],
+                    )
+                )
 
-        return metadata
+            return metadata
+        finally:
+            if legacy_weights_offloaded:
+                legacy_adapter.release_memory(tags=["weights"])
+            elif weights_offloaded:
+                self.release_memory(tags=["weights"])
 
     def get_local_shard_parameters(
         self, required_names: list[str] | None = None
     ) -> dict[str, torch.Tensor]:
+        if self._awex_weight_converter is not None:
+            return self._convert_parameters(required_names=required_names)
+
         required = set(required_names) if required_names else None
         result: dict[str, torch.Tensor] = {}
         for hf_name, tensor in self._iter_hf_params():
@@ -137,6 +274,34 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
                 continue
             result[hf_name] = tensor
         return result
+
+    def _iter_model_params_for_delta(self):
+        """Yield model tensors in the same order used by the payload converter."""
+        if self._awex_weight_converter is not None:
+            from awex.converter.mcore_converter import get_mcore_model_parameters
+
+            seen: set[int] = set()
+            for model in self._iter_model_chunks():
+                for param in get_mcore_model_parameters(model).values():
+                    pid = id(param)
+                    if pid in seen:
+                        continue
+                    seen.add(pid)
+                    yield param
+            return
+
+        from areal.engine.megatron_utils.megatron import get_named_parameters
+
+        num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
+        seen: set[int] = set()
+        for _mcore_name, param in get_named_parameters(
+            self._engine.model, num_moe_experts
+        ):
+            pid = id(param)
+            if pid in seen:
+                continue
+            seen.add(pid)
+            yield param
 
     def save_parameters(self, save_path: str, names: list[str] | None = None) -> None:
         weights_offloaded = "weights" in self._released_tags
@@ -228,6 +393,18 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             self._colocate_http_client.close()
             self._colocate_http_client = None
 
+    def _rank_info_or_none(self) -> RankInfo | None:
+        """``_build_rank_info`` or ``None`` when mpu groups are unavailable.
+
+        Single-process contexts (unit tests, dry runs) have no Megatron
+        parallel state; callers that only need dp/ep coordinates fall back to
+        single-rank semantics instead of asserting inside mpu.
+        """
+        try:
+            return self._build_rank_info()
+        except (AssertionError, ValueError, RuntimeError):
+            return None
+
     def _build_rank_info(self) -> RankInfo:
         from megatron.core import parallel_state as mpu
 
@@ -267,13 +444,231 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             cp_mode="ring" if cp_size > 1 else "none",
         )
 
-    def _iter_hf_params(self):
+    def _normalize_awex_infer_conf(
+        self, infer_conf: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        conf = dict(infer_conf or {})
+        hf_conf = conf.get("hf_config")
+        if isinstance(hf_conf, dict):
+            conf["hf_config"] = SimpleNamespace(**hf_conf)
+        elif hf_conf is None:
+            conf["hf_config"] = self._engine.hf_config
+        if "infer_atten_tp_size" not in conf:
+            conf["infer_atten_tp_size"] = int(
+                conf.get("tp_size", self.parallelism_strategy.get("tp_size", 1))
+            )
+        if "router_dtype" not in conf:
+            conf["router_dtype"] = getattr(
+                self._engine.hf_config, "router_dtype", "bf16"
+            )
+        if "device_backend" not in conf:
+            conf["device_backend"] = os.environ.get("AWEX_DEVICE_TYPE", "cuda")
+        return conf
+
+    def _get_tf_config(self):
+        for model in self._iter_model_chunks():
+            for attr in ("transformer_config", "config"):
+                cfg = getattr(model, attr, None)
+                if cfg is not None:
+                    return cfg
+        return None
+
+    def _make_awex_engine_shim(self):
+        class _EngineShim:
+            def __init__(self, engine):
+                self.model = engine.model
+                if not isinstance(self.model, (list, tuple)):
+                    self.model = [self.model]
+                self.hf_config = engine.hf_config
+                self.enable_debug_mode = False
+                self.enable_colocate_mode = True
+                self.engine_name = "mcore"
+                self.config = {}
+                self.meta_server_addr = ""
+
+            def release_memory_occupation(self, tags=None):
+                pass
+
+            def resume_memory_occupation(self, tags=None):
+                pass
+
+        return _EngineShim(self._engine)
+
+    def _ensure_awex_converter(
+        self, infer_conf: dict[str, Any] | None = None
+    ) -> tuple[list[ParameterMeta], Any]:
+        if (
+            self._awex_weight_converter is not None
+            and self._awex_train_meta is not None
+        ):
+            return self._awex_train_meta, self._awex_weight_converter
+
+        from awex.meta.train_meta_resolver import McoreParamMetaResolver
+        from awex.models.registry import get_train_weights_converter
+
+        conf = self._normalize_awex_infer_conf(infer_conf or self._awex_infer_conf)
+        architecture = self._engine.hf_config.architectures[0]
+        _install_awex_qwen_converter(architecture)
+        shim = self._make_awex_engine_shim()
+        meta_resolver = McoreParamMetaResolver(shim, self._engine.hf_config, conf)
+        train_meta = meta_resolver.get_parameters_meta()
+        self._awex_omit_tied_lm_head = bool(
+            getattr(self._engine.hf_config, "tie_word_embeddings", False)
+            and not conf.get("include_tied_lm_head", True)
+        )
+        if self._awex_omit_tied_lm_head:
+            train_meta = [meta for meta in train_meta if meta.name != "lm_head.weight"]
+
+        from awex.sharding.param_sharding import get_rank_info_extractor
+
+        rank_info = get_rank_info_extractor("mcore")()
+        converter = get_train_weights_converter(
+            "mcore",
+            architecture,
+            self._engine.hf_config,
+            rank_info,
+            {
+                **conf,
+                "train_pp_stage_layer_id_map": (
+                    meta_resolver.get_pp_stage_layer_id_map()
+                ),
+            },
+            tf_config=self._get_tf_config(),
+        )
+
+        self._awex_infer_conf = conf
+        self._awex_rank_info = rank_info
+        self._awex_train_meta = train_meta
+        self._awex_weight_converter = converter
+        logger.info(
+            "Initialized AWEX mcore converter for colocate payload (params_meta=%d)",
+            len(train_meta),
+        )
+        return train_meta, converter
+
+    @torch.no_grad()
+    def _iter_convert_parameters(
+        self,
+        required_names: list[str] | None = None,
+        theta_by_id: dict[int, torch.Tensor] | None = None,
+        consume_overrides: bool = False,
+    ):
+        """Yield Megatron tensors converted through AWEX's native mcore converter.
+
+        With ``consume_overrides=True`` each entry of ``theta_by_id`` is popped
+        as soon as its mcore param has been converted, so a streaming consumer
+        (AdamW-inversion mask loop) releases reconstructed fp32 pre-step
+        tensors incrementally instead of holding the full set alive.
+        """
+        from awex.converter.mcore_converter import get_mcore_model_parameters
+
+        if self._awex_weight_converter is None:
+            self._ensure_awex_converter()
+        converter = self._awex_weight_converter
+        assert converter is not None
+
+        required = set(required_names) if required_names else None
+        overrides = theta_by_id if theta_by_id is not None else {}
+        embed_tokens: torch.Tensor | None = None
+        saw_lm_head = False
+        for vp_stage, model in enumerate(self._iter_model_chunks()):
+            for name, param in get_mcore_model_parameters(model).items():
+                src = overrides.get(id(param), param)
+                for hf_name, hf_param in converter.convert_param(
+                    name, src.detach(), vp_stage=vp_stage
+                ):
+                    if self._awex_omit_tied_lm_head and hf_name == "lm_head.weight":
+                        continue
+                    if required is None or hf_name in required:
+                        tensor = hf_param.detach()
+                        if hf_name == "model.embed_tokens.weight":
+                            embed_tokens = tensor
+                        elif hf_name == "lm_head.weight":
+                            saw_lm_head = True
+                        yield hf_name, tensor
+                if consume_overrides:
+                    overrides.pop(id(param), None)
+
+        hf_config = self._engine.hf_config
+        if (
+            getattr(hf_config, "tie_word_embeddings", False)
+            and self._awex_rank_info is not None
+            and self._awex_rank_info.pp_rank == self._awex_rank_info.pp_size - 1
+            and not saw_lm_head
+            and embed_tokens is not None
+            and not self._awex_omit_tied_lm_head
+            and (required is None or "lm_head.weight" in required)
+        ):
+            yield "lm_head.weight", embed_tokens
+
+    @torch.no_grad()
+    def _convert_parameters(
+        self,
+        required_names: list[str] | None = None,
+        theta_by_id: dict[int, torch.Tensor] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Convert Megatron tensors through AWEX's native mcore converter."""
+        converted: dict[str, torch.Tensor] = {}
+        for hf_name, tensor in self._iter_convert_parameters(
+            required_names=required_names,
+            theta_by_id=theta_by_id,
+        ):
+            converted[hf_name] = tensor
+
+        return converted
+
+    def _live_module_storage_ptrs(self) -> set[int]:
+        live_storages: set[int] = set()
+        for chunk in self._iter_model_chunks():
+            for _, param in chunk.named_parameters():
+                live_storages.add(param.untyped_storage().data_ptr())
+            for _, buf in chunk.named_buffers():
+                live_storages.add(buf.untyped_storage().data_ptr())
+        return live_storages
+
+    def _release_owned_payload_tensors(self, tensors: list[torch.Tensor]) -> None:
+        if not tensors:
+            return
+        owned = self._owned_payload_tensors(tensors)
+        if not owned:
+            logger.info(
+                "No owned converted payload tensors to release "
+                "(all %d alias live module storage)",
+                len(tensors),
+            )
+            return
+        release_tensors(owned)
+        logger.info(
+            "Released %d/%d converted payload tensors before weights offload",
+            len(owned),
+            len(tensors),
+        )
+
+    def _owned_payload_tensors(self, tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+        live_storages = self._live_module_storage_ptrs()
+        return [
+            tensor
+            for tensor in tensors
+            if tensor.untyped_storage().data_ptr() not in live_storages
+        ]
+
+    def _iter_hf_params(
+        self,
+        theta_by_id: dict[int, torch.Tensor] | None = None,
+        consume_overrides: bool = False,
+    ):
         """Yield (hf_name, tensor) for every parameter on this rank.
 
         Uses get_named_parameters + all_gather_param + convert_to_hf to produce
         HF-style per-expert names (e.g. experts.0.gate_proj.weight). The SGLang
         adapter's _unfuse_params converts SGLang's fused w13/w2 format to the
         same per-expert names, so both sides match for the transfer plan.
+
+        ``theta_by_id`` maps ``id(model_param) -> replacement tensor`` (same
+        shape/dtype as the mcore param). The AdamW-inversion detector uses it to
+        push reconstructed pre-step weights through the EXACT same all_gather +
+        convert path as the live payload; a param without an override is
+        converted as-is.
         """
         from areal.engine.megatron_utils.megatron import (
             all_gather_param,
@@ -281,6 +676,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             get_named_parameters,
         )
 
+        overrides = theta_by_id if theta_by_id is not None else {}
         num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
         model_name = self._engine.hf_config.model_type
         tie_word_embeddings = getattr(
@@ -290,9 +686,10 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         for mcore_name, param in get_named_parameters(
             self._engine.model, num_moe_experts
         ):
+            src = overrides.get(id(param), param)
             gathered = all_gather_param(
                 mcore_name,
-                param,
+                src,
                 fp8_direct_convert=False,
                 quantization_config=None,
                 duplicated_param_names=self._engine._duplicated_param_names,
@@ -309,6 +706,869 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
                 if tie_word_embeddings and hf_name == "lm_head.weight":
                     continue
                 yield hf_name, tensor.detach()
+            if consume_overrides:
+                overrides.pop(id(param), None)
+
+    def _get_inner_optimizers(self):
+        """Inner per-chunk optimizers (unwrap Megatron ChainedOptimizer).
+
+        Used by the AdamW-inversion detector to read resident AdamW moments.
+        """
+        optimizer = self._engine.optimizer
+        if optimizer is None:
+            return []
+
+        def flatten(opt):
+            chained = getattr(opt, "chained_optimizers", None)
+            if chained is not None:
+                result = []
+                for child in chained:
+                    result.extend(flatten(child))
+                return result
+            optimizers = getattr(opt, "optimizers", None)
+            if optimizers is not None:
+                result = []
+                for child in optimizers:
+                    result.extend(flatten(child))
+                return result
+            return [opt]
+
+        return flatten(optimizer)
+
+    @staticmethod
+    def _env_bool(name: str, default: bool = False) -> bool:
+        value = os.environ.get(name)
+        if value is None or value.strip() == "":
+            return default
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _env_int(name: str, default: int) -> int:
+        value = os.environ.get(name)
+        if value is None or value.strip() == "":
+            return default
+        return int(value.strip())
+
+    def _step_dirty_name_resolver(self):
+        from areal.engine.megatron_utils.megatron import get_named_parameters
+
+        id2name: dict[int, str] = {}
+        ptr2name: dict[tuple[int, tuple], str] = {}
+        num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
+        for name, param in get_named_parameters(self._engine.model, num_moe_experts):
+            id2name.setdefault(id(param), name)
+            try:
+                if param.data.numel() > 0:
+                    ptr2name.setdefault(
+                        (param.data.data_ptr(), tuple(param.shape)), name
+                    )
+            except RuntimeError:
+                pass
+
+        def resolve(param: torch.Tensor) -> str | None:
+            name = id2name.get(id(param))
+            if name is not None:
+                return name
+            try:
+                if param.data.numel() > 0:
+                    return ptr2name.get((param.data.data_ptr(), tuple(param.shape)))
+            except RuntimeError:
+                return None
+            return None
+
+        return resolve
+
+    def before_optimizer_step(self) -> dict[str, float]:
+        """Optional B1 dry-run: snapshot optimizer-owned shards before step."""
+        self._prepare_copyback_dirty_bit_provider()
+        if not self._env_bool("DTE_STEP_DIRTY_DRY_RUN", default=False):
+            return {}
+        storage = (
+            os.environ.get("DTE_STEP_DIRTY_DRY_RUN_STORAGE", "cpu").strip().lower()
+        )
+        max_bytes = self._env_int(
+            "DTE_STEP_DIRTY_DRY_RUN_MAX_BYTES",
+            1 << 30,
+        )
+        sync_cuda = self._env_bool("DTE_STEP_DIRTY_DRY_RUN_SYNC", default=False)
+        inner = self._get_inner_optimizers()
+        refs = iter_optimizer_shard_refs(
+            inner,
+            name_resolver=self._step_dirty_name_resolver(),
+        )
+        capture = capture_bf16_optimizer_shards(
+            refs,
+            max_snapshot_bytes=max_bytes,
+            storage=storage,
+            sync_cuda=sync_cuda,
+        )
+        self._step_dirty_dry_run_capture = capture
+        logger.info(
+            "[dte-perf][step-dirty] phase=before storage=%s total_params=%d "
+            "captured_params=%d skipped_by_cap=%d snapshot_mb=%.1f "
+            "total_snapshot_mb=%.1f capture_ms=%.1f",
+            storage,
+            capture.total_params,
+            capture.captured_params,
+            capture.skipped_by_cap,
+            capture.captured_snapshot_bytes / 1e6,
+            capture.total_snapshot_bytes / 1e6,
+            capture.capture_ms,
+        )
+        return {
+            "perf/step_dirty_capture_time": capture.capture_ms / 1000,
+            "perf/step_dirty_total_params": float(capture.total_params),
+            "perf/step_dirty_captured_params": float(capture.captured_params),
+            "perf/step_dirty_skipped_by_cap": float(capture.skipped_by_cap),
+            "perf/step_dirty_snapshot_mb": capture.captured_snapshot_bytes / 1e6,
+            "perf/step_dirty_total_snapshot_mb": capture.total_snapshot_bytes / 1e6,
+        }
+
+    def after_optimizer_step(
+        self, update_successful: bool, grad_norm: float | None = None
+    ) -> dict[str, float]:
+        """Optional B1 dry-run: compare optimizer-owned shards after step."""
+        self._last_optimizer_update_successful = bool(update_successful)
+        self._last_optimizer_grad_norm = (
+            float(grad_norm) if grad_norm is not None else None
+        )
+        stats = self._maybe_record_optimizer_dirty_bitsets(bool(update_successful))
+        if not self._env_bool("DTE_STEP_DIRTY_DRY_RUN", default=False):
+            return stats
+        capture = self._step_dirty_dry_run_capture
+        self._step_dirty_dry_run_capture = None
+        if capture is None:
+            return stats
+        if not update_successful:
+            logger.info(
+                "[dte-perf][step-dirty] phase=after skipped "
+                "reason=optimizer_step_unsuccessful captured_params=%d",
+                capture.captured_params,
+            )
+            stats.update(
+                {
+                    "perf/step_dirty_compare_time": 0.0,
+                    "perf/step_dirty_changed_ratio": 0.0,
+                    "perf/step_dirty_changed_elements": 0.0,
+                    "perf/step_dirty_captured_elements": 0.0,
+                    "perf/step_dirty_bitset_mb": 0.0,
+                    "perf/step_dirty_indices_time": 0.0,
+                    "perf/step_dirty_indices_elements": 0.0,
+                    "perf/step_dirty_indices_mb": 0.0,
+                }
+            )
+            return stats
+        pack_bitset = self._env_bool("DTE_STEP_DIRTY_DRY_RUN_PACK", default=False)
+        materialize_indices = self._env_bool(
+            "DTE_STEP_DIRTY_DRY_RUN_INDICES",
+            default=False,
+        )
+        sync_cuda = self._env_bool("DTE_STEP_DIRTY_DRY_RUN_SYNC", default=False)
+        result = compare_bf16_optimizer_shards(
+            capture,
+            pack_bitset=pack_bitset,
+            materialize_indices=materialize_indices,
+            sync_cuda=sync_cuda,
+        )
+        logger.info(
+            "[dte-perf][step-dirty] phase=after captured_params=%d "
+            "captured_elements=%d changed_elements=%d changed_ratio=%.6f "
+            "snapshot_mb=%.1f bitset_mb=%.1f indices_elements=%d "
+            "indices_mb=%.1f compare_ms=%.1f pack_ms=%.1f indices_ms=%.1f",
+            result.captured_params,
+            result.captured_elements,
+            result.changed_elements,
+            result.changed_ratio,
+            result.snapshot_bytes / 1e6,
+            result.bitset_bytes / 1e6,
+            result.indices_elements,
+            result.indices_bytes / 1e6,
+            result.compare_ms,
+            result.pack_ms,
+            result.indices_ms,
+        )
+        stats.update(
+            {
+                "perf/step_dirty_compare_time": result.compare_ms / 1000,
+                "perf/step_dirty_pack_time": result.pack_ms / 1000,
+                "perf/step_dirty_indices_time": result.indices_ms / 1000,
+                "perf/step_dirty_changed_ratio": result.changed_ratio,
+                "perf/step_dirty_changed_elements": float(result.changed_elements),
+                "perf/step_dirty_captured_elements": float(result.captured_elements),
+                "perf/step_dirty_bitset_mb": result.bitset_bytes / 1e6,
+                "perf/step_dirty_indices_elements": float(result.indices_elements),
+                "perf/step_dirty_indices_mb": result.indices_bytes / 1e6,
+            }
+        )
+        return stats
+
+    def _dirty_bit_provider_mode(self) -> str:
+        return (
+            (
+                os.environ.get("DTE_DIRTY_BIT_PROVIDER")
+                or os.environ.get("AWEX_DIRTY_BIT_PROVIDER")
+                or ""
+            )
+            .strip()
+            .lower()
+        )
+
+    @staticmethod
+    def _copyback_dirty_provider_modes() -> set[str]:
+        return {"copyback", "copy-back", "model_copyback", "copy_main_to_model"}
+
+    def _prepare_copyback_dirty_bit_provider(self) -> None:
+        if (
+            not delta_transfer_enabled()
+            or not dirty_bit_detector_enabled()
+            or self._dirty_bit_provider_mode()
+            not in self._copyback_dirty_provider_modes()
+        ):
+            return
+        self._copyback_dirty_bitsets = []
+        self._copyback_dirty_bitsets_complete = True
+        self._copyback_dirty_collect_ms = 0.0
+        self._copyback_dirty_name_resolver = self._step_dirty_name_resolver()
+        self._copyback_dirty_seen_copy = False
+        for opt in self._get_inner_optimizers():
+            if getattr(opt, "_areal_copyback_dirty_patched", False):
+                continue
+            original = getattr(opt, "_copy_main_params_to_model_params", None)
+            if original is None:
+                self._copyback_dirty_bitsets_complete = False
+                continue
+
+            adapter = self
+
+            def make_wrapped(original_copy):
+                def wrapped_copy(optimizer_self, *args, **kwargs):
+                    return adapter._copyback_dirty_then_copy(
+                        optimizer_self,
+                        original_copy,
+                        *args,
+                        **kwargs,
+                    )
+
+                return wrapped_copy
+
+            opt._areal_original_copy_main_params_to_model_params = original
+            opt._copy_main_params_to_model_params = MethodType(
+                make_wrapped(original),
+                opt,
+            )
+            opt._areal_copyback_dirty_patched = True
+
+    def _copyback_dirty_then_copy(
+        self,
+        optimizer: object,
+        original_copy,
+        *args,
+        **kwargs,
+    ):
+        try:
+            self._copyback_dirty_seen_copy = True
+            result = collect_copyback_dirty_bitsets(
+                optimizer,
+                name_resolver=self._copyback_dirty_name_resolver,
+            )
+            if self._copyback_dirty_bitsets is None:
+                self._copyback_dirty_bitsets = []
+            self._copyback_dirty_bitsets.extend(result.records)
+            self._copyback_dirty_bitsets_complete = (
+                self._copyback_dirty_bitsets_complete and result.complete
+            )
+            self._copyback_dirty_collect_ms += result.collect_ms
+        except Exception:
+            logger.exception(
+                "Dirty-bit copyback provider failed; this step will dense fallback."
+            )
+            self._copyback_dirty_bitsets = None
+            self._copyback_dirty_bitsets_complete = False
+        return original_copy(*args, **kwargs)
+
+    def _maybe_record_optimizer_dirty_bitsets(
+        self, update_successful: bool
+    ) -> dict[str, float]:
+        if not delta_transfer_enabled() or not dirty_bit_detector_enabled():
+            return {}
+
+        if not update_successful:
+            self.record_optimizer_dirty_bitsets([], complete=True)
+            logger.info(
+                "Dirty-bit provider: optimizer step skipped; recorded empty masks."
+            )
+            return {
+                "perf/dirty_bit_collect_time": 0.0,
+                "perf/dirty_bit_records": 0.0,
+                "perf/dirty_bit_complete": 1.0,
+            }
+
+        provider_mode = self._dirty_bit_provider_mode()
+        if provider_mode in self._copyback_dirty_provider_modes():
+            records = self._copyback_dirty_bitsets
+            complete = self._copyback_dirty_bitsets_complete
+            collect_ms = self._copyback_dirty_collect_ms
+            seen_copy = self._copyback_dirty_seen_copy
+            self._copyback_dirty_bitsets = None
+            self._copyback_dirty_bitsets_complete = False
+            self._copyback_dirty_collect_ms = 0.0
+            self._copyback_dirty_seen_copy = False
+            if records is None or not seen_copy:
+                self._clear_optimizer_dirty_bitsets()
+                logger.warning(
+                    "Dirty-bit copyback provider produced no records; dense fallback."
+                )
+                return {
+                    "perf/dirty_bit_collect_time": collect_ms / 1000,
+                    "perf/dirty_bit_records": 0.0,
+                    "perf/dirty_bit_complete": 0.0,
+                }
+            self.record_optimizer_dirty_bitsets(records, complete=complete)
+            logger.info(
+                "[dte-perf][dirty-bit-provider] provider=copyback "
+                "records=%d complete=%d collect_ms=%.1f",
+                len(records),
+                int(complete),
+                collect_ms,
+            )
+            return {
+                "perf/dirty_bit_collect_time": collect_ms / 1000,
+                "perf/dirty_bit_records": float(len(records)),
+                "perf/dirty_bit_complete": 1.0 if complete else 0.0,
+            }
+
+        if provider_mode not in {"optimizer", "optim", "fused"}:
+            self._clear_optimizer_dirty_bitsets()
+            return {}
+
+        start = time.monotonic()
+        records, complete = self._consume_optimizer_dirty_bitsets()
+        collect_ms = (time.monotonic() - start) * 1000
+        if records is None:
+            self._clear_optimizer_dirty_bitsets()
+            logger.warning(
+                "Dirty-bit provider '%s' produced no records; dense fallback.",
+                provider_mode,
+            )
+            return {
+                "perf/dirty_bit_collect_time": collect_ms / 1000,
+                "perf/dirty_bit_records": 0.0,
+                "perf/dirty_bit_complete": 0.0,
+            }
+
+        self.record_optimizer_dirty_bitsets(records, complete=complete)
+        logger.info(
+            "[dte-perf][dirty-bit-provider] records=%d complete=%d collect_ms=%.1f",
+            len(records),
+            int(complete),
+            collect_ms,
+        )
+        return {
+            "perf/dirty_bit_collect_time": collect_ms / 1000,
+            "perf/dirty_bit_records": float(len(records)),
+            "perf/dirty_bit_complete": 1.0 if complete else 0.0,
+        }
+
+    def _consume_optimizer_dirty_bitsets(
+        self,
+    ) -> tuple[list[MCoreShardDirtyBitset] | None, bool]:
+        records: list[MCoreShardDirtyBitset] = []
+        saw_provider = False
+        complete = True
+
+        for opt in self._get_inner_optimizers():
+            opt_has_provider = False
+            for candidate in (opt, getattr(opt, "optimizer", None)):
+                if candidate is None:
+                    continue
+                raw = self._read_dirty_bitset_provider(candidate)
+                if raw is None:
+                    continue
+                opt_has_provider = True
+                saw_provider = True
+                provider_records, provider_complete = self._normalize_dirty_bitsets(
+                    raw,
+                    default_complete=getattr(
+                        candidate,
+                        "areal_dirty_bitsets_complete",
+                        True,
+                    ),
+                )
+                records.extend(provider_records)
+                complete = complete and provider_complete
+                break
+            if not opt_has_provider:
+                complete = False
+
+        if not saw_provider:
+            return None, False
+        return records, complete
+
+    @staticmethod
+    def _read_dirty_bitset_provider(candidate: object):
+        for method_name in (
+            "areal_consume_dirty_bitsets",
+            "consume_dirty_bitsets",
+            "pop_dirty_bitsets",
+        ):
+            method = getattr(candidate, method_name, None)
+            if method is not None:
+                return method()
+        for attr_name in ("areal_dirty_bitsets", "dirty_bitsets"):
+            if hasattr(candidate, attr_name):
+                return getattr(candidate, attr_name)
+        return None
+
+    @staticmethod
+    def _normalize_dirty_bitsets(
+        raw,
+        *,
+        default_complete: bool,
+    ) -> tuple[list[MCoreShardDirtyBitset], bool]:
+        complete = bool(default_complete)
+        records_raw = raw
+        if isinstance(raw, MCoreShardDirtyBitset):
+            records_raw = [raw]
+        elif isinstance(raw, Mapping):
+            complete = bool(raw.get("complete", complete))
+            if "name" in raw and "packed_bitset" in raw:
+                records_raw = [raw]
+            else:
+                records_raw = (
+                    raw.get("records")
+                    or raw.get("bitsets")
+                    or raw.get("dirty_bitsets")
+                    or []
+                )
+        elif isinstance(raw, tuple) and len(raw) == 2:
+            records_raw, complete = raw
+            complete = bool(complete)
+
+        records = [
+            AwexMegatronAdapter._normalize_dirty_bitset_record(record)
+            for record in records_raw
+        ]
+        return records, complete
+
+    @staticmethod
+    def _normalize_dirty_bitset_record(record) -> MCoreShardDirtyBitset:
+        if isinstance(record, MCoreShardDirtyBitset):
+            return record
+        if not isinstance(record, Mapping):
+            raise TypeError(
+                "dirty-bit provider records must be MCoreShardDirtyBitset or mapping"
+            )
+        packed = record["packed_bitset"]
+        if not isinstance(packed, torch.Tensor):
+            raise TypeError("dirty-bit provider packed_bitset must be a tensor")
+        if packed.dtype != torch.uint8:
+            raise TypeError(
+                f"dirty-bit provider packed_bitset must be uint8, got {packed.dtype}"
+            )
+        return MCoreShardDirtyBitset(
+            name=str(record["name"]),
+            packed_bitset=packed,
+            shape=tuple(int(dim) for dim in record["shape"]),
+            shard_start=int(record["shard_start"]),
+            shard_numel=int(record["shard_numel"]),
+        )
+
+    def record_optimizer_dirty_bitsets(
+        self,
+        shard_bitsets,
+        *,
+        version: int | None = None,
+        complete: bool = False,
+    ) -> None:
+        """Record B2 fused optimizer dirty-bit output for the next payload.
+
+        ``complete`` must only be true when the provider covered every optimizer
+        shard relevant to the current payload. The dirty-bit detector refuses to
+        emit sparse masks from partial records because missing coverage would be
+        a false negative.
+        """
+        self._optimizer_dirty_bitsets = [
+            self._normalize_dirty_bitset_record(record) for record in shard_bitsets
+        ]
+        self._optimizer_dirty_bitsets_version = version
+        self._optimizer_dirty_bitsets_complete = bool(complete)
+
+    def _clear_optimizer_dirty_bitsets(self, version: int | None = None) -> None:
+        if version is not None and self._optimizer_dirty_bitsets_version not in {
+            None,
+            version,
+        }:
+            return
+        self._optimizer_dirty_bitsets = None
+        self._optimizer_dirty_bitsets_version = None
+        self._optimizer_dirty_bitsets_complete = False
+
+    @staticmethod
+    def _dirty_bit_collective_device() -> torch.device:
+        if torch.cuda.is_available():
+            return torch.device("cuda", torch.cuda.current_device())
+        return torch.device("cpu")
+
+    @staticmethod
+    def _is_expert_mcore_param(name: str) -> bool:
+        return ".mlp.experts." in name
+
+    @staticmethod
+    def _dirty_bit_records_to_payload(
+        records: list[MCoreShardDirtyBitset],
+        *,
+        device: torch.device,
+    ) -> tuple[list[dict[str, Any]], torch.Tensor]:
+        metadata: list[dict[str, Any]] = []
+        payloads: list[torch.Tensor] = []
+        offset = 0
+        for record in records:
+            packed = record.packed_bitset.reshape(-1).to(
+                device=device,
+                dtype=torch.uint8,
+                copy=True,
+            )
+            nbytes = int(packed.numel())
+            metadata.append(
+                {
+                    "name": record.name,
+                    "shape": tuple(record.shape),
+                    "shard_start": int(record.shard_start),
+                    "shard_numel": int(record.shard_numel),
+                    "offset": offset,
+                    "nbytes": nbytes,
+                }
+            )
+            payloads.append(packed)
+            offset += nbytes
+        if payloads:
+            payload = torch.cat(payloads, dim=0)
+        else:
+            payload = torch.empty(0, dtype=torch.uint8, device=device)
+        return metadata, payload
+
+    @staticmethod
+    def _dirty_bit_records_from_payload(
+        metadata_by_rank: list[list[dict[str, Any]]],
+        payloads_by_rank: list[torch.Tensor],
+        lengths: list[int],
+    ) -> list[MCoreShardDirtyBitset]:
+        records: list[MCoreShardDirtyBitset] = []
+        for rank_metadata, payload, length in zip(
+            metadata_by_rank,
+            payloads_by_rank,
+            lengths,
+        ):
+            rank_payload = payload[:length]
+            for item in rank_metadata:
+                offset = int(item["offset"])
+                nbytes = int(item["nbytes"])
+                records.append(
+                    MCoreShardDirtyBitset(
+                        name=str(item["name"]),
+                        packed_bitset=rank_payload[offset : offset + nbytes].clone(),
+                        shape=tuple(int(dim) for dim in item["shape"]),
+                        shard_start=int(item["shard_start"]),
+                        shard_numel=int(item["shard_numel"]),
+                    )
+                )
+        return records
+
+    def _dirty_bit_dp_group(self):
+        try:
+            from megatron.core import parallel_state as mpu
+
+            return mpu.get_data_parallel_group()
+        except Exception:
+            return None
+
+    def _dirty_bit_global_ready(self, local_ready: bool) -> bool:
+        if not dist.is_available() or not dist.is_initialized():
+            return local_ready
+        group = self._dirty_bit_dp_group()
+        try:
+            world_size = dist.get_world_size(group)
+        except Exception:
+            world_size = 1
+        if world_size <= 1:
+            return local_ready
+
+        device = self._dirty_bit_collective_device()
+        ready = torch.tensor(
+            [1 if local_ready else 0],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(ready, op=dist.ReduceOp.MIN, group=group)
+        return bool(ready.item())
+
+    def _gather_non_expert_dirty_bitsets_across_dp(
+        self,
+        shard_bitsets: list[MCoreShardDirtyBitset],
+    ) -> list[MCoreShardDirtyBitset]:
+        """Gather non-expert dirty-bit shards across the dense DP group.
+
+        Distributed optimizer shards split replicated non-expert parameters
+        across DP ranks.  A local dirty-bit provider therefore only covers this
+        rank's flat range; each sender needs the whole DP group's ranges to emit
+        a complete HF sparse mask without dense fallback.  Expert-local records
+        remain local because their parameter ownership follows the EP mapping.
+        """
+        local_non_expert = [
+            record
+            for record in shard_bitsets
+            if not self._is_expert_mcore_param(record.name)
+        ]
+        local_expert = [
+            record
+            for record in shard_bitsets
+            if self._is_expert_mcore_param(record.name)
+        ]
+        if not dist.is_available() or not dist.is_initialized():
+            return shard_bitsets
+        group = self._dirty_bit_dp_group()
+        try:
+            world_size = dist.get_world_size(group)
+        except Exception:
+            world_size = 1
+        if world_size <= 1:
+            return shard_bitsets
+
+        device = self._dirty_bit_collective_device()
+        local_metadata, local_payload = self._dirty_bit_records_to_payload(
+            local_non_expert,
+            device=device,
+        )
+        metadata_by_rank: list[list[dict[str, Any]]] = [None] * world_size  # type: ignore[list-item]
+        dist.all_gather_object(metadata_by_rank, local_metadata, group=group)
+
+        local_len = torch.tensor(
+            [local_payload.numel()],
+            dtype=torch.int64,
+            device=device,
+        )
+        gathered_lens = [torch.empty_like(local_len) for _ in range(world_size)]
+        dist.all_gather(gathered_lens, local_len, group=group)
+        lengths = [int(length.item()) for length in gathered_lens]
+        max_len = max(lengths, default=0)
+        if max_len == 0:
+            gathered_non_expert: list[MCoreShardDirtyBitset] = []
+        else:
+            if local_payload.numel() < max_len:
+                padded_payload = torch.empty(max_len, dtype=torch.uint8, device=device)
+                if local_payload.numel() > 0:
+                    padded_payload[: local_payload.numel()].copy_(local_payload)
+            else:
+                padded_payload = local_payload
+            gathered_payloads = [
+                torch.empty(max_len, dtype=torch.uint8, device=device)
+                for _ in range(world_size)
+            ]
+            dist.all_gather(gathered_payloads, padded_payload, group=group)
+            gathered_non_expert = self._dirty_bit_records_from_payload(
+                metadata_by_rank,
+                gathered_payloads,
+                lengths,
+            )
+        logger.info(
+            "Dirty-bit detector: gathered %d local and %d DP non-expert records "
+            "across dp_size=%d",
+            len(local_non_expert),
+            len(gathered_non_expert),
+            world_size,
+        )
+        return gathered_non_expert + local_expert
+
+    def _qwen3_moe_index_remap_config(self) -> Qwen3MoeIndexRemapConfig:
+        cfg = self._engine.tf_config
+        rank_info = self._rank_info_or_none()
+        ep_size = rank_info.ep_size if rank_info is not None else 1
+        ep_rank = rank_info.ep_rank if rank_info is not None else 0
+        head_dim = getattr(cfg, "kv_channels", None)
+        if head_dim is None:
+            head_dim = getattr(cfg, "head_dim", None)
+        if head_dim is None:
+            head_dim = cfg.hidden_size // cfg.num_attention_heads
+        if getattr(cfg, "num_query_groups", None) is None:
+            raise ValueError("Qwen3-MoE dirty-bit remap requires num_query_groups")
+        hf_config = getattr(self._engine, "hf_config", None)
+        num_moe_experts = getattr(hf_config, "num_experts", None)
+        if num_moe_experts is None:
+            num_moe_experts = getattr(cfg, "num_moe_experts", None)
+        return Qwen3MoeIndexRemapConfig(
+            hidden_size=int(cfg.hidden_size),
+            num_attention_heads=int(cfg.num_attention_heads),
+            num_query_groups=int(cfg.num_query_groups),
+            head_dim=int(head_dim),
+            num_moe_experts=(
+                int(num_moe_experts) if num_moe_experts is not None else None
+            ),
+            expert_model_parallel_size=int(ep_size),
+            expert_model_parallel_rank=int(ep_rank),
+        )
+
+    def _dirty_bitset_masks_from_optimizer(
+        self,
+        names: list[str],
+        tensors: list[torch.Tensor],
+        version: int,
+    ) -> dict[str, torch.Tensor] | None:
+        shard_bitsets = self._optimizer_dirty_bitsets
+        version_matches = self._optimizer_dirty_bitsets_version in {None, version}
+        local_ready = (
+            shard_bitsets is not None
+            and self._optimizer_dirty_bitsets_complete
+            and version_matches
+        )
+        if not self._dirty_bit_global_ready(local_ready):
+            return None
+        if not version_matches:
+            logger.warning(
+                "Dirty-bit detector: version mismatch, records=%s payload=%d",
+                self._optimizer_dirty_bitsets_version,
+                version,
+            )
+            return None
+        if shard_bitsets is None:
+            return None
+        device_by_name = {name: tensor.device for name, tensor in zip(names, tensors)}
+        if not shard_bitsets:
+            return {
+                name: torch.empty(0, dtype=torch.int32, device=device_by_name[name])
+                for name in names
+            }
+        rank_info = self._rank_info_or_none()
+        dp_size = rank_info.dp_size if rank_info is not None else 1
+        if dp_size > 1:
+            original_count = len(shard_bitsets)
+            shard_bitsets = self._gather_non_expert_dirty_bitsets_across_dp(
+                shard_bitsets
+            )
+            logger.info(
+                "Dirty-bit detector: dp_size=%d, using %d/%d local+gathered bitsets",
+                dp_size,
+                len(shard_bitsets),
+                original_count,
+            )
+        masks = remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks(
+            shard_bitsets,
+            self._qwen3_moe_index_remap_config(),
+            hf_names=names,
+            device_by_hf_name=device_by_name,
+            fill_all_hf_names=True,
+        )
+        logger.info(
+            "Dirty-bit detector: remapped %d mcore shard bitsets to %d HF masks",
+            len(shard_bitsets),
+            len(masks),
+        )
+        return masks
+
+    @staticmethod
+    def _get_optimizer_state_owner(opt):
+        """Return the torch optimizer object that owns ``state``.
+
+        Megatron's ChainedOptimizer exposes an ``optimizer`` property inherited
+        from MegatronOptimizer, but accessing it asserts when there is more than
+        one child optimizer. Callers should flatten chains first, then use this
+        helper for wrappers such as DistributedOptimizer.
+        """
+        state = getattr(opt, "state", None)
+        if state is not None:
+            return opt
+        try:
+            base_opt = opt.optimizer
+        except AttributeError:
+            return opt
+        except AssertionError as exc:
+            logger.warning(
+                "Skipping optimizer state owner lookup for %s: %s",
+                type(opt).__name__,
+                exc,
+            )
+            return None
+        return base_opt
+
+    @torch.no_grad()
+    def _sync_model_params_from_optimizer(self) -> None:
+        """Make the HF payload read see the latest optimizer main params.
+
+        Megatron's distributed optimizer updates fp32 main-param shards, copies
+        them into DDP param buffers, then all-gathers into the model-visible
+        params. Colocate weight exchange can run after offload/resume, so do a
+        conservative copy + synchronous param sync before reading HF tensors.
+        """
+        copied = 0
+        gathered = 0
+        for opt in self._get_inner_optimizers():
+            copy_fn = getattr(opt, "_copy_main_params_to_model_params", None)
+            if copy_fn is None:
+                copy_fn = getattr(opt, "_copy_main_params_to_param_buffer", None)
+            if copy_fn is None:
+                continue
+            copy_fn()
+            copied += 1
+
+            gather_fn = getattr(
+                opt, "_reset_metadata_and_sync_gather_all_model_params", None
+            )
+            if gather_fn is not None:
+                gather_fn(force_sync=True)
+                gathered += 1
+
+        model = self._engine.model
+        if model is None:
+            return
+        model_chunks = model if isinstance(model, (list, tuple)) else [model]
+        synced = 0
+        if gathered == 0:
+            for model_chunk in model_chunks:
+                start_param_sync = getattr(model_chunk, "start_param_sync", None)
+                if start_param_sync is None:
+                    continue
+                start_param_sync(force_sync=True)
+                synced += 1
+
+        if copied or gathered or synced:
+            torch.cuda.synchronize()
+            logger.info(
+                "Synced Megatron optimizer main params before AWEX payload read "
+                "(copied=%d, optimizer_gather=%d, param_sync=%d)",
+                copied,
+                gathered,
+                synced,
+            )
+
+    @torch.no_grad()
+    def _convert_hf_with_overrides(
+        self, theta_by_id: dict[int, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Convert mcore params to HF, substituting reconstructed pre-step
+        weights by ``id(model_param)``.
+
+        The inversion detector builds the previous-version HF payload through
+        this (the same all_gather + convert path as the live payload), then
+        bitwise-compares it against the current payload to get change masks.
+        """
+        if self._awex_weight_converter is not None:
+            return self._convert_parameters(theta_by_id=theta_by_id)
+        return dict(self._iter_hf_params(theta_by_id))
+
+    @torch.no_grad()
+    def _iter_hf_with_overrides(self, theta_by_id: dict[int, torch.Tensor]):
+        """Yield HF params with reconstructed overrides without materializing all.
+
+        Consumes ``theta_by_id`` as it iterates: reconstructed fp32 pre-step
+        tensors are popped (and thus freed) right after conversion, so the
+        AdamW-inversion peak drops as the mask loop advances instead of
+        holding every theta_old alive until the end.
+        """
+        if self._awex_weight_converter is not None:
+            yield from self._iter_convert_parameters(
+                theta_by_id=theta_by_id, consume_overrides=True
+            )
+            return
+        yield from self._iter_hf_params(theta_by_id, consume_overrides=True)
 
     # ── Colocated weight transfer methods ─────────────────────────────────
 
@@ -320,9 +1580,13 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        master_addr: str,
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        expected_delta_enabled: bool | None = None,
+        metadata_path: str = "",
+        infer_conf: dict[str, Any] | None = None,
     ) -> None:
         self._colocate_pair_name = pair_name
         self._colocate_kv_store_url = kv_store_url
@@ -332,15 +1596,517 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         self._colocate_timeout_s = timeout_s
         if self._colocate_http_client is None:
             self._colocate_http_client = httpx.Client()
+        if infer_conf is not None:
+            self._ensure_awex_converter(infer_conf)
+        self._register_colocate_training_device()
         logger.info(
             "Initialized colocate weight update for pair '%s', transfer_rank=%d",
             pair_name,
+            transfer_rank,
+        )
+        local_delta = delta_transfer_enabled()
+        if (
+            expected_delta_enabled is not None
+            and bool(expected_delta_enabled) != local_delta
+        ):
+            raise ValueError(
+                "Colocate delta config mismatch on training rank "
+                f"{transfer_rank}: expected={expected_delta_enabled}, "
+                f"local={local_delta}. Check DTE_DELTA_TRANSFER propagation."
+            )
+        if local_delta and self._delta_tracker is None:
+            # Fail fast: surface a missing dte / bad config at init, not mid-run.
+            self._delta_tracker = make_delta_tracker()
+            logger.info("colocate delta enabled (sender); dte DeltaTracker ready")
+
+    def _register_colocate_training_device(self) -> None:
+        assert self._colocate_http_client is not None
+        ip_address = get_colocate_ip_address()
+        device_id = get_physical_cuda_device_id()
+        self._colocate_device_ip = ip_address
+        self._colocate_device_id = device_id
+
+        pair_name = self._colocate_pair_name
+        transfer_rank = self._colocate_transfer_rank
+        kv_store_url = self._colocate_kv_store_url
+        auth_headers = {"Authorization": f"Bearer {self._colocate_admin_api_key}"}
+        device_key = device_mapping_key(ip_address, device_id)
+        value = {
+            "ip": ip_address,
+            "device_id": device_id,
+            "train_rank": transfer_rank,
+        }
+        resp = self._colocate_http_client.put(
+            f"{kv_store_url}/weight_meta/{pair_name}/"
+            f"colocate_train_rank_by_device_{device_key}",
+            json={"value": transfer_rank},
+            headers=auth_headers,
+            timeout=self._colocate_timeout_s,
+        )
+        resp.raise_for_status()
+        resp = self._colocate_http_client.put(
+            f"{kv_store_url}/weight_meta/{pair_name}/"
+            f"colocate_train_device_by_rank_{transfer_rank}",
+            json={"value": value},
+            headers=auth_headers,
+            timeout=self._colocate_timeout_s,
+        )
+        resp.raise_for_status()
+        logger.info(
+            "Registered colocate training device mapping: ip=%s, device=%s, "
+            "train_rank=%d",
+            ip_address,
+            device_id,
             transfer_rank,
         )
 
     def execute_colocate_weight_update(self, version: int) -> None:
         with self._colocate_lock:
             self._execute_colocate_weight_update_locked(version)
+
+    def precompute_delta_masks(self, version: int) -> bool:
+        """Precompute delta change masks before the optimizer is offloaded.
+
+        The colocate gateway calls this on every training worker right before
+        it issues ``release_memory(tags=["optimizer"])``: at that point the
+        fp32 main shards and AdamW moments are still GPU-resident, so the
+        inversion detector can compute masks without staging 30+GB of
+        optimizer state back from CPU during the sync critical path. The
+        result is cached inside the detector and consumed by the next
+        ``compute_masks`` call for the same version and parameter list.
+
+        All training ranks must enter together (the mask computation and the
+        full-sync promotion below run global collectives). Returns ``True``
+        when masks were cached, ``False`` when precompute was skipped (full
+        sync pending, detector without precompute support, weights already
+        offloaded) -- the sync path then computes masks in-band.
+        """
+        if not delta_transfer_enabled():
+            return False
+        with self._colocate_lock:
+            return self._precompute_delta_masks_locked(version)
+
+    def _precompute_delta_masks_locked(self, version: int) -> bool:
+        self._ensure_delta_components()
+        detector = self._delta_detector
+        precompute = getattr(detector, "precompute_masks", None)
+        if precompute is None:
+            return False
+        t0 = time.monotonic()
+        # Rank-invariant skip decision mirroring _delta_encode: every local
+        # skip reason must flow through the global promotion below so all
+        # ranks either enter the compute_masks collectives together or all
+        # skip together. An early rank-local return here would leave peers
+        # blocked in the WORLD all-reduce.
+        reason: str | None = None
+        if "weights" in self._released_tags:
+            # Payload tensors have empty storage; let the sync path resume
+            # weights and compute masks in-band instead.
+            reason = "weights_offloaded"
+        if reason is None:
+            reason = self._delta_tracker.full_sync_reason(version)
+        if reason is None:
+            has_watermark = getattr(detector, "has_synced_watermark", lambda: False)
+            if not has_watermark():
+                reason = "initial_full"
+        reason = self._delta_sync_full_reason(reason, version)
+        if reason is not None:
+            logger.info(
+                "precompute_delta_masks v%d: full sync pending (%s), skipping",
+                version,
+                reason,
+            )
+            return False
+        self._sync_model_params_from_optimizer()
+        # The sync path can skip its own (collective) param sync for this
+        # version; consumed by _precompute_param_sync_covers with a global
+        # MIN-reduce so all ranks skip or none do.
+        self._precompute_param_synced_version = int(version)
+        params = self.get_local_shard_parameters()
+        feasible = precompute(list(params.keys()), list(params.values()), version)
+        # Capture the detector's synced-state watermark now, while the fp32
+        # main shards and moments are still GPU-resident: the same capture on
+        # the sync critical path reads the offloaded CPU copies and costs
+        # >1 s. Consumed (rank-locally, no collectives involved) by
+        # _delta_capture_synced_state during the sync for the same version.
+        t_cap = time.monotonic()
+        captured = self._delta_capture_synced_state(params)
+        self._precomputed_synced_state = (int(version), captured)
+        logger.info(
+            "[dte-perf][train] v%d rank %d precompute_masks_ms=%.1f "
+            "capture_synced_state_ms=%.1f feasible=%s",
+            version,
+            self._colocate_transfer_rank,
+            (time.monotonic() - t0) * 1000,
+            (time.monotonic() - t_cap) * 1000,
+            feasible,
+        )
+        return bool(feasible)
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Skip virtual delta seeding; the first real update is the full base."""
+        if not delta_transfer_enabled():
+            logger.info("seed_delta_base skipped: delta transfer disabled")
+            return
+        logger.info(
+            "seed_delta_base skipped for DTE delta transfer at v%d; "
+            "the first real payload will be a full sync base",
+            version,
+        )
+
+    def _ensure_delta_components(self) -> None:
+        if self._delta_tracker is None:
+            self._delta_tracker = make_delta_tracker()
+        if self._delta_detector is None:
+            self._delta_detector = build_detector(delta_detector_mode(), self)
+
+    def _needs_external_detector_sync_before_payload(self, version: int) -> bool:
+        """Whether this step needs model params refreshed before mask detection.
+
+        Initial/anchor full syncs should follow the dense AWEX path and avoid
+        the extra Megatron param-sync peak. The sync is only required once we
+        are about to compute external masks for a real delta payload.
+        """
+        if not delta_transfer_enabled():
+            return False
+        detector_mode = delta_detector_mode()
+        if not external_delta_detector_enabled(detector_mode):
+            return False
+        self._ensure_delta_components()
+        reason = self._delta_tracker.full_sync_reason(version)
+        if reason is not None:
+            logger.info(
+                "Skipping Megatron optimizer param sync before payload v%d: "
+                "delta full sync is required (%s)",
+                version,
+                reason,
+            )
+            return False
+        has_watermark = getattr(
+            self._delta_detector, "has_synced_watermark", lambda: False
+        )
+        if not has_watermark():
+            logger.info(
+                "Skipping Megatron optimizer param sync before payload v%d: "
+                "detector watermark missing; first payload will be full sync",
+                version,
+            )
+            return False
+        return True
+
+    def _precompute_param_sync_covers(self, version: int) -> bool:
+        """Whether every rank already param-synced for ``version`` in precompute.
+
+        ``_sync_model_params_from_optimizer`` runs Megatron param-gather
+        collectives, so skipping it during the sync must be a rank-invariant
+        decision: if any rank missed the precompute (e.g. restarted worker),
+        all ranks redo the sync together. A 1-int global MIN-reduce promotes
+        any local miss, mirroring the detector's mask-cache handshake. The
+        redo is idempotent (same fp32 main -> bf16 copy), so correctness never
+        depends on the cache hitting.
+        """
+        local = self._precompute_param_synced_version == int(version)
+        self._precompute_param_synced_version = None
+        if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+            device = (
+                torch.device("cuda", torch.cuda.current_device())
+                if torch.cuda.is_available()
+                else torch.device("cpu")
+            )
+            flag = torch.tensor([1 if local else 0], dtype=torch.int32, device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MIN)
+            if int(flag.item()) == 0:
+                if local:
+                    logger.warning(
+                        "v%d: redoing param sync on all ranks; another rank "
+                        "missed its precompute param-sync marker",
+                        version,
+                    )
+                return False
+        return local
+
+    @staticmethod
+    def _colocate_full_group_max_bytes() -> int:
+        raw = os.environ.get("DTE_COLOCATE_FULL_GROUP_MAX_BYTES")
+        if raw is None or raw.strip() == "":
+            raw = os.environ.get("AWEX_COLOCATE_FULL_GROUP_MAX_BYTES")
+        if raw is None or raw.strip() == "":
+            return 512 * 1024 * 1024
+        try:
+            return max(int(raw), 1)
+        except ValueError as exc:
+            raise ValueError(
+                "DTE_COLOCATE_FULL_GROUP_MAX_BYTES must be an integer byte count"
+            ) from exc
+
+    def _full_tensors_for_ipc(
+        self,
+        tensors: list[torch.Tensor],
+        names: list[str] | None = None,
+    ) -> tuple[list[torch.Tensor], list[dict]]:
+        """Build bounded AWEX groups for colocated full-sync IPC.
+
+        The first delta-transfer frame is a dense full sync. It must use
+        exporter-owned storage because training weights are offloaded before the
+        inference process maps the CUDA IPC handles. One handle per parameter is
+        fragile for large colocated Megatron shards, while AWEX's default 5 GiB
+        groups can create too high a temporary cat+clone peak. This path keeps
+        AWEX's cat+clone ownership invariant but caps each same-shape group.
+        """
+        if names is not None and len(names) != len(tensors):
+            raise ValueError(
+                "names must match tensors when building colocate IPC payload"
+            )
+
+        max_group_bytes = self._colocate_full_group_max_bytes()
+        live_storages = self._live_module_storage_ptrs()
+        group_tensors: list[torch.Tensor] = []
+        metadata: list[dict] = []
+        packed_live = 0
+        packed_owned = 0
+        made_contiguous = 0
+        zero_sized = 0
+        oversized_groups = 0
+        # Bucket by dtype only. Reconstruction slices each entry by
+        # offset/size and reshapes from per-entry metadata, so same-shape
+        # packing is not required for correctness — and keying by shape
+        # degenerates to one group per parameter on sparse delta payloads
+        # (every param's values/indices have unique lengths), recreating the
+        # per-parameter handle flood this grouping exists to avoid (observed:
+        # 4636 groups for 4888 params, receiver cudaIpcOpenMemHandle driver
+        # OOM with >50GB free).
+        buckets: dict[torch.dtype, list[int]] = {}
+
+        def append_zero_group(original_index: int, source: torch.Tensor) -> None:
+            nonlocal zero_sized
+            group_index = len(group_tensors)
+            group_tensors.append(
+                torch.empty((1,), dtype=source.dtype, device=source.device)
+            )
+            metadata.append(
+                {
+                    "original_index": original_index,
+                    "shape": source.shape,
+                    "dtype": source.dtype,
+                    "group_index": group_index,
+                    "offset": 0,
+                    "size": 0,
+                }
+            )
+            zero_sized += 1
+
+        for original_index, tensor in enumerate(tensors):
+            source = tensor.detach()
+            if source.numel() == 0:
+                append_zero_group(original_index, source)
+                continue
+            buckets.setdefault(source.dtype, []).append(original_index)
+
+        def finalize_group(
+            current: list[tuple[int, torch.Tensor, torch.Size, torch.dtype, int]],
+            current_bytes: int,
+        ) -> None:
+            nonlocal oversized_groups
+            if not current:
+                return
+            if current_bytes > max_group_bytes:
+                oversized_groups += 1
+            group_index = len(group_tensors)
+            flat_tensors = [entry[1].reshape(-1) for entry in current]
+            group_tensor = torch.cat(flat_tensors, dim=0).clone()
+            group_tensors.append(group_tensor)
+            offset = 0
+            for original_index, _flat, shape, dtype, size in current:
+                metadata.append(
+                    {
+                        "original_index": original_index,
+                        "shape": shape,
+                        "dtype": dtype,
+                        "group_index": group_index,
+                        "offset": offset,
+                        "size": size,
+                    }
+                )
+                offset += size
+
+        for indices in buckets.values():
+            current: list[tuple[int, torch.Tensor, torch.Size, torch.dtype, int]] = []
+            current_bytes = 0
+            for original_index in indices:
+                source = tensors[original_index].detach()
+                tensor_bytes = source.numel() * source.element_size()
+                if current and current_bytes + tensor_bytes > max_group_bytes:
+                    finalize_group(current, current_bytes)
+                    current = []
+                    current_bytes = 0
+
+                aliases_live_storage = (
+                    source.untyped_storage().data_ptr() in live_storages
+                )
+                compact = source.contiguous()
+                if (
+                    compact.untyped_storage().data_ptr()
+                    != source.untyped_storage().data_ptr()
+                ):
+                    made_contiguous += 1
+                if aliases_live_storage:
+                    packed_live += 1
+                else:
+                    packed_owned += 1
+                current.append(
+                    (
+                        original_index,
+                        compact,
+                        source.shape,
+                        source.dtype,
+                        source.numel(),
+                    )
+                )
+                current_bytes += tensor_bytes
+            finalize_group(current, current_bytes)
+
+        logger.info(
+            "Built bounded colocate full IPC payload: params=%d, groups=%d, "
+            "max_group_bytes=%d, packed_live_sources=%d, packed_owned_sources=%d, "
+            "made_contiguous=%d, zero_sized=%d, oversized_groups=%d",
+            len(tensors),
+            len(group_tensors),
+            max_group_bytes,
+            packed_live,
+            packed_owned,
+            made_contiguous,
+            zero_sized,
+            oversized_groups,
+        )
+        return group_tensors, metadata
+
+    def _ungrouped_tensors_for_ipc(
+        self,
+        tensors: list[torch.Tensor],
+        names: list[str] | None = None,
+    ) -> tuple[list[torch.Tensor], list[dict]]:
+        """Build one tensor per IPC group.
+
+        Kept for targeted diagnostics; full sync uses ``_full_tensors_for_ipc``
+        so large colocated shards do not export hundreds of CUDA IPC handles.
+        """
+        live_storages = self._live_module_storage_ptrs()
+        group_tensors: list[torch.Tensor] = []
+        metadata: list[dict] = []
+        cloned_live = 0
+        cloned_owned = 0
+        made_contiguous = 0
+        zero_sized = 0
+        for original_index, tensor in enumerate(tensors):
+            source = tensor.detach()
+            aliases_live_storage = source.untyped_storage().data_ptr() in live_storages
+            if names is not None and original_index >= len(names):
+                raise ValueError(
+                    "names must match tensors when building colocate IPC payload"
+                )
+            if source.numel() == 0:
+                group_tensor = torch.empty(
+                    (1,),
+                    dtype=source.dtype,
+                    device=source.device,
+                )
+                zero_sized += 1
+            else:
+                compact = source.contiguous()
+                if (
+                    compact.untyped_storage().data_ptr()
+                    == source.untyped_storage().data_ptr()
+                ):
+                    group_tensor = compact.clone(memory_format=torch.contiguous_format)
+                    if aliases_live_storage:
+                        cloned_live += 1
+                    else:
+                        cloned_owned += 1
+                else:
+                    group_tensor = compact
+                    made_contiguous += 1
+
+            if aliases_live_storage and source.numel() == 0:
+                cloned_live += 1
+            group_tensors.append(group_tensor)
+            metadata.append(
+                {
+                    "original_index": original_index,
+                    "shape": source.shape,
+                    "dtype": source.dtype,
+                    "group_index": original_index,
+                    "offset": 0,
+                    "size": source.numel(),
+                }
+            )
+        logger.info(
+            "Built ungrouped colocate IPC payload: params=%d, "
+            "cloned_live_aliases=%d, cloned_owned=%d, "
+            "made_contiguous=%d, zero_sized=%d",
+            len(group_tensors),
+            cloned_live,
+            cloned_owned,
+            made_contiguous,
+            zero_sized,
+        )
+        return group_tensors, metadata
+
+    @staticmethod
+    def _ipc_tensor_debug(name: str, tensor: torch.Tensor) -> str:
+        try:
+            storage_size = tensor.untyped_storage().size()
+            storage_ptr = tensor.untyped_storage().data_ptr()
+        except Exception:
+            storage_size = "?"
+            storage_ptr = "?"
+        return (
+            f"name={name} shape={tuple(tensor.shape)} dtype={tensor.dtype} "
+            f"device={tensor.device} numel={tensor.numel()} "
+            f"contiguous={tensor.is_contiguous()} "
+            f"storage_offset={tensor.storage_offset()} "
+            f"storage_size={storage_size} data_ptr={storage_ptr}"
+        )
+
+    def _share_tensors_for_cuda_ipc(
+        self,
+        tensors: list[torch.Tensor],
+        names: list[str],
+        metadata: list[dict],
+    ) -> list[torch.Tensor]:
+        shared: list[torch.Tensor] = []
+        for group_index, tensor in enumerate(tensors):
+            meta_name = names[metadata[group_index]["original_index"]]
+            try:
+                shared.append(tensor.share_memory_())
+            except Exception as exc:
+                raise RuntimeError(
+                    "Failed to prepare colocate CUDA IPC tensor: "
+                    + self._ipc_tensor_debug(meta_name, tensor)
+                ) from exc
+        return shared
+
+    def _validate_colocate_cuda_ipc_payload(
+        self,
+        tensors: list[torch.Tensor],
+        names: list[str],
+        metadata: list[dict],
+    ) -> None:
+        env = os.environ.get("DTE_VALIDATE_COLOCATE_IPC", "")
+        if env.strip().lower() not in {"1", "true", "yes", "on"}:
+            return
+        for group_index, tensor in enumerate(tensors):
+            meta = dict(metadata[group_index])
+            name = names[meta["original_index"]]
+            meta["original_index"] = 0
+            meta["group_index"] = 0
+            try:
+                cuda_ipc_serialize(([tensor], [meta], [name]))
+            except Exception as exc:
+                raise RuntimeError(
+                    "Colocate CUDA IPC validation failed: "
+                    + self._ipc_tensor_debug(name, tensor)
+                ) from exc
+        logger.info("Validated %d colocate CUDA IPC tensor groups", len(tensors))
 
     def _execute_colocate_weight_update_locked(self, version: int) -> None:
         kv_store_url = self._colocate_kv_store_url
@@ -352,69 +2118,619 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         client = self._colocate_http_client
         auth_headers = {"Authorization": f"Bearer {self._colocate_admin_api_key}"}
         timeout_s = self._colocate_timeout_s
+        perf_start = time.monotonic()
+        perf_prev = perf_start
+        # Reset the peak counter so the first stage's peak_mb is attributable.
+        cuda_mem_stats_mb()
+
+        def perf_mark(stage: str) -> None:
+            nonlocal perf_prev
+            now = time.monotonic()
+            alloc_mb, peak_mb = cuda_mem_stats_mb()
+            logger.info(
+                "[dte-perf][train] v%d rank %d %s_ms=%.1f total_ms=%.1f "
+                "alloc_mb=%.0f peak_mb=%.0f",
+                version,
+                transfer_rank,
+                stage,
+                (now - perf_prev) * 1000,
+                (now - perf_start) * 1000,
+                alloc_mb,
+                peak_mb,
+            )
+            perf_prev = now
 
         weights_offloaded = "weights" in self._released_tags
-        if weights_offloaded:
+        if torch.cuda.is_available():
+            torch.cuda.ipc_collect()
+        perf_mark("ipc_collect")
+
+        sync_env = os.environ.get("DTE_SYNC_MODEL_PARAMS_BEFORE_PAYLOAD")
+        if sync_env is None or sync_env.strip() == "":
+            sync_env = os.environ.get("AWEX_SYNC_MODEL_PARAMS_BEFORE_PAYLOAD")
+        if sync_env is None or sync_env.strip() == "":
+            # AdamW inversion compares and sends the BF16 HF payload, so the
+            # model-visible Megatron buffers must reflect the latest fp32 main
+            # params before we read them. Dirty-bit mode has the same payload
+            # freshness requirement even though its masks come from optimizer
+            # metadata. This is a GPU-side refresh, not a CPU snapshot.
+            sync_before_payload = (
+                delta_transfer_enabled()
+                and external_delta_detector_enabled(delta_detector_mode())
+            )
+            sync_uses_detector_gate = True
+        else:
+            sync_before_payload = sync_env.strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+            sync_uses_detector_gate = False
+        did_resume_weights_for_sync = False
+        if sync_before_payload:
+            should_sync = (
+                self._needs_external_detector_sync_before_payload(version)
+                if sync_uses_detector_gate
+                else True
+            )
+            if should_sync and self._precompute_param_sync_covers(version):
+                # Precompute already copied fp32 main params into the model
+                # params for this version (no optimizer step since); skip the
+                # redundant ~1.4 s copy + param gather on the critical path.
+                logger.info(
+                    "v%d: skipping param sync before payload; precompute "
+                    "already synced model params",
+                    version,
+                )
+                should_sync = False
+            if should_sync and weights_offloaded:
+                self.resume_memory(tags=["weights"])
+                did_resume_weights_for_sync = True
+            if should_sync:
+                self._sync_model_params_from_optimizer()
+                perf_mark("sync_model_params")
+        if weights_offloaded and not did_resume_weights_for_sync:
             self.resume_memory(tags=["weights"])
-
+            perf_mark("resume_weights_for_payload")
         params = self.get_local_shard_parameters()
-        tensors = list(params.values())
-        names = list(params.keys())
+        perf_mark("get_local_shard_params")
+        zero_copy_full_payload = False
+        if delta_transfer_enabled():
+            names, tensors, zero_copy_full_payload = self._delta_encode(params, version)
+        else:
+            tensors = list(params.values())
+            names = list(params.keys())
+        perf_mark("delta_or_full_encode")
 
-        group_tensors, metadata = group_tensors_by_shape_and_dtype(tensors)
+        delta_synced_state = self._pop_precomputed_synced_state(version)
+        if delta_synced_state is _CAPTURE_MISS:
+            delta_synced_state = self._delta_capture_synced_state(params)
+        perf_mark("capture_synced_state")
+        self.release_memory(tags=["optimizer"])
+        perf_mark("release_optimizer")
+        self._release_grad_memory()
+        perf_mark("release_grad")
+
+        if zero_copy_full_payload:
+            group_tensors, metadata = self._full_tensors_for_ipc(tensors, names)
+            logger.info(
+                "Using bounded colocate full payload for v%d (params=%d, groups=%d)",
+                version,
+                len(tensors),
+                len(group_tensors),
+            )
+        else:
+            group_tensors, metadata = group_tensors_by_shape_and_dtype(tensors)
         torch.cuda.synchronize()
+        perf_mark("group_payload_tensors")
 
-        del tensors
+        if not zero_copy_full_payload:
+            self._release_owned_payload_tensors(tensors)
+            perf_mark("release_owned_payload_tensors")
+        del tensors, params
 
-        group_shared = [t.share_memory_() for t in group_tensors]
-        serialized_weights = cuda_ipc_serialize((group_shared, metadata, names))
-        torch.cuda.synchronize()
+        if zero_copy_full_payload:
+            live_storages = self._live_module_storage_ptrs()
+            live_aliases = sum(
+                t.untyped_storage().data_ptr() in live_storages for t in group_tensors
+            )
+            if live_aliases:
+                raise RuntimeError(
+                    "Ungrouped colocate full payload still aliases live model "
+                    f"storage for {live_aliases} tensors; refusing to offload "
+                    "weights before IPC transfer"
+                )
 
-        kv_key = f"colocate_weights_rank{transfer_rank}_{version}"
+        self.release_memory(tags=["weights"])
+        perf_mark("release_weights")
 
+        offloaded_key = (
+            f"colocate_train_weights_offloaded_rank{transfer_rank}_{version}"
+        )
         client.put(
-            f"{kv_store_url}/weight_meta/{pair_name}/{kv_key}",
-            json={"value": serialized_weights.hex()},
+            f"{kv_store_url}/weight_meta/{pair_name}/{offloaded_key}",
+            json={"value": True},
             headers=auth_headers,
             timeout=timeout_s,
         )
-
         logger.info(
-            "Serialized %d params (%d groups) for colocate transfer v%d, rank %d",
-            len(names),
-            len(group_shared),
+            "Signaled colocate train weights offloaded for v%d, rank %d",
             version,
             transfer_rank,
         )
+        perf_mark("signal_weights_offloaded")
 
+        kv_key = f"colocate_weights_rank{transfer_rank}_{version}"
         done_key = f"colocate_done_rank{transfer_rank}_{version}"
-        deadline = time.monotonic() + timeout_s
-        poll_count = 0
-        last_status = -1
-        while time.monotonic() < deadline:
-            resp = client.get(
-                f"{kv_store_url}/weight_meta/{pair_name}/{done_key}",
-                timeout=5.0,
+        group_shared: list[torch.Tensor] = []
+        serialized_weights: bytes | None = None
+        try:
+            group_shared = self._share_tensors_for_cuda_ipc(
+                group_tensors,
+                names,
+                metadata,
             )
-            last_status = resp.status_code
-            if resp.status_code == 200:
-                break
-            poll_count += 1
-            time.sleep(0.1)
-        else:
-            raise TimeoutError(
-                f"Inference did not signal completion within {timeout_s}s "
-                f"(waiting_key={done_key}, put_key={kv_key}, "
-                f"polls={poll_count}, last_status={last_status})"
+            perf_mark("share_tensors_for_ipc")
+            self._validate_colocate_cuda_ipc_payload(group_shared, names, metadata)
+            perf_mark("validate_ipc_payload")
+            try:
+                serialized_weights = cuda_ipc_serialize((group_shared, metadata, names))
+            except Exception as exc:
+                examples = "; ".join(
+                    self._ipc_tensor_debug(
+                        names[metadata[i]["original_index"]],
+                        group_shared[i],
+                    )
+                    for i in range(min(3, len(group_shared)))
+                )
+                raise RuntimeError(
+                    "Failed to serialize colocate CUDA IPC payload "
+                    f"(groups={len(group_shared)}, examples={examples})"
+                ) from exc
+            torch.cuda.synchronize()
+            perf_mark("serialize_ipc_payload")
+
+            client.put(
+                f"{kv_store_url}/weight_meta/{pair_name}/{kv_key}",
+                json={"value": serialized_weights.hex()},
+                headers=auth_headers,
+                timeout=timeout_s,
+            )
+            perf_mark("put_serialized_payload")
+
+            logger.info(
+                "Serialized %d params (%d groups) for colocate transfer v%d, rank %d",
+                len(names),
+                len(group_shared),
+                version,
+                transfer_rank,
             )
 
-        del group_shared, group_tensors, serialized_weights
-        torch.cuda.synchronize()
-        gc.collect()
-        torch.cuda.empty_cache()
+            deadline = time.monotonic() + timeout_s
+            poll_count = 0
+            last_status = -1
+            while time.monotonic() < deadline:
+                resp = client.get(
+                    f"{kv_store_url}/weight_meta/{pair_name}/{done_key}",
+                    timeout=5.0,
+                )
+                last_status = resp.status_code
+                if resp.status_code == 200:
+                    break
+                poll_count += 1
+                time.sleep(0.1)
+            else:
+                raise TimeoutError(
+                    f"Inference did not signal completion within {timeout_s}s "
+                    f"(waiting_key={done_key}, put_key={kv_key}, "
+                    f"polls={poll_count}, last_status={last_status})"
+                )
 
-        if weights_offloaded:
-            self.release_memory(tags=["weights"])
+            self._delta_mark_synced(version, delta_synced_state)
+            perf_mark("wait_inference_done_and_mark_synced")
+        finally:
+            release_tensors(group_tensors)
+            if group_shared:
+                release_tensors(group_shared)
+            del group_shared, group_tensors, serialized_weights
+            torch.cuda.synchronize()
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.ipc_collect()
+            torch.cuda.empty_cache()
+            perf_mark("cleanup")
+
+    def _pop_precomputed_synced_state(self, version: int):
+        """Consume the synced state captured during precompute, if it matches.
+
+        Returns :data:`_CAPTURE_MISS` when no capture for ``version`` exists;
+        a genuine ``None`` (inversion infeasible at capture time) is a valid
+        cached value and must flow through to ``mark_synced``. Rank-local by
+        design: the captured state feeds only this rank's watermark bookkeeping
+        and involves no collectives, so a per-rank miss simply recomputes.
+        """
+        cached = self._precomputed_synced_state
+        self._precomputed_synced_state = None
+        if cached is not None and cached[0] == int(version):
+            return cached[1]
+        return _CAPTURE_MISS
+
+    def _delta_capture_synced_state(
+        self, payload_params: dict[str, torch.Tensor] | None = None
+    ):
+        """Capture detector watermarks before colocate weight offload.
+
+        The AdamW inversion detector needs to fingerprint model-visible params.
+        Those tensors have empty storage after ``release_memory(tags=["weights"])``,
+        so capture before offload and commit only after inference confirms the
+        payload was applied.
+        """
+        if not delta_transfer_enabled() or self._delta_detector is None:
+            return None
+        capture = getattr(self._delta_detector, "capture_synced_state", None)
+        if capture is None:
+            return None
+        return capture(payload_params)
+
+    def _delta_mark_synced(self, version: int, captured_state=None) -> None:
+        """Let an external delta detector record post-sync watermarks."""
+        if not delta_transfer_enabled() or self._delta_detector is None:
+            return
+        mark_synced = getattr(self._delta_detector, "mark_synced", None)
+        if mark_synced is not None:
+            mark_synced(version, captured_state)
+
+    def _delta_encode(
+        self, params: dict[str, torch.Tensor], version: int
+    ) -> tuple[list[str], list[torch.Tensor], bool]:
+        """Encode ``params`` as a dte delta/full payload (sender side).
+
+        Mirrors ``dte.engine.DeltaEngine.push`` but ships the payload through the
+        existing cuda-IPC colocate channel instead of a dte transport. A full
+        sync ships plain tensors (header-less, shapes unchanged); a delta ships
+        dte's sparse payload (header + ``w@delta_idx``/``w@delta_val`` + dense
+        fallback). The sglang receiver reconstructs full weights before applying,
+        so delta stays transparent to the cross-rank NCCL reshard.
+
+        The change mask comes from the configured detector (DTE_DELTA_DETECTOR):
+        ``snapshot`` (default) returns None so dte diffs its CPU baseline;
+        ``inversion`` reconstructs pre-step weights from the optimizer's resident
+        moments (zero snapshot memory); ``dirty_bit`` consumes optimizer-emitted
+        mcore shard dirty bitsets. External detector infeasible this step -> dense.
+        """
+        self._ensure_delta_components()
+        detector_name = self._delta_detector.name
+        external_detector = detector_name != "snapshot"
+        verify_snapshot = external_detector and self._delta_verify_snapshot_enabled()
+        names = list(params.keys())
+        tensors = list(params.values())
+        params_list = list(params.items())
+        perf_start = time.monotonic()
+        compute_masks_ms = 0.0
+        verify_ms = 0.0
+        seed_ms = 0.0
+        encode_ms = 0.0
+
+        # Full sync on the first frame (not yet seeded) or a forced anchor.
+        reason = self._delta_tracker.full_sync_reason(version)
+        # External detectors compute masks only when this rank would otherwise
+        # ship a delta. If the detector is infeasible this step, compute_masks
+        # returns None and we fall back to a dense full sync.
+        masks = None
+        if external_detector and reason is None:
+            has_watermark = getattr(
+                self._delta_detector, "has_synced_watermark", lambda: False
+            )
+            if not has_watermark():
+                reason = "initial_full"
+        reason = self._delta_sync_full_reason(reason, version)
+        if external_detector and reason is None:
+            t_compute = time.monotonic()
+            masks = self._delta_detector.compute_masks(names, tensors, version)
+            compute_masks_ms = (time.monotonic() - t_compute) * 1000
+            if masks is None:
+                reason = f"{detector_name}_infeasible"
+            elif verify_snapshot:
+                t_verify = time.monotonic()
+                verified = self._delta_verify_masks_against_snapshot(
+                    params_list, masks, version
+                )
+                verify_ms = (time.monotonic() - t_verify) * 1000
+                if not verified:
+                    reason = f"{detector_name}_snapshot_mismatch"
+
+        reason = self._delta_sync_full_reason(reason, version)
+
+        if reason is not None:
+            # Full sync: ship plain tensors. Re-seed the snapshot baseline in
+            # snapshot mode. External detectors normally keep no baseline, but
+            # verification mode intentionally stores one for mask cross-checks.
+            t_seed = time.monotonic()
+            self._delta_tracker.seed(
+                params_list,
+                version,
+                store_snapshot=(not external_detector or verify_snapshot),
+            )
+            seed_ms = (time.monotonic() - t_seed) * 1000
+            if verify_snapshot:
+                self._delta_mark_snapshot_names(params_list)
+            logger.info(
+                "colocate delta v%d: FULL sync (%s)",
+                version,
+                reason,
+            )
+            logger.info(
+                "[dte-perf][train-delta] v%d detector=%s mode=full "
+                "params=%d compute_masks_ms=%.1f verify_ms=%.1f "
+                "seed_ms=%.1f total_ms=%.1f",
+                version,
+                detector_name,
+                len(params_list),
+                compute_masks_ms,
+                verify_ms,
+                seed_ms,
+                (time.monotonic() - perf_start) * 1000,
+            )
+            return names, tensors, True
+
+        t_encode = time.monotonic()
+        encoded = self._delta_tracker.encode(params_list, version, masks=masks)
+        encode_ms = (time.monotonic() - t_encode) * 1000
+        if verify_snapshot:
+            t_verify = time.monotonic()
+            self._delta_refresh_verification_snapshot(params_list)
+            verify_ms += (time.monotonic() - t_verify) * 1000
+        logger.info(
+            "colocate delta v%d [%s]: changed %d/%d (%.2f%%) "
+            "sparse=%d dense_fallback=%d unchanged=%d "
+            "payload=%.1fMB vs dense=%.1fMB",
+            version,
+            self._delta_detector.name,
+            encoded.changed_elements,
+            encoded.total_elements,
+            100.0 * encoded.changed_elements / max(encoded.total_elements, 1),
+            encoded.num_sparse,
+            encoded.num_dense_fallback,
+            encoded.num_unchanged,
+            encoded.payload_bytes / 1e6,
+            encoded.dense_bytes / 1e6,
+        )
+        logger.info(
+            "[dte-perf][train-delta] v%d detector=%s mode=delta "
+            "params=%d compute_masks_ms=%.1f encode_ms=%.1f verify_ms=%.1f "
+            "payload_mb=%.1f dense_mb=%.1f total_ms=%.1f",
+            version,
+            self._delta_detector.name,
+            len(params_list),
+            compute_masks_ms,
+            encode_ms,
+            verify_ms,
+            encoded.payload_bytes / 1e6,
+            encoded.dense_bytes / 1e6,
+            (time.monotonic() - perf_start) * 1000,
+        )
+        return encoded.names, encoded.tensors, False
+
+    def _delta_sync_full_reason(self, reason: str | None, version: int) -> str | None:
+        """Promote rank-local full-sync decisions to all training ranks.
+
+        Colocated apply runs collectives across inference ranks. If paired
+        training ranks emit a mix of full and delta payloads for one version,
+        inference ranks enter different transfer schedules and can deadlock.
+        """
+        if not dist.is_available() or not dist.is_initialized():
+            return reason
+        try:
+            world_size = dist.get_world_size()
+        except RuntimeError:
+            return reason
+        if world_size <= 1:
+            return reason
+
+        device = (
+            torch.device("cuda", torch.cuda.current_device())
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        needs_full = torch.tensor(
+            [1 if reason is not None else 0], dtype=torch.int32, device=device
+        )
+        dist.all_reduce(needs_full, op=dist.ReduceOp.MAX)
+        if int(needs_full.item()) == 0:
+            return None
+        if reason is not None:
+            return reason
+
+        logger.warning(
+            "colocate delta v%d: FULL sync (global_full_sync from peer rank)",
+            version,
+        )
+        return "global_full_sync"
+
+    @staticmethod
+    def _delta_verify_snapshot_enabled() -> bool:
+        env = os.environ.get("DTE_DELTA_VERIFY_SNAPSHOT")
+        if env is None or env.strip() == "":
+            env = os.environ.get("AWEX_DELTA_VERIFY_SNAPSHOT", "")
+        return env.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    def _delta_mark_snapshot_names(
+        self, params_list: list[tuple[str, torch.Tensor]]
+    ) -> None:
+        names = getattr(self._delta_tracker, "_snapshot_names", None)
+        if names is not None:
+            names.update(name for name, _ in params_list)
+
+    @torch.no_grad()
+    def _delta_refresh_verification_snapshot(
+        self, params_list: list[tuple[str, torch.Tensor]]
+    ) -> None:
+        """Refresh the debug snapshot without resetting delta version counters."""
+        snapshot = getattr(self._delta_tracker, "_snapshot", None)
+        names = getattr(self._delta_tracker, "_snapshot_names", None)
+        if snapshot is None or names is None:
+            return
+
+        snapshot.clear()
+        names.clear()
+        by_storage: dict[tuple[int, int], torch.Tensor] = {}
+        pin = torch.cuda.is_available()
+        for name, param in params_list:
+            data = param.detach().contiguous()
+            key = (data.data_ptr(), data.numel())
+            cpu_tensor = by_storage.get(key)
+            if cpu_tensor is None:
+                cpu_tensor = data.cpu().clone()
+                if pin:
+                    cpu_tensor = cpu_tensor.pin_memory()
+                by_storage[key] = cpu_tensor
+            snapshot[name] = cpu_tensor
+            names.add(name)
+
+    @torch.no_grad()
+    def _delta_verify_masks_against_snapshot(
+        self,
+        params_list: list[tuple[str, torch.Tensor]],
+        masks: dict[str, torch.Tensor],
+        version: int,
+    ) -> bool:
+        """Compare external detector masks against a resident snapshot baseline."""
+        from dte.core import bitwise_changed_mask
+
+        snapshot = getattr(self._delta_tracker, "_snapshot", None)
+        if not snapshot:
+            logger.error(
+                "colocate delta v%d verify snapshot-vs-%s FAILED: "
+                "snapshot baseline is missing",
+                version,
+                self._delta_detector.name,
+            )
+            return False
+
+        total = 0
+        snapshot_changed = 0
+        detector_changed = 0
+        false_negative = 0
+        false_positive = 0
+        unverifiable = 0
+        fn_examples: list[str] = []
+        fp_examples: list[str] = []
+        bad_examples: list[str] = []
+
+        for name, cur in params_list:
+            cur = cur.detach().contiguous()
+            numel = cur.numel()
+            total += numel
+            snap = snapshot.get(name)
+            det_mask = masks.get(name)
+            bad_mask = snap is None or snap.dtype != cur.dtype or snap.numel() != numel
+            det_indices = None
+            if det_mask is not None and not bad_mask:
+                if det_mask.dtype == torch.bool:
+                    bad_mask = det_mask.numel() != numel
+                elif det_mask.dtype in {torch.int32, torch.int64}:
+                    det_indices = det_mask.to(cur.device).reshape(-1).long()
+                    if det_indices.numel() > 0:
+                        bad_mask = bool(
+                            det_indices.min().item() < 0
+                            or det_indices.max().item() >= numel
+                        )
+                else:
+                    bad_mask = True
+
+            if bad_mask:
+                unverifiable += 1
+                if len(bad_examples) < 5:
+                    bad_examples.append(f"{name}:missing_or_bad_mask")
+                continue
+
+            snap_mask = bitwise_changed_mask(
+                cur, snap.to(cur.device, non_blocking=False)
+            ).reshape(-1)
+            if det_mask is None:
+                det_count = numel
+                fn_count = 0
+                fp_count = numel - int(snap_mask.sum().item())
+            elif det_indices is None:
+                det_mask = (
+                    det_mask.to(cur.device, non_blocking=False).reshape(-1).bool()
+                )
+                det_count = int(det_mask.sum().item())
+                fn_count = int((snap_mask & ~det_mask).sum().item())
+                fp_count = int((det_mask & ~snap_mask).sum().item())
+            else:
+                det_mask = torch.zeros(numel, dtype=torch.bool, device=cur.device)
+                if det_indices.numel() > 0:
+                    det_mask[det_indices] = True
+                det_count = int(det_mask.sum().item())
+                fn_count = int((snap_mask & ~det_mask).sum().item())
+                fp_count = int((det_mask & ~snap_mask).sum().item())
+
+            snap_count = int(snap_mask.sum().item())
+
+            snapshot_changed += snap_count
+            detector_changed += det_count
+            false_negative += fn_count
+            false_positive += fp_count
+            if fn_count and len(fn_examples) < 5:
+                fn_examples.append(
+                    f"{name}:snapshot={snap_count},detector={det_count},"
+                    f"fn={fn_count},fp={fp_count}"
+                )
+            elif fp_count and len(fp_examples) < 5:
+                fp_examples.append(
+                    f"{name}:snapshot={snap_count},detector={det_count},"
+                    f"fn={fn_count},fp={fp_count}"
+                )
+
+        examples = (fn_examples + bad_examples + fp_examples)[:5]
+        if false_negative or unverifiable:
+            logger.error(
+                "colocate delta v%d verify snapshot-vs-%s MISMATCH: "
+                "snapshot_changed=%d detector_changed=%d total=%d "
+                "false_negative=%d false_positive=%d unverifiable_params=%d "
+                "examples=%s",
+                version,
+                self._delta_detector.name,
+                snapshot_changed,
+                detector_changed,
+                total,
+                false_negative,
+                false_positive,
+                unverifiable,
+                examples,
+            )
+            return False
+
+        if false_positive:
+            logger.warning(
+                "colocate delta v%d verify snapshot-vs-%s OK conservative: "
+                "snapshot_changed=%d detector_changed=%d total=%d "
+                "false_positive=%d examples=%s",
+                version,
+                self._delta_detector.name,
+                snapshot_changed,
+                detector_changed,
+                total,
+                false_positive,
+                examples,
+            )
+            return True
+
+        logger.info(
+            "colocate delta v%d verify snapshot-vs-%s OK: changed=%d/%d",
+            version,
+            self._delta_detector.name,
+            detector_changed,
+            total,
+        )
+        return True
 
     def release_memory(self, tags: list[str] | None = None) -> None:
         """Release GPU memory for specified tags by offloading to CPU.
@@ -430,6 +2746,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             return
 
         logger.info("release_memory: offloading tags=%s", tags_to_release)
+        t0 = time.monotonic()
 
         if "optimizer" in tags_to_release:
             self._offload_optimizer_states()
@@ -440,9 +2757,19 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             self._released_tags.add("weights")
 
         torch.cuda.synchronize()
+        t_offload = time.monotonic()
         gc.collect()
+        t_gc = time.monotonic()
         torch.cuda.empty_cache()
-        logger.info("release_memory: done for tags=%s", tags_to_release)
+        t_empty = time.monotonic()
+        logger.info(
+            "release_memory: done for tags=%s "
+            "(offload_ms=%.1f gc_ms=%.1f empty_cache_ms=%.1f)",
+            tags_to_release,
+            (t_offload - t0) * 1000,
+            (t_gc - t_offload) * 1000,
+            (t_empty - t_gc) * 1000,
+        )
 
     def resume_memory(self, tags: list[str] | None = None) -> None:
         """Resume GPU memory for specified tags by reloading from CPU.
@@ -476,83 +2803,288 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         if optimizer is None:
             logger.warning("No optimizer found, skipping optimizer offload")
             return
+        if os.environ.get("AWEX_P71_SKIP_OPT_OFFLOAD", "").strip() == "1":
+            logger.info("P71: skipping optimizer offload (AWEX_P71_SKIP_OPT_OFFLOAD)")
+            return
+        if os.environ.get("AWEX_OPT_OFFLOAD_VIA_HDO", "").strip() == "1" and hasattr(
+            optimizer, "offload_to_cpu"
+        ):
+            optimizer.offload_to_cpu()
+            logger.info("Offloaded optimizer via offload_to_cpu()")
+            return
 
-        # Megatron's ChainedOptimizer wraps per-model-chunk optimizers;
-        # each in turn wraps a base torch optimizer holding the state dict.
-        if hasattr(optimizer, "optimizers"):
-            inner_optimizers = optimizer.optimizers
-        else:
-            inner_optimizers = [optimizer]
-            logger.warning(
-                "Optimizer does not have 'optimizers' attribute. "
-                "Treating it as a single optimizer; offload may be incomplete "
-                "for non-standard Megatron optimizer structures."
-            )
-        for opt in inner_optimizers:
-            base_opt = getattr(opt, "optimizer", opt)
-            for param, state in base_opt.state.items():
-                cpu_state: dict[str, torch.Tensor] = {}
-                for key, val in state.items():
+        def _to_cpu(t: torch.Tensor) -> torch.Tensor:
+            return t.to("cpu", non_blocking=True)
+
+        count = 0
+        for opt in self._get_inner_optimizers():
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            if fp32_groups is not None:
+                for group in fp32_groups:
+                    if isinstance(group, list):
+                        for tensor in group:
+                            if tensor is not None and tensor.data.is_cuda:
+                                tensor.data = _to_cpu(tensor.data)
+                                count += 1
+                    elif group is not None and group.data.is_cuda:
+                        group.data = _to_cpu(group.data)
+                        count += 1
+
+            base_opt = self._get_optimizer_state_owner(opt)
+            if base_opt is None:
+                continue
+            state_dict = getattr(base_opt, "state", None)
+            if state_dict is None:
+                logger.warning(
+                    "Optimizer %s has no state dict; skipping optimizer offload",
+                    type(base_opt).__name__,
+                )
+                continue
+            for state in state_dict.values():
+                for key in ("exp_avg", "exp_avg_sq"):
+                    val = state.get(key)
                     if isinstance(val, torch.Tensor) and val.is_cuda:
-                        cpu_state[key] = val.detach().to("cpu", non_blocking=True)
-                        state[key] = torch.empty(0, device="cpu")
-                if cpu_state:
-                    self._offloaded_optimizer_states[param] = cpu_state
+                        state[key] = _to_cpu(val)
+                        count += 1
 
-        logger.info(
-            "Offloaded optimizer states for %d params",
-            len(self._offloaded_optimizer_states),
-        )
+        try:
+            from transformer_engine.pytorch.module.base import _dummy_wgrads
+
+            purged = len(_dummy_wgrads)
+            for key in list(_dummy_wgrads):
+                del _dummy_wgrads[key]
+            if purged:
+                logger.info("Purged %d TE _dummy_wgrads cache entries", purged)
+        except ImportError:
+            pass
+
+        torch.cuda.synchronize()
+        logger.info("Offloaded %d optimizer state tensors to CPU", count)
 
     def _reload_optimizer_states(self) -> None:
         """Restore optimizer state tensors from CPU back to GPU."""
-        if not self._offloaded_optimizer_states:
-            return
-
         optimizer = self._engine.optimizer
         if optimizer is None:
             return
+        if os.environ.get("AWEX_P71_SKIP_OPT_OFFLOAD", "").strip() == "1":
+            logger.info("P71: skipping optimizer reload (AWEX_P71_SKIP_OPT_OFFLOAD)")
+            return
+        if os.environ.get("AWEX_OPT_OFFLOAD_VIA_HDO", "").strip() == "1" and hasattr(
+            optimizer, "restore_from_cpu"
+        ):
+            optimizer.restore_from_cpu()
+            logger.info("Reloaded optimizer via restore_from_cpu()")
+            return
 
-        inner_optimizers = getattr(optimizer, "optimizers", [optimizer])
-        for opt in inner_optimizers:
-            base_opt = getattr(opt, "optimizer", opt)
-            for param, state in base_opt.state.items():
-                if param in self._offloaded_optimizer_states:
-                    cpu_state = self._offloaded_optimizer_states[param]
-                    for key, val in cpu_state.items():
-                        state[key] = val.to(param.device, non_blocking=True)
+        device = self._engine.device
+        count = 0
+        for opt in self._get_inner_optimizers():
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            if fp32_groups is not None:
+                for group in fp32_groups:
+                    if isinstance(group, list):
+                        for tensor in group:
+                            if tensor is not None and not tensor.data.is_cuda:
+                                tensor.data = tensor.data.to(device, non_blocking=True)
+                                count += 1
+                    elif group is not None and not group.data.is_cuda:
+                        group.data = group.data.to(device, non_blocking=True)
+                        count += 1
 
+            base_opt = self._get_optimizer_state_owner(opt)
+            if base_opt is None:
+                continue
+            state_dict = getattr(base_opt, "state", None)
+            if state_dict is None:
+                continue
+            for param, state in state_dict.items():
+                legacy_state = self._offloaded_optimizer_states.get(param)
+                for key in ("exp_avg", "exp_avg_sq"):
+                    if legacy_state is not None and key in legacy_state:
+                        state[key] = legacy_state[key].to(device, non_blocking=True)
+                        count += 1
+                        continue
+                    val = state.get(key)
+                    if isinstance(val, torch.Tensor) and not val.is_cuda:
+                        state[key] = val.to(device, non_blocking=True)
+                        count += 1
         self._offloaded_optimizer_states.clear()
-        logger.info("Reloaded optimizer states to GPU")
+        torch.cuda.synchronize()
+        logger.info("Reloaded %d optimizer state tensors to GPU", count)
+
+    def _iter_model_chunks(self):
+        model = self._engine.model
+        if model is None:
+            return []
+        return model if isinstance(model, (list, tuple)) else [model]
+
+    @staticmethod
+    def _iter_buffer_list(value):
+        if value is None or callable(value):
+            return []
+        if isinstance(value, dict):
+            return value.values()
+        return value
+
+    def _iter_ddp_buffers(self, chunk):
+        """Yield Megatron DDP buffers without depending on a concrete DDP class."""
+        seen: set[int] = set()
+        for attr in ("buffers", "expert_parallel_buffers"):
+            for buf in self._iter_buffer_list(getattr(chunk, attr, None)):
+                if buf is None:
+                    continue
+                buf_id = id(buf)
+                if buf_id in seen:
+                    continue
+                seen.add(buf_id)
+                if hasattr(buf, "param_data") or hasattr(buf, "grad_data"):
+                    yield buf
 
     def _offload_model_weights(self) -> None:
-        """Move model parameters to CPU, keeping references for reload."""
+        """Move model parameters to CPU, preserving Megatron DDP buffer views."""
         if self._engine.model is None:
             return
 
-        for name, param in self._engine.model.named_parameters():
-            if param.is_cuda:
-                self._offloaded_weights[name] = param.data.detach().to(
-                    "cpu", non_blocking=True
-                )
-                param.data = torch.empty(0, device="cpu")
+        count = 0
+        for chunk_idx, chunk in enumerate(self._iter_model_chunks()):
+            ddp_buffers = list(self._iter_ddp_buffers(chunk))
+            if ddp_buffers:
+                for buf in ddp_buffers:
+                    offload_to_cpu = getattr(buf, "offload_to_cpu", None)
+                    if offload_to_cpu is not None:
+                        offload_to_cpu()
+                        count += 1
+                        continue
+
+                    param_data = getattr(buf, "param_data", None)
+                    if param_data is not None:
+                        param_storage = param_data.storage()
+                        if param_storage.size() > 0:
+                            if not hasattr(param_data, "cpu_data"):
+                                try:
+                                    param_data.cpu_data = torch.empty(
+                                        param_data.data.shape,
+                                        dtype=param_data.data.dtype,
+                                        pin_memory=torch.cuda.is_available(),
+                                        device="cpu",
+                                    )
+                                except RuntimeError:
+                                    param_data.cpu_data = torch.empty(
+                                        param_data.data.shape,
+                                        dtype=param_data.data.dtype,
+                                        device="cpu",
+                                    )
+                            param_data.cpu_data.copy_(
+                                param_data.data, non_blocking=True
+                            )
+                            buf.param_data_size = param_storage.size()
+                            param_storage.resize_(0)
+                            count += 1
+
+                    grad_data = getattr(buf, "grad_data", None)
+                    if grad_data is not None and grad_data.storage().size() > 0:
+                        buf.grad_data_size = grad_data.storage().size()
+                        grad_data.storage().resize_(0)
+                continue
+
+            prefix = f"chunk{chunk_idx}."
+            for name, param in chunk.named_parameters():
+                if param.is_cuda:
+                    self._offloaded_weights[prefix + name] = param.data.detach().to(
+                        "cpu", non_blocking=True
+                    )
+                    param.data = torch.empty(0, device="cpu")
+                    count += 1
 
         logger.info(
-            "Offloaded %d model weight tensors to CPU",
-            len(self._offloaded_weights),
+            "Offloaded %d model weight buffers/tensors to CPU",
+            count,
         )
 
     def _reload_model_weights(self) -> None:
-        """Restore model parameters from CPU back to GPU."""
-        if not self._offloaded_weights:
+        """Restore model parameters without breaking Megatron DDP buffer views."""
+        if not self._offloaded_weights and self._engine.model is None:
             return
         if self._engine.model is None:
             return
 
         device = self._engine.device
-        for name, param in self._engine.model.named_parameters():
-            if name in self._offloaded_weights:
-                param.data = self._offloaded_weights[name].to(device, non_blocking=True)
+        count = 0
+        for chunk_idx, chunk in enumerate(self._iter_model_chunks()):
+            ddp_buffers = list(self._iter_ddp_buffers(chunk))
+            if ddp_buffers:
+                for buf in ddp_buffers:
+                    reload_from_cpu = getattr(buf, "reload_from_cpu", None)
+                    if reload_from_cpu is not None:
+                        reload_from_cpu(move_grads=False)
+                        count += 1
+                        continue
+
+                    param_data = getattr(buf, "param_data", None)
+                    if param_data is None:
+                        continue
+                    if (
+                        hasattr(buf, "param_data_size")
+                        and param_data.storage().size() == 0
+                    ):
+                        param_data.storage().resize_(buf.param_data_size)
+                    cpu_data = getattr(param_data, "cpu_data", None)
+                    if cpu_data is not None:
+                        param_data.copy_(cpu_data, non_blocking=True)
+                        count += 1
+                continue
+
+            prefix = f"chunk{chunk_idx}."
+            for name, param in chunk.named_parameters():
+                key = prefix + name
+                if key in self._offloaded_weights:
+                    param.data = self._offloaded_weights[key].to(
+                        device, non_blocking=True
+                    )
+                    count += 1
 
         self._offloaded_weights.clear()
-        logger.info("Reloaded model weights to GPU")
+        logger.info("Reloaded %d model weight buffers/tensors to GPU", count)
+
+    def _release_grad_memory(self) -> None:
+        """Release Megatron DDP grad buffers until the next training batch."""
+        if self._engine.model is None:
+            return
+
+        count = 0
+        for chunk in self._iter_model_chunks():
+            for buf in self._iter_ddp_buffers(chunk):
+                grad_data = getattr(buf, "grad_data", None)
+                if grad_data is None or grad_data.storage().size() == 0:
+                    continue
+                buf.grad_data_size = grad_data.storage().size()
+                grad_data.storage().resize_(0)
+                count += 1
+        if count:
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            logger.info("Released %d grad buffers", count)
+        else:
+            logger.info("No Megatron grad buffers released before weight payload read")
+
+    def ensure_grad_buffers(self) -> None:
+        """Reallocate Megatron DDP grad buffers released with train weights."""
+        if self._engine.model is None:
+            return
+
+        count = 0
+        for chunk in self._iter_model_chunks():
+            for buf in self._iter_ddp_buffers(chunk):
+                grad_data = getattr(buf, "grad_data", None)
+                if (
+                    grad_data is not None
+                    and hasattr(buf, "grad_data_size")
+                    and grad_data.storage().size() == 0
+                ):
+                    grad_data.storage().resize_(buf.grad_data_size)
+                    grad_data.zero_()
+                    count += 1
+        if count:
+            torch.cuda.synchronize()
+            logger.info("Allocated %d grad buffers for training", count)

--- a/areal/v2/weight_update/awex/sglang_adapter.py
+++ b/areal/v2/weight_update/awex/sglang_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402, I001
 # pyright: reportMissingImports=false
 from __future__ import annotations
 
@@ -11,6 +12,42 @@ from typing import Any
 import httpx
 import torch
 import torch.distributed as dist
+
+
+def _patch_tms_hook_mode_for_awex_registry() -> None:
+    """Avoid a torch_memory_saver late-set crash during AWEX model registration."""
+    try:
+        import torch_memory_saver as _tms
+    except Exception:
+        return
+
+    inst = getattr(_tms, "torch_memory_saver", None)
+    if inst is None:
+        return
+
+    cls = type(inst)
+    prop = getattr(cls, "hook_mode", None)
+    if not isinstance(prop, property) or prop.fget is None or prop.fset is None:
+        return
+    if getattr(prop.fset, "_areal_awex_safe", False):
+        return
+
+    orig_fset = prop.fset
+
+    def _safe_setter(self, value):
+        if not hasattr(self, "_impl_ctor_kwargs"):
+            return
+        return orig_fset(self, value)
+
+    _safe_setter._areal_awex_safe = True
+    cls.hook_mode = property(prop.fget, _safe_setter, prop.fdel, prop.__doc__)
+
+
+# Must run before importing awex modules.  AWEX auto-registers model converters
+# during import; without this guard, BailingMoe registration can fail silently in
+# the already-initialized SGLang scheduler process.
+_patch_tms_hook_mode_for_awex_registry()
+
 from awex.meta.weight_meta import (
     ParameterMeta,
     ParameterReplicaMeta,
@@ -24,7 +61,7 @@ from awex.sharding.sglang_sharding import (
 )
 from awex.transfer.nccl_comm import batch_send_recv, nccl_build_recv_ops
 from awex.transfer.nccl_stream_batch import NcclColocateStreamBatchTransport
-from awex.transfer.transfer_plan import TransferPlan, TransferPlanBuilder
+from awex.transfer.transfer_plan import TransferPlan, TransferPlanBuilder, slice_tensor
 from awex.util.tensor_util import (
     cuda_ipc_deserialize,
     reconstruct_tensors_from_groups,
@@ -34,6 +71,18 @@ from areal.utils import logging
 from areal.v2.weight_update.awex import (
     awex_wu_use_group,
     fetch_kv_metadata,
+    load_kv_metadata_file,
+)
+from areal.v2.weight_update.awex.delta_config import (
+    cuda_mem_stats_mb,
+    delta_transfer_enabled,
+    make_delta_engine,
+    payload_carries_delta,
+)
+from areal.v2.weight_update.awex.colocate_device import (
+    device_mapping_key,
+    get_colocate_ip_address,
+    get_physical_cuda_device_id,
 )
 from areal.v2.weight_update.inference_adapter import (
     AwexInferenceAdapter,
@@ -44,6 +93,32 @@ from areal.v2.weight_update.nccl_group import (
 )
 
 logger = logging.getLogger("AwexSGLangAdapter")
+
+
+def _ensure_awex_bailing_models_registered() -> None:
+    """Rebuild AWEX model registry if an earlier import cached a failed state."""
+    required = ("BailingMoeV2_5ForCausalLM", "BailingMoeV2ForCausalLM")
+    try:
+        from awex.models import registry as _reg
+
+        cache_clear = getattr(_reg.import_model_configs, "cache_clear", None)
+        if cache_clear is not None:
+            cache_clear()
+        _reg.ModelRegistry.models = _reg.import_model_configs()
+        models = getattr(_reg.ModelRegistry, "models", {}) or {}
+        missing = [name for name in required if name not in models]
+        if missing:
+            logger.warning(
+                "AWEX model registry missing Bailing converters after rebuild: %s",
+                missing,
+            )
+        else:
+            logger.info("AWEX model registry has BailingMoe converters registered")
+    except Exception:
+        logger.warning("Failed to rebuild AWEX model registry", exc_info=True)
+
+
+_ensure_awex_bailing_models_registered()
 
 
 class AwexSGLangAdapter(AwexInferenceAdapter):
@@ -63,9 +138,84 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._colocate_transport = None
         self._train_to_infer_device_mapping: dict | None = None
         self._infer_to_train_device_mapping: dict | None = None
+        self._colocate_device_ip: str = ""
+        self._colocate_device_id: str = ""
+        # Lazy dte DeltaEngine (receiver side); persists across versions to hold
+        # only the version chain for live delta apply. Created on first
+        # delta-enabled transfer.
+        self._delta_engine = None
+        self._rebuild_derived_weights("adapter init")
 
     def _get_model(self) -> torch.nn.Module:
         return self._scheduler.tp_worker.model_runner.model
+
+    def _derived_weight_abs_sums(self) -> dict[str, float]:
+        sums: dict[str, float] = {}
+        inner = getattr(self._get_model(), "model", None)
+        for i, layer in enumerate(getattr(inner, "layers", []) or []):
+            attn = getattr(layer, "attention", None)
+            for attr in ("w_kc", "w_vc"):
+                t = getattr(attn, attr, None)
+                if isinstance(t, torch.Tensor):
+                    sums[f"layers.{i}.attention.{attr}"] = float(
+                        t.detach().abs().sum().item()
+                    )
+        return sums
+
+    def _check_derived_weight_sanity(self, reason: str, sums: dict[str, float]) -> None:
+        enabled = os.environ.get("DTE_DERIVED_WEIGHT_SANITY", "1").lower()
+        if enabled in {"0", "false", "no", "off"} or not sums:
+            return
+
+        bad = {
+            name: value
+            for name, value in sums.items()
+            if not math.isfinite(value) or value <= 0.0
+        }
+        if not bad:
+            logger.info(
+                "derived weight sanity OK (%s): count=%d min_abs_sum=%.6e max_abs_sum=%.6e",
+                reason,
+                len(sums),
+                min(sums.values()),
+                max(sums.values()),
+            )
+            return
+
+        logger.error(
+            "derived weight sanity FAILED (%s): %d/%d tensors have non-positive "
+            "or non-finite abs_sum; examples=%s",
+            reason,
+            len(bad),
+            len(sums),
+            list(bad.items())[:8],
+        )
+        fail = os.environ.get("DTE_DERIVED_WEIGHT_SANITY_FAIL", "0").lower()
+        if fail in {"1", "true", "yes", "on"}:
+            raise RuntimeError(
+                f"derived weight sanity failed after {reason}: "
+                f"{len(bad)}/{len(sums)} tensors invalid"
+            )
+
+    def _rebuild_derived_weights(self, reason: str) -> None:
+        """Refresh plain tensor attributes derived from model parameters."""
+        model = self._get_model()
+        fn = getattr(model, "post_load_weights", None)
+        if fn is None:
+            return
+        torch.cuda.synchronize()
+        before = self._derived_weight_abs_sums()
+        fn()
+        torch.cuda.synchronize()
+        after = self._derived_weight_abs_sums()
+        logger.info(
+            "post_load_weights rebuilt derived weights (%s): "
+            "derived abs_sum before=%s after=%s",
+            reason,
+            before,
+            after,
+        )
+        self._check_derived_weight_sanity(reason, after)
 
     def _get_model_context(self) -> dict[str, Any]:
         server_args = self._scheduler.server_args
@@ -109,6 +259,64 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             "attn_dp_rank": int(getattr(self._scheduler, "attn_dp_rank", 0)),
         }
 
+    def _get_colocate_device_id(self) -> str:
+        physical_gpu_id = getattr(self._scheduler, "gpu_id", None)
+        if physical_gpu_id is None:
+            physical_gpu_id = int(torch.cuda.current_device())
+        return get_physical_cuda_device_id(int(physical_gpu_id))
+
+    def _build_awex_infer_conf(self, model_context: dict[str, Any]) -> dict[str, Any]:
+        from awex.util.common import simple_hf_config
+
+        def json_safe(value: Any) -> Any:
+            if value is None or isinstance(value, str | int | float | bool):
+                return value
+            if isinstance(value, dict):
+                return {str(k): json_safe(v) for k, v in value.items()}
+            if isinstance(value, list | tuple):
+                return [json_safe(v) for v in value]
+            return str(value)
+
+        model = self._get_model()
+        hf_config = getattr(model, "config", None)
+        server_args = self._scheduler.server_args
+        infer_engine_config: dict[str, Any] = {}
+        for key in (
+            "device",
+            "device_backend",
+            "device_type",
+            "comm_backend",
+            "tp_size",
+            "pp_size",
+            "dp_size",
+            "ep_size",
+        ):
+            value = getattr(server_args, key, None)
+            if value is None or isinstance(value, str | int | float | bool):
+                infer_engine_config[key] = value
+
+        device_backend = (
+            infer_engine_config.get("device_backend")
+            or infer_engine_config.get("device_type")
+            or ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+        include_tied_lm_head = any(
+            hf_name == "lm_head.weight"
+            for name, param in model.named_parameters()
+            for hf_name, _ in self._unfuse_params(name, param.data)
+        )
+        return {
+            "engine_name": "sglang",
+            "infer_atten_tp_size": int(model_context["attn_tp_size"]),
+            "router_dtype": str(getattr(hf_config, "router_dtype", "bf16")),
+            "infer_engine_config": json_safe(infer_engine_config),
+            "hf_config": (
+                json_safe(dict(simple_hf_config(hf_config))) if hf_config else {}
+            ),
+            "device_backend": device_backend,
+            "include_tied_lm_head": include_tied_lm_head,
+        }
+
     @property
     def parallelism_strategy(self) -> dict:
         model_context = self._get_model_context()
@@ -125,6 +333,7 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             "dp_size": dp_size,
             "ep_size": ep_size,
             "num_engines": 1,
+            "awex_infer_conf": self._build_awex_infer_conf(model_context),
         }
 
     def _unfuse_params(
@@ -137,6 +346,10 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         into ``experts.w13_weight`` (gate+up) and ``experts.w2_weight`` (down).
         The training side keeps per-expert HF names, so we unfuse here to match.
         """
+        if name == "model.word_embeddings.weight":
+            return [("model.embed_tokens.weight", tensor)]
+        if ".attention.fused_qkv_a_proj_with_mqa." in name:
+            return [(name, tensor)]
         if "qkv_proj" in name:
             cfg = self._get_model().config
             num_heads = cfg.num_attention_heads
@@ -156,6 +369,8 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                     tensor.narrow(0, q_size + kv_size, kv_size),
                 ),
             ]
+        if ".attention.o_proj." in name:
+            return [(name.replace(".attention.o_proj.", ".attention.dense."), tensor)]
         if "gate_up_proj" in name:
             half = tensor.shape[0] // 2
             return [
@@ -450,6 +665,84 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
 
     # ── Colocated weight transfer methods ─────────────────────────────────
 
+    def _fetch_colocate_metadata(
+        self,
+        kv_store_url: str,
+        pair_name: str,
+        timeout_s: float,
+        metadata_path: str = "",
+    ) -> tuple[Any, Any]:
+        """Fetch colocate metadata once per SGLang engine, then fan out locally."""
+        scheduler = self._scheduler
+        tp_rank = int(getattr(scheduler, "tp_rank", 0))
+        tp_size = int(getattr(scheduler, "tp_size", 1))
+
+        payload: list[Any] = [None]
+        if tp_rank == 0:
+            try:
+                if metadata_path:
+                    try:
+                        logger.info(
+                            "Loading colocate metadata for pair '%s' from %s",
+                            pair_name,
+                            metadata_path,
+                        )
+                        infer_meta, train_meta = load_kv_metadata_file(metadata_path)
+                    except Exception:
+                        logger.warning(
+                            "Failed to load colocate metadata file for pair '%s'; "
+                            "falling back to %s",
+                            pair_name,
+                            kv_store_url,
+                            exc_info=True,
+                        )
+                        infer_meta, train_meta = fetch_kv_metadata(
+                            kv_store_url, pair_name, timeout_s=timeout_s
+                        )
+                else:
+                    logger.info(
+                        "Fetching colocate metadata for pair '%s' from %s",
+                        pair_name,
+                        kv_store_url,
+                    )
+                    infer_meta, train_meta = fetch_kv_metadata(
+                        kv_store_url, pair_name, timeout_s=timeout_s
+                    )
+                payload[0] = ("ok", infer_meta, train_meta)
+                logger.info(
+                    "Fetched colocate metadata for pair '%s': infer_params=%d, "
+                    "train_params=%d",
+                    pair_name,
+                    len(infer_meta) if hasattr(infer_meta, "__len__") else -1,
+                    len(train_meta) if hasattr(train_meta, "__len__") else -1,
+                )
+            except Exception as exc:
+                payload[0] = ("error", repr(exc))
+
+        if dist.is_available() and dist.is_initialized() and tp_size > 1:
+            tp_cpu_group = getattr(scheduler, "tp_cpu_group", None)
+            if tp_cpu_group is None:
+                raise RuntimeError(
+                    "SGLang tp_cpu_group is required for TP metadata broadcast"
+                )
+            try:
+                src_rank = dist.get_global_rank(tp_cpu_group, 0)
+            except Exception:
+                pp_rank = int(getattr(scheduler, "pp_rank", 0))
+                src_rank = pp_rank * tp_size
+            dist.broadcast_object_list(payload, src=src_rank, group=tp_cpu_group)
+
+        status = payload[0]
+        if not status:
+            raise RuntimeError(
+                f"Failed to fetch colocate metadata for pair '{pair_name}'"
+            )
+        if status[0] == "error":
+            raise RuntimeError(
+                f"Failed to fetch colocate metadata for pair '{pair_name}': {status[1]}"
+            )
+        return status[1], status[2]
+
     def init_colocate_weight_update(
         self,
         pair_name: str,
@@ -458,9 +751,12 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        master_addr: str,
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        expected_delta_enabled: bool | None = None,
+        metadata_path: str = "",
     ) -> None:
         if infer_world_size != train_world_size:
             raise ValueError(
@@ -470,7 +766,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             )
         self._colocate_pair_name = pair_name
         self._colocate_kv_store_url = kv_store_url
-        self._transfer_rank = transfer_rank
         self._colocate_infer_world_size = infer_world_size
         self._colocate_train_world_size = train_world_size
         self._colocate_admin_api_key = admin_api_key
@@ -478,7 +773,34 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         if self._colocate_http_client is None:
             self._colocate_http_client = httpx.Client()
 
-        infer_meta, train_meta = fetch_kv_metadata(kv_store_url, pair_name)
+        per_engine_world = infer_world_size // num_engines
+        ctx = self._get_model_context()
+        tp_size = int(ctx["tp_size"])
+        tp_rank = int(ctx["tp_rank"])
+        pp_size = int(ctx["pp_size"])
+        pp_rank = int(ctx["pp_rank"])
+        if per_engine_world != tp_size * pp_size:
+            raise RuntimeError(
+                "awex colocate per-engine world mismatch: gateway reports "
+                f"infer_world_size={infer_world_size} / num_engines={num_engines} "
+                f"= {per_engine_world}, but local engine has "
+                f"tp_size*pp_size={tp_size * pp_size}"
+            )
+
+        engine_local_rank = pp_rank * tp_size + tp_rank
+        global_rank = transfer_rank * per_engine_world + engine_local_rank
+        self._transfer_rank = global_rank
+
+        train_to_infer, infer_to_train = self._register_and_resolve_device_mapping(
+            global_rank=global_rank,
+            infer_world_size=infer_world_size,
+            train_world_size=train_world_size,
+        )
+
+        infer_meta, train_meta = self._fetch_colocate_metadata(
+            kv_store_url, pair_name, timeout_s, metadata_path
+        )
+        self._rebuild_derived_weights("colocate init")
 
         builder = TransferPlanBuilder(
             infer_world_size=infer_world_size,
@@ -486,47 +808,164 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             num_infer_engines=num_engines,
         )
 
-        train_to_infer = {}
-        infer_to_train = {}
-        for i in range(min(infer_world_size, train_world_size)):
-            train_rank = infer_world_size + i
-            train_to_infer[train_rank] = i
-            infer_to_train[i] = train_rank
         self._train_to_infer_device_mapping = train_to_infer
         self._infer_to_train_device_mapping = infer_to_train
 
         self._send_transfer_plan = builder.build_local_transfer_plan(
             infer_meta,
             train_meta,
-            global_transfer_rank=infer_to_train[transfer_rank],
+            global_transfer_rank=infer_to_train[global_rank],
         )
         self._recv_transfer_plan = builder.build_local_transfer_plan(
             infer_meta,
             train_meta,
-            global_transfer_rank=transfer_rank,
+            global_transfer_rank=global_rank,
         )
 
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
         self._weights_update_group = init_weights_update_group(
-            master_address="127.0.0.1",
+            master_address=master_addr,
             master_port=master_port,
-            rank=transfer_rank,
+            rank=global_rank,
             world_size=infer_world_size,
             group_name=f"awex_colocate_{pair_name}",
             role="inference",
         )
 
         self._colocate_transport = NcclColocateStreamBatchTransport(
-            transfer_rank, infer_world_size
+            global_rank, infer_world_size
         )
 
         logger.info(
             "Initialized colocate weight update for pair '%s', "
-            "transfer_rank=%d, infer_world_size=%d",
+            "engine_rank=%d, local_rank=%d, global_rank=%d, infer_world_size=%d, "
+            "paired_train_rank=%d, device=%s/%s",
             pair_name,
             transfer_rank,
+            engine_local_rank,
+            global_rank,
             infer_world_size,
+            infer_to_train[global_rank],
+            self._colocate_device_ip,
+            self._colocate_device_id,
         )
+        local_delta = delta_transfer_enabled()
+        if (
+            expected_delta_enabled is not None
+            and bool(expected_delta_enabled) != local_delta
+        ):
+            raise ValueError(
+                "Colocate delta config mismatch on inference rank "
+                f"{global_rank}: expected={expected_delta_enabled}, "
+                f"local={local_delta}. Check DTE_DELTA_TRANSFER propagation."
+            )
+        if local_delta and self._delta_engine is None:
+            # Fail fast: surface a missing dte / bad config at init, not mid-run.
+            self._delta_engine = make_delta_engine(
+                f"cuda:{torch.cuda.current_device()}"
+            )
+            logger.info("colocate delta enabled (receiver); dte DeltaEngine ready")
+
+    def _put_colocate_kv(self, key: str, value: Any) -> None:
+        assert self._colocate_http_client is not None
+        resp = self._colocate_http_client.put(
+            f"{self._colocate_kv_store_url}/weight_meta/"
+            f"{self._colocate_pair_name}/{key}",
+            json={"value": value},
+            headers={"Authorization": f"Bearer {self._colocate_admin_api_key}"},
+            timeout=self._colocate_timeout_s,
+        )
+        resp.raise_for_status()
+
+    def _get_colocate_kv(self, key: str, timeout_s: float, label: str) -> Any:
+        assert self._colocate_http_client is not None
+        deadline = time.monotonic() + timeout_s
+        last_status = -1
+        polls = 0
+        while time.monotonic() < deadline:
+            resp = self._colocate_http_client.get(
+                f"{self._colocate_kv_store_url}/weight_meta/"
+                f"{self._colocate_pair_name}/{key}",
+                timeout=5.0,
+            )
+            last_status = resp.status_code
+            if resp.status_code == 200:
+                return resp.json()["value"]
+            polls += 1
+            time.sleep(0.1)
+        raise TimeoutError(
+            f"Timed out waiting for {label} "
+            f"(key={key}, polls={polls}, last_status={last_status})"
+        )
+
+    def _register_and_resolve_device_mapping(
+        self,
+        *,
+        global_rank: int,
+        infer_world_size: int,
+        train_world_size: int,
+    ) -> tuple[dict[int, int], dict[int, int]]:
+        if infer_world_size != train_world_size:
+            raise ValueError(
+                "Colocate mode requires equal total rank counts "
+                f"(infer={infer_world_size}, train={train_world_size})"
+            )
+
+        ip_address = get_colocate_ip_address()
+        device_id = self._get_colocate_device_id()
+        self._colocate_device_ip = ip_address
+        self._colocate_device_id = device_id
+        device_info = {
+            "ip": ip_address,
+            "device_id": device_id,
+            "infer_rank": global_rank,
+        }
+        self._put_colocate_kv(
+            f"colocate_infer_device_by_rank_{global_rank}", device_info
+        )
+        self._put_colocate_kv(
+            f"colocate_infer_rank_by_device_"
+            f"{device_mapping_key(ip_address, device_id)}",
+            global_rank,
+        )
+
+        infer_to_train: dict[int, int] = {}
+        train_to_infer: dict[int, int] = {}
+        for infer_rank in range(infer_world_size):
+            info = self._get_colocate_kv(
+                f"colocate_infer_device_by_rank_{infer_rank}",
+                self._colocate_timeout_s,
+                f"inference device mapping for rank {infer_rank}",
+            )
+            mapped_device_key = device_mapping_key(
+                str(info["ip"]), str(info["device_id"])
+            )
+            train_rank = int(
+                self._get_colocate_kv(
+                    f"colocate_train_rank_by_device_{mapped_device_key}",
+                    self._colocate_timeout_s,
+                    f"training rank for inference rank {infer_rank}",
+                )
+            )
+            infer_to_train[infer_rank] = train_rank
+            train_to_infer[train_rank] = infer_rank
+
+        mapping_complete = (
+            len(infer_to_train) == infer_world_size
+            and len(train_to_infer) == train_world_size
+        )
+        if not mapping_complete:
+            raise RuntimeError(
+                "Incomplete colocate device mapping: "
+                f"infer_to_train={len(infer_to_train)}/{infer_world_size}, "
+                f"train_to_infer={len(train_to_infer)}/{train_world_size}"
+            )
+        logger.info(
+            "Resolved colocate device mapping for rank %d: paired_train_rank=%d",
+            global_rank,
+            infer_to_train[global_rank],
+        )
+        return train_to_infer, infer_to_train
 
     def execute_colocate_weight_update(self, version: int) -> None:
         kv_store_url = self._colocate_kv_store_url
@@ -542,6 +981,60 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
 
         paired_train_rank = self._infer_to_train_device_mapping[transfer_rank]
         kv_key = f"colocate_weights_rank{paired_train_rank}_{version}"
+        offloaded_key = (
+            f"colocate_train_weights_offloaded_rank{paired_train_rank}_{version}"
+        )
+        perf_start = time.monotonic()
+        perf_prev = perf_start
+        # Reset the peak counter so the first stage's peak_mb is attributable.
+        cuda_mem_stats_mb()
+
+        def perf_mark(stage: str) -> None:
+            nonlocal perf_prev
+            now = time.monotonic()
+            alloc_mb, peak_mb = cuda_mem_stats_mb()
+            logger.info(
+                "[dte-perf][infer] v%d rank %d paired_train_rank=%d "
+                "%s_ms=%.1f total_ms=%.1f alloc_mb=%.0f peak_mb=%.0f",
+                version,
+                transfer_rank,
+                paired_train_rank,
+                stage,
+                (now - perf_prev) * 1000,
+                (now - perf_start) * 1000,
+                alloc_mb,
+                peak_mb,
+            )
+            perf_prev = now
+
+        deadline = time.monotonic() + timeout_s
+        offloaded = False
+        poll_count = 0
+        last_status = -1
+        while time.monotonic() < deadline:
+            resp = client.get(
+                f"{kv_store_url}/weight_meta/{pair_name}/{offloaded_key}",
+                timeout=5.0,
+            )
+            last_status = resp.status_code
+            if resp.status_code == 200:
+                offloaded = True
+                break
+            poll_count += 1
+            time.sleep(0.1)
+        if not offloaded:
+            raise TimeoutError(
+                f"Training did not offload colocate weights within {timeout_s}s "
+                f"(waiting_key={offloaded_key}, polls={poll_count}, "
+                f"last_status={last_status})"
+            )
+
+        logger.info(
+            "Observed colocate train weights offloaded for v%d, paired rank %d",
+            version,
+            paired_train_rank,
+        )
+        perf_mark("wait_train_offloaded")
 
         deadline = time.monotonic() + timeout_s
         serialized_hex = None
@@ -564,46 +1057,128 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                 f"(waiting_key={kv_key}, polls={poll_count}, "
                 f"last_status={last_status})"
             )
+        perf_mark("wait_payload_kv")
 
         serialized_weights = bytes.fromhex(serialized_hex)
+        logger.info(
+            "[dte-perf][infer] v%d rank %d serialized_payload_mb=%.1f",
+            version,
+            transfer_rank,
+            len(serialized_weights) / 1e6,
+        )
+        perf_mark("hex_to_bytes")
         group_shared, metadata, names = cuda_ipc_deserialize(serialized_weights)
         torch.cuda.synchronize()
+        perf_mark("cuda_ipc_deserialize")
         tensors = reconstruct_tensors_from_groups(group_shared, metadata)
         torch.cuda.synchronize()
+        perf_mark("reconstruct_group_tensors")
         deserialized_weights = dict(zip(names, tensors))
+        perf_mark("build_deserialized_dict")
+        # Reconstruct when delta is enabled locally OR the payload itself carries
+        # a delta header. The latter defends against the trainer enabling delta
+        # while this worker's DTE_DELTA_TRANSFER did not propagate: without it,
+        # the sparse header/@delta_idx names would flow straight into the apply.
+        carries_delta = payload_carries_delta(names)
+        decoded_delta = None
+        if delta_transfer_enabled() or carries_delta:
+            if carries_delta:
+                decoded_delta = self._delta_decode_for_live_apply(
+                    deserialized_weights, version
+                )
+                perf_mark("delta_decode_for_live_apply")
+            else:
+                self._delta_mark_full_sync(deserialized_weights, version)
+                perf_mark("delta_mark_full_sync")
 
-        recv_parameters = self.get_local_shard_parameters()
-
-        rank_info = self._build_rank_info()
-        rank_coordinate = f"infer_{rank_info.global_rank}"
-
-        assert self._colocate_transport is not None
-        self._colocate_transport.update_weights_in_colocate_mode(
-            self._train_to_infer_device_mapping,
-            self._infer_to_train_device_mapping,
-            transfer_rank,
-            rank_coordinate,
-            self._colocate_infer_world_size,
-            self._send_transfer_plan,
-            self._recv_transfer_plan,
-            self._weights_update_group,
-            deserialized_weights,
-            recv_parameters,
-            step_id=version,
-        )
-
+        resumed_weights = False
+        update_succeeded = False
         done_key = f"colocate_done_rank{paired_train_rank}_{version}"
-        client.put(
-            f"{kv_store_url}/weight_meta/{pair_name}/{done_key}",
-            json={"value": True},
-            headers=auth_headers,
-            timeout=10.0,
-        )
 
-        del deserialized_weights, group_shared, tensors, serialized_weights
-        torch.cuda.synchronize()
-        gc.collect()
-        torch.cuda.empty_cache()
+        def put_done() -> None:
+            client.put(
+                f"{kv_store_url}/weight_meta/{pair_name}/{done_key}",
+                json={"value": True},
+                headers=auth_headers,
+                timeout=10.0,
+            )
+
+        try:
+            if self._decoded_delta_is_empty(decoded_delta):
+                self._delta_engine.commit_live_apply(decoded_delta)
+                perf_mark("commit_empty_delta")
+                put_done()
+                perf_mark("put_done")
+                update_succeeded = True
+            else:
+                # During colocate update, weights are only made addressable here;
+                # the train payload is applied immediately after.  Rebuilding Flash
+                # derived tensors before the payload sees SGLang's offloaded zero
+                # buffers and can fail sanity checks prematurely.
+                self.resume_memory(tags=["weights"], rebuild_derived=False)
+                resumed_weights = True
+                perf_mark("resume_weights")
+                recv_parameters = self.get_local_shard_parameters()
+                perf_mark("get_local_shard_params")
+
+                rank_info = self._build_rank_info()
+                rank_coordinate = f"infer_{rank_info.global_rank}"
+                perf_mark("build_rank_info")
+
+                assert self._colocate_transport is not None
+                if decoded_delta is not None:
+                    from dte.core.colocate_protocol import apply_decoded_delta_colocate
+
+                    schedule_fn = self._colocate_transport.execute_recursive_partition_stream_transfer
+                    apply_decoded_delta_colocate(
+                        transfer_rank=transfer_rank,
+                        world_size=self._colocate_infer_world_size,
+                        send_plan=self._send_transfer_plan,
+                        recv_plan=self._recv_transfer_plan,
+                        train_to_infer_device_mapping=self._train_to_infer_device_mapping,
+                        infer_to_train_device_mapping=self._infer_to_train_device_mapping,
+                        weights_update_group=self._weights_update_group,
+                        decoded=decoded_delta,
+                        recv_params=recv_parameters,
+                        device=torch.device(f"cuda:{torch.cuda.current_device()}"),
+                        schedule_fn=schedule_fn,
+                        slice_fn=slice_tensor,
+                        rank_coordinate=rank_coordinate,
+                        step_id=version,
+                    )
+                    perf_mark("apply_decoded_delta_colocate")
+                else:
+                    self._colocate_transport.update_weights_in_colocate_mode(
+                        self._train_to_infer_device_mapping,
+                        self._infer_to_train_device_mapping,
+                        transfer_rank,
+                        rank_coordinate,
+                        self._colocate_infer_world_size,
+                        self._send_transfer_plan,
+                        self._recv_transfer_plan,
+                        self._weights_update_group,
+                        deserialized_weights,
+                        recv_parameters,
+                        step_id=version,
+                    )
+                    perf_mark("apply_full_colocate")
+                self._rebuild_derived_weights(f"colocate update v{version}")
+                perf_mark("rebuild_derived_weights")
+                if decoded_delta is not None:
+                    self._delta_engine.commit_live_apply(decoded_delta)
+                    perf_mark("commit_live_delta")
+
+                put_done()
+                perf_mark("put_done")
+                update_succeeded = True
+        finally:
+            del deserialized_weights, group_shared, tensors, serialized_weights
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            if resumed_weights and not update_succeeded:
+                self.release_memory(tags=["weights"])
+            perf_mark("cleanup")
 
         logger.info(
             "Colocate weight update completed for v%d, rank %d",
@@ -611,8 +1186,91 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             transfer_rank,
         )
 
+    @staticmethod
+    def _decoded_delta_is_empty(decoded_delta) -> bool:
+        if decoded_delta is None:
+            return False
+        sparse = getattr(decoded_delta, "sparse", {}) or {}
+        dense = getattr(decoded_delta, "dense", {}) or {}
+        sparse_nnz = 0
+        for indices, _values in sparse.values():
+            sparse_nnz += int(indices.numel())
+        dense_numel = sum(int(tensor.numel()) for tensor in dense.values())
+        return sparse_nnz == 0 and dense_numel == 0
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Skip virtual delta seeding; the first real update is the full base."""
+        if not delta_transfer_enabled():
+            logger.info("seed_delta_base skipped: delta transfer disabled")
+            return
+        logger.info(
+            "seed_delta_base skipped for DTE delta transfer at v%d; "
+            "the first real payload will be a full sync base",
+            version,
+        )
+
+    def _delta_reconstruct(
+        self, named_tensors: dict[str, torch.Tensor], version: int
+    ) -> dict[str, torch.Tensor]:
+        """Reconstruct full weights from a dte delta/full payload (receiver side).
+
+        The bytes already arrived via cuda-IPC, so we use dte's transport-free
+        ``DeltaEngine.reconstruct``: it verifies the version chain, decodes the
+        sparse patch against the CPU base, refreshes that base, and returns the
+        full ``{name: tensor}``. Full weights then flow into
+        ``update_weights_in_colocate_mode`` unchanged, so the cross-rank NCCL
+        reshard never sees a delta payload. The per-param change masks dte also
+        returns are unused for now (first cut applies full weights).
+        """
+        if self._delta_engine is None:
+            self._delta_engine = make_delta_engine(
+                f"cuda:{torch.cuda.current_device()}"
+            )
+        full_params, _masks = self._delta_engine.reconstruct(named_tensors, version)
+        return full_params
+
+    def _delta_mark_full_sync(
+        self, named_tensors: dict[str, torch.Tensor], version: int
+    ) -> None:
+        """Record a dense full-sync version without saving a CPU model copy."""
+        if self._delta_engine is None:
+            self._delta_engine = make_delta_engine(
+                f"cuda:{torch.cuda.current_device()}"
+            )
+        decoded = self._delta_engine.decode_for_live_apply(named_tensors, version)
+        if decoded is not None:
+            raise RuntimeError("Expected a full-sync payload, got a delta payload")
+        logger.info(
+            "dte receiver full base advanced to v%d without CPU snapshot", version
+        )
+
+    def _delta_decode_for_live_apply(
+        self, named_tensors: dict[str, torch.Tensor], version: int
+    ):
+        """Decode delta and verify version chain without reconstructing full params."""
+        if self._delta_engine is None:
+            self._delta_engine = make_delta_engine(
+                f"cuda:{torch.cuda.current_device()}"
+            )
+        decoded = self._delta_engine.decode_for_live_apply(named_tensors, version)
+        if decoded is None:
+            raise RuntimeError("Expected a delta payload, got a full-sync payload")
+        sparse_nnz = sum(int(indices.numel()) for indices, _ in decoded.sparse.values())
+        dense_numel = sum(int(t.numel()) for t in decoded.dense.values())
+        logger.info(
+            "[dte-perf][infer-delta] v%d sparse_params=%d sparse_nnz=%d "
+            "dense_params=%d dense_numel=%d payload_tensors=%d",
+            version,
+            len(decoded.sparse),
+            sparse_nnz,
+            len(decoded.dense),
+            dense_numel,
+            len(named_tensors),
+        )
+        return decoded
+
     # Tags understood by SGLang's native release/resume_memory_occupation.
-    _SGLANG_MEMORY_TAGS = {"kv_cache"}
+    _SGLANG_MEMORY_TAGS = {"weights", "kv_cache"}
 
     def release_memory(self, tags: list[str] | None = None) -> None:
         from sglang.srt.managers.io_struct import ReleaseMemoryOccupationReqInput
@@ -630,23 +1288,25 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                 unsupported,
                 self._SGLANG_MEMORY_TAGS,
             )
-        if native_tags:
-            req = ReleaseMemoryOccupationReqInput(tags=native_tags)
+        requested_tags = list(self._SGLANG_MEMORY_TAGS) if tags is None else native_tags
+        tags_to_release = [t for t in requested_tags if t not in self._released_tags]
+        if tags_to_release:
+            req = ReleaseMemoryOccupationReqInput(tags=tags_to_release)
             self._scheduler.release_memory_occupation(req)
-            self._released_tags.update(native_tags)
-        logger.info("release_memory completed with tags=%s", tags)
+            self._released_tags.update(tags_to_release)
+        logger.info(
+            "release_memory completed with tags=%s released_now=%s",
+            tags,
+            tags_to_release,
+        )
 
-    def resume_memory(self, tags: list[str] | None = None) -> None:
+    def resume_memory(
+        self, tags: list[str] | None = None, *, rebuild_derived: bool = False
+    ) -> None:
         from sglang.srt.managers.io_struct import ResumeMemoryOccupationReqInput
 
         native_tags = (
-            [
-                t
-                for t in tags
-                if t in self._SGLANG_MEMORY_TAGS and t in self._released_tags
-            ]
-            if tags
-            else None
+            [t for t in tags if t in self._SGLANG_MEMORY_TAGS] if tags else None
         )
         unsupported = (
             [t for t in tags if t not in self._SGLANG_MEMORY_TAGS] if tags else []
@@ -658,8 +1318,17 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                 unsupported,
                 self._SGLANG_MEMORY_TAGS,
             )
-        if native_tags:
-            req = ResumeMemoryOccupationReqInput(tags=native_tags)
+        requested_tags = list(self._SGLANG_MEMORY_TAGS) if tags is None else native_tags
+        tags_to_resume = [t for t in requested_tags if t in self._released_tags]
+        if tags_to_resume:
+            req = ResumeMemoryOccupationReqInput(tags=tags_to_resume)
             self._scheduler.resume_memory_occupation(req)
-            self._released_tags.difference_update(native_tags)
-        logger.info("resume_memory completed with tags=%s", tags)
+            self._released_tags.difference_update(tags_to_resume)
+            if "weights" in tags_to_resume and rebuild_derived:
+                self._rebuild_derived_weights("resume weights")
+        logger.info(
+            "resume_memory completed with tags=%s resumed_now=%s rebuild_derived=%s",
+            tags,
+            tags_to_resume,
+            rebuild_derived,
+        )

--- a/areal/v2/weight_update/awex/step_dirty_dryrun.py
+++ b/areal/v2/weight_update/awex/step_dirty_dryrun.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterable
+from typing import Any, NamedTuple
+
+import torch
+
+
+class OptimizerShardRef(NamedTuple):
+    name: str
+    tensor: torch.Tensor
+
+
+class StepDirtyShardSnapshot(NamedTuple):
+    name: str
+    tensor: torch.Tensor
+    before_bf16: torch.Tensor
+    numel: int
+    snapshot_bytes: int
+
+
+class StepDirtyCapture(NamedTuple):
+    shards: list[StepDirtyShardSnapshot]
+    total_params: int
+    captured_params: int
+    skipped_by_cap: int
+    total_snapshot_bytes: int
+    captured_snapshot_bytes: int
+    capture_ms: float
+
+
+class StepDirtyCompareResult(NamedTuple):
+    captured_params: int
+    captured_elements: int
+    changed_elements: int
+    changed_ratio: float
+    snapshot_bytes: int
+    bitset_bytes: int
+    indices_elements: int
+    indices_bytes: int
+    compare_ms: float
+    pack_ms: float
+    indices_ms: float
+
+
+class CopybackDirtyBitsetResult(NamedTuple):
+    records: list[dict[str, Any]]
+    complete: bool
+    collect_ms: float
+
+
+NameResolver = Callable[[torch.Tensor], str | None]
+
+
+def iter_optimizer_shard_refs(
+    inner_optimizers: Iterable[object],
+    *,
+    name_resolver: NameResolver | None = None,
+) -> list[OptimizerShardRef]:
+    """Return Megatron distributed-optimizer main shard tensor refs.
+
+    The function intentionally depends only on Megatron optimizer attributes used
+    elsewhere in the AWEX inversion detector. It is safe for unit tests with fake
+    optimizers and for dry-run profiling because it only returns tensor refs.
+    """
+    refs: list[OptimizerShardRef] = []
+    seen: set[int] = set()
+    for opt_idx, opt in enumerate(inner_optimizers):
+        fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+        model_groups = getattr(opt, "model_float16_groups", None)
+        if fp32_groups is None or model_groups is None:
+            continue
+        for group_idx, (fp32_group, model_group) in enumerate(
+            zip(fp32_groups, model_groups)
+        ):
+            for param_idx, (main_shard, model_param) in enumerate(
+                zip(fp32_group, model_group)
+            ):
+                if main_shard is None or not isinstance(main_shard, torch.Tensor):
+                    continue
+                if main_shard.numel() == 0:
+                    continue
+                ptr = main_shard.data_ptr()
+                if ptr in seen:
+                    continue
+                seen.add(ptr)
+                name = name_resolver(model_param) if name_resolver is not None else None
+                if name is None:
+                    name = f"optimizer{opt_idx}.group{group_idx}.param{param_idx}"
+                refs.append(OptimizerShardRef(name=name, tensor=main_shard))
+    return refs
+
+
+def capture_bf16_optimizer_shards(
+    shard_refs: Iterable[OptimizerShardRef],
+    *,
+    max_snapshot_bytes: int = 0,
+    storage: str = "cpu",
+    sync_cuda: bool = False,
+) -> StepDirtyCapture:
+    """Snapshot optimizer main shards as bf16 for dry-run dirty detection.
+
+    Args:
+        shard_refs: optimizer main shard tensor refs.
+        max_snapshot_bytes: byte cap for captured bf16 snapshots. ``0`` means no
+            cap. Positive values keep profiling safe on large models.
+        storage: ``"cpu"`` or ``"gpu"``. CPU is safer for colocate memory;
+            GPU is closer to a kernel-level implementation but can OOM.
+        sync_cuda: synchronize around timing to get blocking GPU cost.
+    """
+    if storage not in {"cpu", "gpu"}:
+        raise ValueError(f"storage must be 'cpu' or 'gpu', got {storage!r}")
+    if max_snapshot_bytes < 0:
+        raise ValueError("max_snapshot_bytes must be non-negative")
+
+    refs = list(shard_refs)
+    if sync_cuda and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    start = time.perf_counter()
+    snapshots: list[StepDirtyShardSnapshot] = []
+    total_snapshot_bytes = 0
+    captured_snapshot_bytes = 0
+    skipped_by_cap = 0
+    for ref in refs:
+        snapshot_bytes = (
+            ref.tensor.numel() * torch.tensor([], dtype=torch.bfloat16).element_size()
+        )
+        total_snapshot_bytes += snapshot_bytes
+        if (
+            max_snapshot_bytes > 0
+            and captured_snapshot_bytes + snapshot_bytes > max_snapshot_bytes
+        ):
+            skipped_by_cap += 1
+            continue
+        device = ref.tensor.device if storage == "gpu" else torch.device("cpu")
+        before = (
+            ref.tensor.detach().to(device=device, dtype=torch.bfloat16).contiguous()
+        )
+        if before.data_ptr() == ref.tensor.data_ptr():
+            before = before.clone()
+        snapshots.append(
+            StepDirtyShardSnapshot(
+                name=ref.name,
+                tensor=ref.tensor,
+                before_bf16=before,
+                numel=ref.tensor.numel(),
+                snapshot_bytes=snapshot_bytes,
+            )
+        )
+        captured_snapshot_bytes += snapshot_bytes
+    if sync_cuda and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    capture_ms = (time.perf_counter() - start) * 1000
+    return StepDirtyCapture(
+        shards=snapshots,
+        total_params=len(refs),
+        captured_params=len(snapshots),
+        skipped_by_cap=skipped_by_cap,
+        total_snapshot_bytes=total_snapshot_bytes,
+        captured_snapshot_bytes=captured_snapshot_bytes,
+        capture_ms=capture_ms,
+    )
+
+
+def compare_bf16_optimizer_shards(
+    capture: StepDirtyCapture,
+    *,
+    pack_bitset: bool = False,
+    materialize_indices: bool = False,
+    sync_cuda: bool = False,
+) -> StepDirtyCompareResult:
+    """Compare current optimizer shards with a prior bf16 snapshot.
+
+    Equality is bitwise, not numerical: bf16 tensors are viewed as int16 before
+    comparing so cases like ``+0.0`` vs ``-0.0`` keep the payload oracle's
+    semantics.
+    """
+    if sync_cuda and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    start = time.perf_counter()
+    pack_ms = 0.0
+    indices_ms = 0.0
+    captured_elements = 0
+    changed_elements = 0
+    bitset_bytes = 0
+    indices_elements = 0
+    indices_bytes = 0
+    pack_bool_mask_to_uint8 = None
+    packed_bool_mask_to_indices = None
+    if pack_bitset or materialize_indices:
+        from dte.core import pack_bool_mask_to_uint8
+    if materialize_indices:
+        from dte.core import packed_bool_mask_to_indices
+
+    for shard in capture.shards:
+        before = shard.before_bf16.reshape(-1)
+        after = (
+            shard.tensor.detach()
+            .to(device=before.device, dtype=torch.bfloat16)
+            .contiguous()
+            .reshape(-1)
+        )
+        changed = before.view(torch.int16) != after.view(torch.int16)
+        captured_elements += shard.numel
+        changed_elements += int(changed.sum().item())
+        if pack_bitset or materialize_indices:
+            pack_start = time.perf_counter()
+            packed = pack_bool_mask_to_uint8(changed)
+            if sync_cuda and torch.cuda.is_available():
+                torch.cuda.synchronize()
+            pack_ms += (time.perf_counter() - pack_start) * 1000
+            bitset_bytes += packed.numel()
+            if materialize_indices:
+                indices_start = time.perf_counter()
+                indices = packed_bool_mask_to_indices(
+                    packed,
+                    shard.numel,
+                    dtype=torch.int32,
+                )
+                if sync_cuda and torch.cuda.is_available():
+                    torch.cuda.synchronize()
+                indices_ms += (time.perf_counter() - indices_start) * 1000
+                indices_elements += indices.numel()
+                indices_bytes += indices.numel() * indices.element_size()
+        else:
+            bitset_bytes += (shard.numel + 7) // 8
+
+    if sync_cuda and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    compare_ms = (time.perf_counter() - start) * 1000
+    return StepDirtyCompareResult(
+        captured_params=capture.captured_params,
+        captured_elements=captured_elements,
+        changed_elements=changed_elements,
+        changed_ratio=changed_elements / max(captured_elements, 1),
+        snapshot_bytes=capture.captured_snapshot_bytes,
+        bitset_bytes=bitset_bytes,
+        indices_elements=indices_elements,
+        indices_bytes=indices_bytes,
+        compare_ms=compare_ms,
+        pack_ms=pack_ms,
+        indices_ms=indices_ms,
+    )
+
+
+def collect_copyback_dirty_bitsets(
+    optimizer: object,
+    *,
+    name_resolver: NameResolver | None = None,
+) -> CopybackDirtyBitsetResult:
+    """Collect dirty bitsets before Megatron copies main shards to model params.
+
+    This is an experimental B1.5/B2 bridge: Megatron's distributed optimizer
+    copy-back path still has the old model-visible payload slice resident in
+    the grad buffer and the updated fp32 main shard in hand. Comparing them
+    here can produce optimizer-shard dirty bitsets without AdamW inversion and
+    without a CPU snapshot. The caller must invoke this immediately before the
+    optimizer's original ``_copy_main_params_to_model_params`` method.
+    """
+    from dte.core import bitwise_changed_mask, pack_bool_mask_to_uint8
+
+    start = time.perf_counter()
+    records: list[dict[str, Any]] = []
+    complete = True
+
+    def collect_group(shard_main_groups, model_groups) -> None:
+        nonlocal complete
+        for shard_main_group, model_group in zip(shard_main_groups, model_groups):
+            for shard_main_param, model_param in zip(shard_main_group, model_group):
+                if shard_main_param is None or not isinstance(
+                    shard_main_param, torch.Tensor
+                ):
+                    complete = False
+                    continue
+                name = name_resolver(model_param) if name_resolver is not None else None
+                if name is None:
+                    complete = False
+                    continue
+
+                try:
+                    param_range_map = optimizer._get_model_param_range_map(model_param)
+                    param_range = param_range_map["param"]
+                    world_range = param_range_map["gbuf_world_in_bucket"]
+                    gbuf_index, _, bucket_id = optimizer.model_param_gbuf_map[
+                        model_param
+                    ]
+                    model_param_buffer = (
+                        optimizer.buffers[gbuf_index].buckets[bucket_id].param_data
+                    )
+                except Exception:
+                    complete = False
+                    continue
+
+                old_payload = model_param_buffer.view(-1)[
+                    world_range.start : world_range.end
+                ].detach()
+                new_payload = (
+                    shard_main_param.detach()
+                    .to(device=old_payload.device, dtype=old_payload.dtype)
+                    .reshape(-1)
+                )
+                if old_payload.numel() != new_payload.numel():
+                    complete = False
+                    continue
+
+                changed = bitwise_changed_mask(
+                    new_payload,
+                    old_payload.reshape(-1),
+                )
+                packed = pack_bool_mask_to_uint8(changed).contiguous()
+                records.append(
+                    {
+                        "name": name,
+                        "packed_bitset": packed,
+                        "shape": tuple(model_param.shape),
+                        "shard_start": int(param_range.start),
+                        "shard_numel": int(param_range.size),
+                    }
+                )
+
+    fp32_from_float16_groups = getattr(
+        optimizer,
+        "shard_fp32_from_float16_groups",
+        None,
+    )
+    model_float16_groups = getattr(optimizer, "model_float16_groups", None)
+    if fp32_from_float16_groups is None or model_float16_groups is None:
+        complete = False
+    else:
+        collect_group(fp32_from_float16_groups, model_float16_groups)
+
+    shard_fp32_groups = getattr(optimizer, "shard_fp32_groups", None)
+    model_fp32_groups = getattr(optimizer, "model_fp32_groups", None)
+    if shard_fp32_groups is not None and model_fp32_groups is not None:
+        collect_group(shard_fp32_groups, model_fp32_groups)
+
+    return CopybackDirtyBitsetResult(
+        records=records,
+        complete=complete,
+        collect_ms=(time.perf_counter() - start) * 1000,
+    )

--- a/areal/v2/weight_update/controller/controller.py
+++ b/areal/v2/weight_update/controller/controller.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 
 from areal.infra.utils.proc import kill_process_tree
+from areal.infra.utils.python import get_python_executable
 from areal.utils import logging
 from areal.utils.network import find_free_ports
 from areal.v2.weight_update.controller.config import (
@@ -45,7 +46,7 @@ class WeightUpdateController:
             port = find_free_ports(1)[0]
 
         cmd = [
-            sys.executable,
+            get_python_executable(),
             "-m",
             "areal.v2.weight_update.gateway",
             "--host",
@@ -68,7 +69,8 @@ class WeightUpdateController:
             stderr=sys.stdout,
         )
 
-        self._gateway_url = f"http://{cfg.host}:{port}"
+        client_host = "127.0.0.1" if cfg.host in ("0.0.0.0", "::") else cfg.host
+        self._gateway_url = f"http://{client_host}:{port}"
         self._session = httpx.Client()
         self._session.headers["Authorization"] = f"Bearer {cfg.admin_api_key}"
         self._wait_for_health()
@@ -155,12 +157,17 @@ class WeightUpdateController:
         )
         resp.raise_for_status()
         data = resp.json()
-        return WeightUpdateResult(
+        result = WeightUpdateResult(
             status=data["status"],
             version=data["version"],
             duration_ms=data["duration_ms"],
             error=data.get("error"),
         )
+        if result.status != "ok":
+            raise RuntimeError(
+                f"Weight update v{result.version} failed: {result.error or result.status}"
+            )
+        return result
 
     def disconnect(self) -> None:
         if self._pair_name is None:

--- a/areal/v2/weight_update/gateway/app.py
+++ b/areal/v2/weight_update/gateway/app.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import asyncio
 import os
+import pickle
 import socket
+import tempfile
 import time
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 import aiohttp  # pyright: ignore[reportMissingImports]
@@ -15,7 +18,7 @@ from pydantic import BaseModel  # pyright: ignore[reportMissingImports]
 
 from areal.infra.utils.http import async_http_retry
 from areal.utils import logging
-from areal.utils.network import find_free_ports
+from areal.v2.weight_update.awex.delta_config import delta_transfer_enabled
 from areal.v2.weight_update.gateway.auth import require_admin_key
 from areal.v2.weight_update.gateway.config import (
     PairInfo,
@@ -131,21 +134,67 @@ def _get_own_ip() -> str:
         return "127.0.0.1"
 
 
-def _merge_training_meta_by_name(meta_list: list[dict]) -> list[dict]:
-    """Merge serialized training ParameterMeta entries by parameter name.
+def _serialized_data(value: Any) -> Any:
+    return value.get("data", value) if isinstance(value, dict) else value
 
-    Each FSDP worker reports metadata for its own local shard only.
-    With ``dp_size > 1`` the same parameter name appears once per worker,
-    each carrying a single shard.  The ``TransferPlanBuilder`` indexes
-    parameters with ``{meta.name: meta}``, so duplicates silently shadow
-    earlier entries.  We merge them here so the builder sees one
-    ``ParameterMeta`` per name with all shards in a single replica.
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    data = _serialized_data(value)
+    if isinstance(data, dict):
+        return data.get(name, default)
+    return getattr(data, name, default)
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple((k, _freeze(v)) for k, v in sorted(value.items()))
+    if isinstance(value, list | tuple):
+        return tuple(_freeze(v) for v in value)
+    return value
+
+
+def _shard_signature(shard: Any) -> tuple[Any, ...]:
+    data = _serialized_data(shard)
+    return (
+        _field(data, "name"),
+        _field(data, "global_rank"),
+        _freeze(_field(data, "global_offset")),
+        _freeze(_field(data, "shape")),
+        _freeze(_field(data, "dtype")),
+        _freeze(_field(data, "sharding_type")),
+        _field(data, "sharding_dim"),
+        _field(data, "num_shards"),
+    )
+
+
+def _extend_unique_shards(target: list[Any], source: list[Any]) -> int:
+    seen = {_shard_signature(shard) for shard in target}
+    added = 0
+    for shard in source:
+        sig = _shard_signature(shard)
+        if sig in seen:
+            continue
+        target.append(shard)
+        seen.add(sig)
+        added += 1
+    return added
+
+
+def _merge_meta_by_name(meta_list: list[Any], label: str) -> list[Any]:
+    """Merge serialized ParameterMeta entries by parameter name.
+
+    Training and SGLang inference workers can report one ``ParameterMeta`` per
+    local shard.  ``TransferPlanBuilder`` indexes parameters as
+    ``{meta.name: meta}``, so duplicates would otherwise shadow earlier shards.
+    SGLang also reports the same per-engine TP metadata from every engine; shard
+    de-duplication keeps one logical engine, which the builder then expands via
+    ``num_infer_engines``.
     """
-    by_name: dict[str, dict] = {}
-    overflow: list[dict] = []
+    by_name: dict[str, Any] = {}
+    overflow: list[Any] = []
     for pm in meta_list:
-        data = pm.get("data", pm) if isinstance(pm, dict) else pm
-        name = data.get("name") if isinstance(data, dict) else None
+        data = _serialized_data(pm)
+        name = _field(data, "name")
         if name is None:
             logger.warning("Found parameter metadata with no name: %s", pm)
             overflow.append(pm)
@@ -154,17 +203,78 @@ def _merge_training_meta_by_name(meta_list: list[dict]) -> list[dict]:
         if name not in by_name:
             by_name[name] = pm
         else:
-            existing_data = by_name[name].get("data", by_name[name])
-            existing_data.setdefault("shards", []).extend(data.get("shards", []))
+            existing_data = _serialized_data(by_name[name])
+            existing_shards = existing_data.setdefault("shards", [])
+            _extend_unique_shards(existing_shards, data.get("shards", []))
+
             ex_replicas = existing_data.get("replicas", [])
             new_replicas = data.get("replicas", [])
             if ex_replicas and new_replicas:
-                ex_rep_data = ex_replicas[0].get("data", ex_replicas[0])
-                new_rep_data = new_replicas[0].get("data", new_replicas[0])
-                ex_rep_data.setdefault("shards", []).extend(
-                    new_rep_data.get("shards", [])
+                ex_rep_data = _serialized_data(ex_replicas[0])
+                new_rep_data = _serialized_data(new_replicas[0])
+                _extend_unique_shards(
+                    ex_rep_data.setdefault("shards", []),
+                    new_rep_data.get("shards", []),
                 )
-    return list(by_name.values()) + overflow
+    merged = list(by_name.values()) + overflow
+    if len(merged) != len(meta_list):
+        logger.info(
+            "Merged %s parameter metadata by name: %d -> %d",
+            label,
+            len(meta_list),
+            len(merged),
+        )
+    return merged
+
+
+def _safe_file_component(value: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in value)
+
+
+def _colocate_metadata_dir() -> Path:
+    root = (
+        os.environ.get("DTE_WEIGHT_META_DIR")
+        or os.environ.get("AREAL_WEIGHT_META_DIR")
+        or os.environ.get("AREAL_STORAGE")
+        or os.getcwd()
+    )
+    return Path(root).expanduser().resolve() / ".areal_weight_meta"
+
+
+def _write_colocate_metadata_file(
+    pair_name: str,
+    infer_params_meta: list[Any],
+    training_params_meta: list[Any],
+) -> str:
+    metadata_dir = _colocate_metadata_dir()
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    safe_pair = _safe_file_component(pair_name)
+    final_path = metadata_dir / (
+        f"{safe_pair}.{os.getpid()}.{int(time.time() * 1000)}.pkl"
+    )
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{safe_pair}.",
+        suffix=".tmp",
+        dir=metadata_dir,
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            pickle.dump(
+                {
+                    "infer_params_meta": infer_params_meta,
+                    "training_params_meta": training_params_meta,
+                },
+                f,
+                protocol=pickle.HIGHEST_PROTOCOL,
+            )
+        os.replace(tmp_path, final_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return str(final_path)
 
 
 def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
@@ -200,8 +310,23 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         inference_urls = body.inference_worker_urls
 
         if body.colocate:
+            if not body.nccl_master_addr or body.nccl_master_port <= 0:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": (
+                            "nccl_master_addr and nccl_master_port are required "
+                            "when colocate=True"
+                        )
+                    },
+                )
             return await _connect_colocate(
-                request, pair_name, train_urls, inference_urls
+                request,
+                pair_name,
+                train_urls,
+                inference_urls,
+                body.nccl_master_addr,
+                body.nccl_master_port,
             )
 
         if body.mode == "disk":
@@ -311,7 +436,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 training_params_meta.extend(meta)
             else:
                 training_params_meta.append(meta)
-        training_params_meta = _merge_training_meta_by_name(training_params_meta)
+        training_params_meta = _merge_meta_by_name(training_params_meta, "training")
 
         infer_params_meta = []
         for result in infer_meta_resps:
@@ -320,6 +445,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 infer_params_meta.extend(meta)
             else:
                 infer_params_meta.append(meta)
+        infer_params_meta = _merge_meta_by_name(infer_params_meta, "inference")
 
         kv_store.put(pair_name, "training_params_meta", training_params_meta)
         kv_store.put(pair_name, "infer_params_meta", infer_params_meta)
@@ -398,6 +524,8 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         pair_name: str,
         train_urls: list[str],
         inference_urls: list[str],
+        nccl_master_addr: str,
+        nccl_master_port: int,
     ) -> ConnectResponse:
         session = request.app.state.http_session
         init_timeout_s = config.init_timeout_s
@@ -420,12 +548,19 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         # report_parallelism returns per-instance world_size (e.g. TP size).
         # The total inference world for colocate NCCL groups spans all engines.
         infer_world_size = infer_par["world_size"] * num_engines
+        infer_conf = dict(
+            infer_par.get("awex_infer_conf") or infer_par.get("infer_conf") or {}
+        )
+        infer_conf["infer_world_size"] = infer_world_size
 
         train_meta_resps, infer_meta_resps = await asyncio.gather(
             asyncio.gather(
                 *[
                     _post_json(
-                        session, f"{url}/awex/report_weight_meta", init_timeout_s
+                        session,
+                        f"{url}/awex/report_weight_meta",
+                        init_timeout_s,
+                        json_data={"infer_conf": infer_conf},
                     )
                     for url in train_urls
                 ]
@@ -447,7 +582,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 training_params_meta.extend(meta)
             else:
                 training_params_meta.append(meta)
-        training_params_meta = _merge_training_meta_by_name(training_params_meta)
+        training_params_meta = _merge_meta_by_name(training_params_meta, "training")
 
         infer_params_meta = []
         for result in infer_meta_resps:
@@ -456,16 +591,36 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 infer_params_meta.extend(meta)
             else:
                 infer_params_meta.append(meta)
+        infer_params_meta = _merge_meta_by_name(infer_params_meta, "inference")
 
         kv_store.put(pair_name, "training_params_meta", training_params_meta)
         kv_store.put(pair_name, "infer_params_meta", infer_params_meta)
+        try:
+            metadata_path = _write_colocate_metadata_file(
+                pair_name, infer_params_meta, training_params_meta
+            )
+            kv_store.put(pair_name, "metadata_path", metadata_path)
+            logger.info(
+                "Wrote colocate metadata file for pair '%s': %s",
+                pair_name,
+                metadata_path,
+            )
+        except Exception:
+            metadata_path = ""
+            logger.warning(
+                "Failed to write colocate metadata file for pair '%s'; "
+                "falling back to gateway KV metadata fetch",
+                pair_name,
+                exc_info=True,
+            )
 
         gateway_addr = (
             _get_own_ip() if config.host in ("0.0.0.0", "::") else config.host
         )
         kv_store_url = f"http://{gateway_addr}:{config.gateway_port}"
 
-        [master_port] = find_free_ports(1)
+        master_addr = nccl_master_addr
+        master_port = nccl_master_port
 
         init_payload_base = {
             "pair_name": pair_name,
@@ -473,8 +628,12 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             "infer_world_size": infer_world_size,
             "train_world_size": train_world_size,
             "num_engines": num_engines,
+            "master_addr": master_addr,
             "master_port": master_port,
             "admin_api_key": config.admin_api_key,
+            "timeout_s": init_timeout_s,
+            "expected_delta_enabled": delta_transfer_enabled(),
+            "metadata_path": metadata_path,
         }
 
         init_tasks = []
@@ -496,6 +655,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                     json_data={
                         **init_payload_base,
                         "transfer_rank": infer_world_size + i,
+                        "infer_conf": infer_conf,
                     },
                 )
             )
@@ -507,11 +667,19 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             inference_worker_urls=inference_urls,
             train_world_size=train_world_size,
             inference_world_size=infer_world_size,
+            master_addr=master_addr,
+            master_port=master_port,
             colocate=True,
         )
         registry.register(pair_info)
 
-        logger.info("Connected colocate pair '%s'", pair_name)
+        logger.info(
+            "Connected colocate pair '%s' (kv_store=%s, master=%s:%d)",
+            pair_name,
+            kv_store_url,
+            master_addr,
+            master_port,
+        )
         return ConnectResponse(pair_name=pair_name)
 
     async def _colocate_transfer_weights(
@@ -520,6 +688,38 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         session: aiohttp.ClientSession,
         timeout_s: float,
     ) -> None:
+        logger.info(
+            "Colocate v%d: inference memory transition is owned by rollout "
+            "pause/offload; skip duplicate gateway release",
+            version,
+        )
+
+        # Precompute delta change masks while the optimizer (fp32 main shards
+        # + AdamW moments) is still GPU-resident; the release below moves it
+        # to CPU and would otherwise force the inversion detector to stage
+        # 30+GB back during the sync critical path. All train workers must be
+        # posted together (the mask computation runs training collectives).
+        # Failure is non-fatal: the sync computes masks in-band instead.
+        try:
+            await asyncio.gather(
+                *[
+                    _post(
+                        session,
+                        f"{url}/awex/precompute_delta_masks",
+                        timeout_s,
+                        json_data={"version": version},
+                    )
+                    for url in pair_info.train_worker_urls
+                ]
+            )
+        except Exception:
+            logger.warning(
+                "Colocate v%d: precompute_delta_masks failed; "
+                "masks will be computed during the sync",
+                version,
+                exc_info=True,
+            )
+
         await asyncio.gather(
             *[
                 _post(
@@ -536,18 +736,6 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             *[
                 _post(
                     session,
-                    f"{url}/awex/resume_memory",
-                    timeout_s,
-                    json_data={"tags": ["weights"]},
-                )
-                for url in pair_info.inference_worker_urls
-            ]
-        )
-
-        await asyncio.gather(
-            *[
-                _post(
-                    session,
                     f"{url}/awex/execute_colocate_weight_update",
                     timeout_s,
                     json_data={"version": version},
@@ -565,29 +753,29 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             ],
         )
 
-        await asyncio.gather(
-            *[
-                _post(
-                    session,
-                    f"{url}/awex/release_memory",
-                    timeout_s,
-                    json_data={"tags": ["weights"]},
-                )
-                for url in pair_info.train_worker_urls
-            ]
-        )
-
-        await asyncio.gather(
-            *[
-                _post(
-                    session,
-                    f"{url}/awex/resume_memory",
-                    timeout_s,
-                    json_data={"tags": ["kv_cache"]},
-                )
-                for url in pair_info.inference_worker_urls
-            ]
-        )
+        release_env = os.environ.get("DTE_RELEASE_TRAIN_WEIGHTS_AFTER_UPDATE")
+        if release_env is None or release_env.strip() == "":
+            release_env = os.environ.get(
+                "AWEX_COLOCATE_RELEASE_TRAIN_WEIGHTS_AFTER_UPDATE", "1"
+            )
+        release_train_weights = release_env.strip().lower() not in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+        if release_train_weights:
+            await asyncio.gather(
+                *[
+                    _post(
+                        session,
+                        f"{url}/awex/release_memory",
+                        timeout_s,
+                        json_data={"tags": ["weights"]},
+                    )
+                    for url in pair_info.train_worker_urls
+                ]
+            )
 
         # Flush colocate KV keys for this version to prevent accumulation
         infer_world_size = pair_info.inference_world_size
@@ -596,8 +784,12 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             transfer_rank = infer_world_size + i
             weight_key = f"colocate_weights_rank{transfer_rank}_{version}"
             done_key = f"colocate_done_rank{transfer_rank}_{version}"
+            offloaded_key = (
+                f"colocate_train_weights_offloaded_rank{transfer_rank}_{version}"
+            )
             kv_store.delete(pair_info.pair_name, weight_key)
             kv_store.delete(pair_info.pair_name, done_key)
+            kv_store.delete(pair_info.pair_name, offloaded_key)
 
     async def _awex_transfer_weights(
         pair_info: PairInfo,
@@ -769,6 +961,19 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 status_code=404,
                 content={"error": f"Pair '{body.pair_name}' not found"},
             )
+
+        metadata_path = kv_store.get(pair_info.pair_name, "metadata_path")
+        if isinstance(metadata_path, str) and metadata_path:
+            try:
+                os.unlink(metadata_path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                logger.warning(
+                    "Failed to remove colocate metadata file: %s",
+                    metadata_path,
+                    exc_info=True,
+                )
 
         registry.unregister(pair_info.pair_name)
         kv_store.clear_pair(pair_info.pair_name)

--- a/areal/v2/weight_update/inference_adapter.py
+++ b/areal/v2/weight_update/inference_adapter.py
@@ -66,15 +66,22 @@ class AwexInferenceAdapter(Protocol):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        master_addr: str,
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        expected_delta_enabled: bool | None = None,
+        metadata_path: str = "",
     ) -> None:
         """Build device mapping, inference-only NCCL group, and colocate transport."""
         ...
 
     def execute_colocate_weight_update(self, version: int) -> None:
         """Fetch IPC weights from KV store and apply via colocate transport."""
+        ...
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Seed colocate delta state from the current local weights."""
         ...
 
     def release_memory(self, tags: list[str] | None = None) -> None:

--- a/areal/v2/weight_update/training_adapter.py
+++ b/areal/v2/weight_update/training_adapter.py
@@ -18,7 +18,7 @@ class AwexTrainingAdapter(Protocol):
         """
         ...
 
-    def get_weight_metadata(self) -> list:
+    def get_weight_metadata(self, infer_conf: dict | None = None) -> list:
         """Extract this worker's parameter shard metadata in awex format.
 
         Returns list[ParameterMeta].
@@ -66,15 +66,31 @@ class AwexTrainingAdapter(Protocol):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        master_addr: str,
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        expected_delta_enabled: bool | None = None,
+        metadata_path: str = "",
+        infer_conf: dict | None = None,
     ) -> None:
         """Register device info in KV store for colocated weight transfer."""
         ...
 
     def execute_colocate_weight_update(self, version: int) -> None:
         """Serialize weights via IPC and put to KV store."""
+        ...
+
+    def precompute_delta_masks(self, version: int) -> bool:
+        """Precompute delta masks while optimizer state is still GPU-resident.
+
+        Optional fast path called before ``release_memory(["optimizer"])``;
+        returns False when skipped so the sync computes masks in-band.
+        """
+        ...
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Seed colocate delta state from the current local weights."""
         ...
 
     def release_memory(self, tags: list[str] | None = None) -> None:

--- a/examples/dte/README.md
+++ b/examples/dte/README.md
@@ -1,0 +1,57 @@
+# DTE Weight Transfer Examples
+
+This folder contains compact GSM8K RL configurations for DTE colocated weight updates.
+
+## Configs
+
+- `gsm8k_dte_full.yaml`: colocated full-weight transfer.
+- `gsm8k_dte_delta_adamw.yaml`: first update is full, then DTE delta transfer with AdamW
+  inversion.
+- `gsm8k_dte_base.yaml`: shared two-GPU GSM8K smoke settings.
+
+The important knobs are:
+
+```yaml
+actor:
+  dte:
+    enabled: true
+    transfer: full        # full | delta
+    delta_method: adamw   # only used when transfer=delta; snapshot | adamw
+    anchor_interval: 0
+    verify_snapshot: false
+```
+
+## Install
+
+Install AReaL with the DTE dependency:
+
+```bash
+python -m pip install -e ".[delta]"
+```
+
+## Run
+
+Run AdamW-inversion delta transfer locally:
+
+```bash
+python examples/math/gsm8k_rl.py \
+  --config examples/dte/gsm8k_dte_delta_adamw.yaml
+```
+
+Run full-weight transfer instead:
+
+```bash
+python examples/math/gsm8k_rl.py \
+  --config examples/dte/gsm8k_dte_full.yaml
+```
+
+Use snapshot-based delta detection without adding another config file:
+
+```bash
+python examples/math/gsm8k_rl.py \
+  --config examples/dte/gsm8k_dte_delta_adamw.yaml \
+  actor.dte.delta_method=snapshot
+```
+
+Override `scheduler.type`, model paths, and cluster settings for your environment. Set
+`actor.dte.verify_snapshot=true` to compare AdamW-inversion masks with snapshot diffing.

--- a/examples/dte/gsm8k_dte_base.yaml
+++ b/examples/dte/gsm8k_dte_base.yaml
@@ -1,0 +1,65 @@
+defaults:
+  - ../math/gsm8k_grpo_megatron@_global_
+  - _self_
+
+experiment_name: gsm8k-dte
+trial_name: trial0
+total_train_steps: null
+
+cluster:
+  n_gpus_per_node: 2
+
+scheduler:
+  type: local
+
+gconfig:
+  n_samples: 4
+  max_new_tokens: 256
+  max_tokens: 1024
+
+rollout:
+  _version: v2
+  backend: sglang:d2p1t1
+  max_concurrent_rollouts: 32
+  queue_size: 32
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 1000000
+
+actor:
+  _version: v2
+  backend: megatron:d2p1t1
+  weight_update_mode: awex
+  dte:
+    enabled: true
+    transfer: full
+    anchor_interval: 0
+    verify_snapshot: false
+  optimizer:
+    lr: 8e-7
+    warmup_steps_proportion: 0
+  reward_norm: null
+  adv_norm: null
+
+sglang:
+  mem_fraction_static: 0.35
+
+train_dataset:
+  batch_size: 8
+  num_workers: 1
+
+valid_dataset:
+  batch_size: 8
+  num_workers: 1
+
+saver:
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+
+evaluator:
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null

--- a/examples/dte/gsm8k_dte_delta_adamw.yaml
+++ b/examples/dte/gsm8k_dte_delta_adamw.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - gsm8k_dte_base@_global_
+  - _self_
+
+experiment_name: gsm8k-dte-delta-adamw
+
+actor:
+  dte:
+    enabled: true
+    transfer: delta
+    delta_method: adamw
+    anchor_interval: 0
+    verify_snapshot: false

--- a/examples/dte/gsm8k_dte_full.yaml
+++ b/examples/dte/gsm8k_dte_full.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - gsm8k_dte_base@_global_
+  - _self_
+
+experiment_name: gsm8k-dte-full
+
+actor:
+  dte:
+    enabled: true
+    transfer: full
+    verify_snapshot: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,11 @@ cli = [
     "click>=8.1",
     "colorlog",
 ]
+# Incremental colocated weight transfer. The AWEX adapters import `dte`
+# lazily, so default installs do not need this optional dependency.
+delta = [
+    "delta-transfer-engine @ git+https://github.com/areal-project/AReaL-DTE.git@6b2bc13e2b626d2677e9997f159b5a3269c97e3e",
+]
 
 [project.scripts]
 areal = "areal.v2.cli.main:cli"

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -194,6 +194,9 @@ cuda = [
 sandbox = [
     "daytona>=0.167.0",
 ]
+delta = [
+    "delta-transfer-engine @ git+https://github.com/areal-project/AReaL-DTE.git@6b2bc13e2b626d2677e9997f159b5a3269c97e3e",
+]
 cli = [
     "click>=8.1",
     "colorlog",

--- a/tests/test_awex_colocate_delta.py
+++ b/tests/test_awex_colocate_delta.py
@@ -1,0 +1,2135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU round-trip tests for colocate delta (incremental) weight transfer.
+
+These validate the migration's correctness contract: the sender-side
+``DeltaTracker`` decision (mirrored from ``AwexMegatronAdapter._delta_encode``)
+feeding dte's transport-free ``DeltaEngine.reconstruct`` (the core of
+``AwexSGLangAdapter._delta_reconstruct``) reconstructs full + delta payloads
+byte-identically against the receiver's version-chained base — no GPU or
+distributed setup required.
+
+``delta_config`` is loaded directly from its file so the test does not pull in
+the full areal runtime import chain (httpx/awex), which is absent in lean CI
+sandboxes; the module itself only depends on ``os`` + (lazily) ``dte``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("dte")
+
+_DC_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "areal/v2/weight_update/awex/delta_config.py"
+)
+
+
+def _load_delta_config():
+    spec = importlib.util.spec_from_file_location("awex_delta_config", _DC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def dc():
+    return _load_delta_config()
+
+
+def _encode_like_adapter(tracker, params, version):
+    """Mirror ``AwexMegatronAdapter._delta_encode`` (sender side)."""
+    params_list = list(params.items())
+    reason = tracker.full_sync_reason(version)
+    if reason is not None:
+        tracker.seed(params_list, version)
+        return list(params.keys()), list(params.values())
+    encoded = tracker.encode(params_list, version)
+    return encoded.names, encoded.tensors
+
+
+def _over_the_wire(names, tensors):
+    """Stand in for cuda_ipc serialize/deserialize: clone to detach storage."""
+    return dict(zip(names, [t.clone() for t in tensors]))
+
+
+def _weights(seed: int):
+    g = torch.Generator().manual_seed(seed)
+    return {
+        "embed.weight": torch.randn(32, 16, generator=g),
+        "layer.weight": torch.randn(16, 16, generator=g),
+        "layer.bias": torch.randn(16, generator=g),
+    }
+
+
+def _changed_indices(mask: torch.Tensor) -> torch.Tensor:
+    return mask.reshape(-1).nonzero(as_tuple=False).squeeze(1).to(torch.int32)
+
+
+def test_delta_config_env_gates(dc, monkeypatch):
+    monkeypatch.delenv("DTE_DELTA_TRANSFER", raising=False)
+    monkeypatch.delenv("AWEX_DELTA_TRANSFER", raising=False)
+    assert dc.delta_transfer_enabled() is False
+    monkeypatch.setenv("AWEX_DELTA_TRANSFER", "1")
+    assert dc.delta_transfer_enabled() is True
+    monkeypatch.setenv("DTE_DELTA_TRANSFER", "0")
+    assert dc.delta_transfer_enabled() is False
+    monkeypatch.setenv("DTE_DELTA_TRANSFER", "1")
+    assert dc.delta_transfer_enabled() is True
+
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "5")
+    assert dc.delta_anchor_interval() == 5
+    monkeypatch.setenv("DTE_DELTA_ANCHOR_INTERVAL", "7")
+    assert dc.delta_anchor_interval() == 7
+    monkeypatch.setenv("AWEX_DELTA_BYTES_RATIO", "0.33")
+    assert dc.delta_bytes_ratio() == pytest.approx(0.33)
+    monkeypatch.setenv("DTE_DELTA_BYTES_RATIO", "0.44")
+    assert dc.delta_bytes_ratio() == pytest.approx(0.44)
+
+
+def test_cuda_mem_stats_mb_without_cuda_returns_sentinel(dc):
+    # Arrange/Act: helper must not raise on CPU-only hosts.
+    alloc_mb, peak_mb = dc.cuda_mem_stats_mb()
+    # Assert: sentinel on CPU; non-negative MB values when CUDA is present.
+    if torch.cuda.is_available():
+        assert alloc_mb >= 0.0
+        assert peak_mb >= 0.0
+        # reset_peak=True must clamp the next peak reading down to ~alloc.
+        alloc2_mb, peak2_mb = dc.cuda_mem_stats_mb(reset_peak=False)
+        assert peak2_mb <= peak_mb or peak2_mb == pytest.approx(alloc2_mb, abs=1.0)
+    else:
+        assert (alloc_mb, peak_mb) == (-1.0, -1.0)
+        assert dc.cuda_mem_stats_mb(reset_peak=False) == (-1.0, -1.0)
+
+
+def test_factories_build_dte_objects(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+    assert hasattr(tracker, "encode") and hasattr(tracker, "seed")
+    assert hasattr(engine, "reconstruct")
+
+
+def test_full_then_delta_roundtrip(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    from dte.core import is_delta_payload
+
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    # v1: first transfer -> full sync (dense); seeds sender snapshot + receiver base.
+    w1 = _weights(0)
+    names, tensors = _encode_like_adapter(tracker, w1, 1)
+    assert not is_delta_payload(names)
+    full1, masks1 = engine.reconstruct(_over_the_wire(names, tensors), 1)
+    assert masks1 is None
+    for k, v in w1.items():
+        assert torch.equal(full1[k], v), f"full-sync mismatch on {k}"
+
+    # v2: change two elements of one tensor -> sparse delta; others unchanged.
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][0, 0] += 1.5
+    w2["layer.weight"][3, 7] -= 2.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+    assert is_delta_payload(names)
+    # Unchanged tensors are not shipped at all.
+    assert "embed.weight" not in names and "layer.bias" not in names
+    full2, masks2 = engine.reconstruct(_over_the_wire(names, tensors), 2)
+    assert masks2 is not None
+    for k, v in w2.items():
+        assert torch.equal(full2[k], v), f"delta reconstruct mismatch on {k}"
+
+
+def test_live_decode_tracks_versions_without_cpu_base(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    from dte.core import is_delta_payload
+
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    w1 = _weights(11)
+    names, tensors = _encode_like_adapter(tracker, w1, 1)
+    assert not is_delta_payload(names)
+    assert engine.decode_for_live_apply(_over_the_wire(names, tensors), 1) is None
+    assert engine.base_version == 1
+    assert getattr(engine, "_base") == {}
+
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][0, 0] += 1.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+    decoded = engine.decode_for_live_apply(_over_the_wire(names, tensors), 2)
+    assert decoded is not None
+    assert decoded.header.base_version == 1
+    assert engine.base_version == 1
+    engine.commit_live_apply(decoded)
+    assert engine.base_version == 2
+    assert getattr(engine, "_base") == {}
+
+
+def test_anchor_interval_forces_full_sync(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "1")  # full sync every 1 delta
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    is_full = []
+    w = _weights(1)
+    for version in (1, 2, 3, 4):
+        if version > 1:
+            w = {k: v.clone() for k, v in w.items()}
+            w["layer.weight"][0, version] += float(version)
+        names, tensors = _encode_like_adapter(tracker, w, version)
+        _full, masks = engine.reconstruct(_over_the_wire(names, tensors), version)
+        is_full.append(masks is None)  # True == full sync
+    # v1 seed(full), v2 delta, v3 anchor(full), v4 delta
+    assert is_full == [True, False, True, False], is_full
+
+
+def test_delta_before_base_raises(dc, monkeypatch):
+    from dte.engine import DeltaChainBroken
+
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    tracker = dc.make_delta_tracker()
+
+    # Build a valid delta payload (requires a seeded tracker)...
+    w1 = _weights(2)
+    _encode_like_adapter(tracker, w1, 1)  # seeds snapshot at v1
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][1, 1] += 1.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+
+    # ...and feed it to a FRESH receiver that never received a full-sync base.
+    fresh_engine = dc.make_delta_engine("cpu")
+    with pytest.raises(DeltaChainBroken):
+        fresh_engine.reconstruct(_over_the_wire(names, tensors), 2)
+
+
+def test_header_constant_matches_dte(dc):
+    # delta_config mirrors dte's wire header so the receiver can detect a delta
+    # payload without importing dte; guard the mirror against drift.
+    from dte.core import DELTA_HEADER_NAME
+
+    assert dc.DELTA_HEADER_NAME == DELTA_HEADER_NAME
+
+
+def test_payload_carries_delta(dc):
+    assert dc.payload_carries_delta([dc.DELTA_HEADER_NAME, "layer.weight@delta_idx"])
+    assert not dc.payload_carries_delta(["layer.weight", "layer.bias"])
+
+
+def test_real_awex_channel_roundtrip(dc):
+    """Delta payload survives the REAL awex group/reconstruct serialization path.
+
+    Guards the highest-risk integration point: dte's variable-length int idx /
+    1-D header tensors must round-trip losslessly through
+    ``group_tensors_by_shape_and_dtype`` + ``reconstruct_tensors_from_groups``
+    (cuda_ipc itself is identity within one process). Skipped where awex is not
+    installed (lean CI sandboxes); runs in the full inference image.
+    """
+    tu = pytest.importorskip("awex.util.tensor_util")
+    group = tu.group_tensors_by_shape_and_dtype
+    reconstruct = tu.reconstruct_tensors_from_groups
+
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    # v1 full sync through the real channel.
+    w1 = _weights(3)
+    names, tensors = _encode_like_adapter(tracker, w1, 1)
+    groups, meta = group(tensors)
+    full1, masks1 = engine.reconstruct(dict(zip(names, reconstruct(groups, meta))), 1)
+    assert masks1 is None
+    for k, v in w1.items():
+        assert torch.equal(full1[k], v)
+
+    # v2 delta through the real channel; assert the channel is lossless first.
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][2, 2] += 1.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+    groups, meta = group(tensors)
+    recon = reconstruct(groups, meta)
+    for name, orig in zip(names, tensors):
+        assert torch.equal(dict(zip(names, recon))[name], orig), f"channel lost {name}"
+    full2, masks2 = engine.reconstruct(dict(zip(names, recon)), 2)
+    assert masks2 is not None
+    for k, v in w2.items():
+        assert torch.equal(full2[k], v)
+
+
+def test_consecutive_deltas_advance_base(dc):
+    """Base must advance across many deltas, not stay pinned at the seed.
+
+    Guards ``reconstruct`` writing each rebuilt full-shard back into the CPU base
+    (dte ``reconstruct_against_base`` does this in place). A regression that left
+    the base at v1 would still pass a single-delta test but corrupt v3+.
+    """
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    w = _weights(7)
+    names, tensors = _encode_like_adapter(tracker, w, 1)  # v1 full sync seeds base
+    engine.reconstruct(_over_the_wire(names, tensors), 1)
+
+    for version in range(2, 8):
+        w = {k: v.clone() for k, v in w.items()}
+        w["layer.weight"][version % 16, (version * 3) % 16] += version * 0.5
+        names, tensors = _encode_like_adapter(tracker, w, version)
+        full, masks = engine.reconstruct(_over_the_wire(names, tensors), version)
+        assert masks is not None, f"v{version} should be a delta"
+        for k, v in w.items():
+            assert torch.equal(full[k], v), f"v{version} mismatch on {k}"
+
+
+def test_invert_adamw_roundtrip():
+    """dte.invert_adamw recovers theta_{t-1} from a real AdamW step (CPU-only).
+
+    This is the only CPU-verifiable piece of the inversion detector — its mcore
+    traversal / DP all-reduce / convert are GPU-only. Confirms both the formula
+    and the (theta_t, m, v, step, lr, wd, b1, b2, eps) argument order the
+    detector (AdamWInversionDetector._reconstruct_pre_step_mcore) relies on.
+    """
+    from dte.core import invert_adamw
+
+    torch.manual_seed(0)
+    theta_prev = torch.randn(512, dtype=torch.float32)
+    p = theta_prev.clone().requires_grad_(True)
+    lr, wd, b1, b2, eps = 1e-3, 0.01, 0.9, 0.999, 1e-8
+    opt = torch.optim.AdamW([p], lr=lr, betas=(b1, b2), eps=eps, weight_decay=wd)
+    p.grad = torch.randn_like(p)
+    opt.step()  # theta_prev -> theta_t, leaving exp_avg / exp_avg_sq resident
+    theta_t = p.detach().clone()
+    st = opt.state[p]
+    recovered = invert_adamw(
+        theta_t, st["exp_avg"], st["exp_avg_sq"], float(st["step"]), lr, wd, b1, b2, eps
+    )
+    torch.testing.assert_close(recovered, theta_prev, rtol=1e-3, atol=1e-4)
+
+
+def _load_delta_detect(monkeypatch):
+    """Load delta_detect.py without the full areal runtime.
+
+    It does ``from areal.utils import logging`` at module top, which would pull
+    in areal/__init__ (httpx/awex, absent in lean sandboxes). Stub that one
+    symbol so the detector logic is importable for CPU tests.
+    """
+    import importlib.util
+    import logging as _stdlog
+    import sys
+    import types
+
+    fake = types.ModuleType("areal.utils.logging")
+    fake.getLogger = _stdlog.getLogger
+    monkeypatch.setitem(sys.modules, "areal", types.ModuleType("areal"))
+    monkeypatch.setitem(sys.modules, "areal.utils", types.ModuleType("areal.utils"))
+    monkeypatch.setitem(sys.modules, "areal.utils.logging", fake)
+    # delta_detect imports cuda_mem_stats_mb from delta_config; inject the real
+    # module (file-loaded, dependency-free) along the stubbed package chain.
+    for pkg in ("areal.v2", "areal.v2.weight_update", "areal.v2.weight_update.awex"):
+        monkeypatch.setitem(sys.modules, pkg, types.ModuleType(pkg))
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.awex.delta_config",
+        _load_delta_config(),
+    )
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "areal/v2/weight_update/awex/delta_detect.py"
+    )
+    spec = importlib.util.spec_from_file_location("awex_delta_detect", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bind_inversion_param_names(inv, *named_params):
+    """Bind fake mcore parameter names for CPU-only inversion tests."""
+    id2key = {id(param): name for name, param in named_params}
+    inv._module_param_key_maps = lambda: (id2key, {})
+
+
+def _stub_colocate_device(monkeypatch):
+    import sys
+    import types
+
+    colocate_device_mod = types.ModuleType(
+        "areal.v2.weight_update.awex.colocate_device"
+    )
+    colocate_device_mod.device_mapping_key = lambda ip, device: f"{ip}_{device}"
+    colocate_device_mod.get_colocate_ip_address = lambda: "127.0.0.1"
+    colocate_device_mod.get_physical_cuda_device_id = lambda local_index=None: str(
+        local_index or 0
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.awex.colocate_device",
+        colocate_device_mod,
+    )
+
+
+def _load_sglang_adapter(monkeypatch):
+    """Load sglang_adapter.py with only the AReaL symbols it imports stubbed."""
+    import importlib.util
+    import logging as _stdlog
+    import sys
+    import types
+
+    pytest.importorskip("awex.meta.weight_meta")
+    pytest.importorskip("awex.sharding.sglang_sharding")
+
+    monkeypatch.setitem(sys.modules, "areal", types.ModuleType("areal"))
+    monkeypatch.setitem(sys.modules, "areal.v2", types.ModuleType("areal.v2"))
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update",
+        types.ModuleType("areal.v2.weight_update"),
+    )
+
+    awex_mod = types.ModuleType("areal.v2.weight_update.awex")
+    awex_mod.awex_wu_use_group = lambda: False
+    awex_mod.fetch_kv_metadata = lambda *args, **kwargs: None
+    awex_mod.load_kv_metadata_file = lambda *args, **kwargs: None
+    awex_mod.__path__ = []
+    monkeypatch.setitem(sys.modules, "areal.v2.weight_update.awex", awex_mod)
+    _stub_colocate_device(monkeypatch)
+
+    delta_config_mod = types.ModuleType("areal.v2.weight_update.awex.delta_config")
+    delta_config_mod.delta_transfer_enabled = lambda: False
+    delta_config_mod.make_delta_engine = lambda *args, **kwargs: None
+    delta_config_mod.payload_carries_delta = lambda names: False
+    delta_config_mod.cuda_mem_stats_mb = lambda reset_peak=True: (-1.0, -1.0)
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.awex.delta_config",
+        delta_config_mod,
+    )
+
+    inference_adapter_mod = types.ModuleType("areal.v2.weight_update.inference_adapter")
+
+    class _AwexInferenceAdapter:
+        pass
+
+    inference_adapter_mod.AwexInferenceAdapter = _AwexInferenceAdapter
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.inference_adapter",
+        inference_adapter_mod,
+    )
+
+    nccl_group_mod = types.ModuleType("areal.v2.weight_update.nccl_group")
+    nccl_group_mod.init_weights_update_group = lambda *args, **kwargs: None
+    nccl_group_mod.setup_batch_isend_irecv = lambda *args, **kwargs: None
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.nccl_group",
+        nccl_group_mod,
+    )
+
+    logging_mod = types.ModuleType("areal.utils.logging")
+    logging_mod.getLogger = _stdlog.getLogger
+    utils_mod = types.ModuleType("areal.utils")
+    utils_mod.logging = logging_mod
+    monkeypatch.setitem(sys.modules, "areal.utils", utils_mod)
+    monkeypatch.setitem(sys.modules, "areal.utils.logging", logging_mod)
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "areal/v2/weight_update/awex/sglang_adapter.py"
+    )
+    spec = importlib.util.spec_from_file_location("awex_sglang_adapter_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_megatron_adapter(monkeypatch):
+    """Load megatron_adapter.py with runtime-heavy AReaL imports stubbed."""
+    import importlib.util
+    import logging as _stdlog
+    import sys
+    import types
+
+    pytest.importorskip("awex.meta.weight_meta")
+    pytest.importorskip("awex.sharding.param_sharding")
+    pytest.importorskip("awex.transfer.transfer_plan")
+    pytest.importorskip("awex.util.tensor_util")
+
+    monkeypatch.setitem(sys.modules, "areal", types.ModuleType("areal"))
+    monkeypatch.setitem(sys.modules, "areal.v2", types.ModuleType("areal.v2"))
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update",
+        types.ModuleType("areal.v2.weight_update"),
+    )
+
+    awex_mod = types.ModuleType("areal.v2.weight_update.awex")
+    awex_mod.awex_wu_use_group = lambda: False
+    awex_mod.fetch_kv_metadata = lambda *args, **kwargs: None
+    awex_mod.__path__ = []
+    monkeypatch.setitem(sys.modules, "areal.v2.weight_update.awex", awex_mod)
+    _stub_colocate_device(monkeypatch)
+
+    delta_config_mod = types.ModuleType("areal.v2.weight_update.awex.delta_config")
+    delta_config_mod.delta_transfer_enabled = lambda: True
+    delta_config_mod.make_delta_tracker = lambda *args, **kwargs: None
+    delta_config_mod.cuda_mem_stats_mb = lambda reset_peak=True: (-1.0, -1.0)
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.awex.delta_config",
+        delta_config_mod,
+    )
+
+    delta_detect_mod = types.ModuleType("areal.v2.weight_update.awex.delta_detect")
+    delta_detect_mod.build_detector = lambda *args, **kwargs: None
+    delta_detect_mod.delta_detector_mode = lambda: "inversion"
+    delta_detect_mod.external_delta_detector_enabled = lambda mode=None: (
+        mode or delta_detect_mod.delta_detector_mode()
+    ) in {"inversion", "dirty_bit", "dirty-bit", "bitset", "fused_dirty_bit"}
+    delta_detect_mod.dirty_bit_detector_enabled = lambda mode=None: (
+        mode or delta_detect_mod.delta_detector_mode()
+    ) in {"dirty_bit", "dirty-bit", "bitset", "fused_dirty_bit"}
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.awex.delta_detect",
+        delta_detect_mod,
+    )
+
+    logging_mod = types.ModuleType("areal.utils.logging")
+    logging_mod.getLogger = _stdlog.getLogger
+    utils_mod = types.ModuleType("areal.utils")
+    utils_mod.logging = logging_mod
+    monkeypatch.setitem(sys.modules, "areal.utils", utils_mod)
+    monkeypatch.setitem(sys.modules, "areal.utils.logging", logging_mod)
+
+    for module_name in ("delta_index_remap", "step_dirty_dryrun"):
+        module_path = (
+            Path(__file__).resolve().parent.parent
+            / "areal"
+            / "v2"
+            / "weight_update"
+            / "awex"
+            / f"{module_name}.py"
+        )
+        module_spec = importlib.util.spec_from_file_location(
+            f"areal.v2.weight_update.awex.{module_name}",
+            module_path,
+        )
+        module = importlib.util.module_from_spec(module_spec)
+        assert module_spec is not None
+        assert module_spec.loader is not None
+        module_spec.loader.exec_module(module)
+        monkeypatch.setitem(
+            sys.modules,
+            f"areal.v2.weight_update.awex.{module_name}",
+            module,
+        )
+
+    nccl_group_mod = types.ModuleType("areal.v2.weight_update.nccl_group")
+    nccl_group_mod.init_weights_update_group = lambda *args, **kwargs: None
+    nccl_group_mod.setup_batch_isend_irecv = lambda *args, **kwargs: None
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.nccl_group",
+        nccl_group_mod,
+    )
+
+    training_adapter_mod = types.ModuleType("areal.v2.weight_update.training_adapter")
+
+    class _AwexTrainingAdapter:
+        pass
+
+    training_adapter_mod.AwexTrainingAdapter = _AwexTrainingAdapter
+    monkeypatch.setitem(
+        sys.modules,
+        "areal.v2.weight_update.training_adapter",
+        training_adapter_mod,
+    )
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "areal/v2/weight_update/awex/megatron_adapter.py"
+    )
+    spec = importlib.util.spec_from_file_location("awex_megatron_adapter_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_sglang_bailing_names_match_train_converter(monkeypatch):
+    """Bailing colocate must use the same keys as AWEX's mcore converter."""
+    mod = _load_sglang_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexSGLangAdapter)
+    tensor = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+
+    embed = adapter._unfuse_params("model.word_embeddings.weight", tensor)
+    assert len(embed) == 1
+    assert embed[0][0] == "model.embed_tokens.weight"
+    assert embed[0][1].data_ptr() == tensor.data_ptr()
+
+    fused_name = "model.layers.7.attention.fused_qkv_a_proj_with_mqa.weight"
+    fused = adapter._unfuse_params(fused_name, tensor)
+    assert len(fused) == 1
+    assert fused[0][0] == fused_name
+    assert fused[0][1].data_ptr() == tensor.data_ptr()
+
+
+def test_sglang_decoded_delta_empty_detection(monkeypatch):
+    """Empty live-apply deltas can skip receiver weight resume/apply."""
+    mod = _load_sglang_adapter(monkeypatch)
+
+    decoded = type(
+        "_Decoded",
+        (),
+        {
+            "sparse": {"w": (torch.empty(0, dtype=torch.int32), torch.empty(0))},
+            "dense": {},
+        },
+    )()
+    assert mod.AwexSGLangAdapter._decoded_delta_is_empty(decoded)
+
+    decoded.sparse = {"w": (torch.tensor([1], dtype=torch.int32), torch.ones(1))}
+    assert not mod.AwexSGLangAdapter._decoded_delta_is_empty(decoded)
+
+    decoded.sparse = {}
+    decoded.dense = {"w": torch.ones(1)}
+    assert not mod.AwexSGLangAdapter._decoded_delta_is_empty(decoded)
+
+
+def test_sglang_colocate_device_id_uses_scheduler_physical_gpu(monkeypatch):
+    mod = _load_sglang_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexSGLangAdapter)
+    adapter._scheduler = type("_Scheduler", (), {"gpu_id": 4})()
+
+    assert adapter._get_colocate_device_id() == "4"
+
+
+def test_initial_full_sync_uses_dense_payload_with_awex_converter(monkeypatch):
+    """Initial inversion frame is dense; execution chooses the IPC grouping."""
+    mod = _load_megatron_adapter(monkeypatch)
+
+    class _Tracker:
+        def __init__(self):
+            self.seed_args = None
+
+        def full_sync_reason(self, version):
+            assert version == 1
+            return "initial_full"
+
+        def seed(self, params_list, version, store_snapshot=False):
+            self.seed_args = (params_list, version, store_snapshot)
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._delta_tracker = _Tracker()
+    adapter._delta_detector = type("_Detector", (), {"name": "inversion"})()
+    adapter._awex_weight_converter = object()
+
+    params = {"w": torch.arange(4)}
+    names, tensors, zero_copy_full_payload = adapter._delta_encode(params, version=1)
+
+    assert names == ["w"]
+    assert tensors == [params["w"]]
+    assert zero_copy_full_payload is True
+    assert adapter._delta_tracker.seed_args == (list(params.items()), 1, False)
+
+
+def test_dirty_bit_detector_initial_frame_uses_full_sync(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+
+    class _Tracker:
+        def __init__(self):
+            self.seed_args = None
+
+        def full_sync_reason(self, version):
+            assert version == 1
+            return None
+
+        def seed(self, params_list, version, store_snapshot=False):
+            self.seed_args = (params_list, version, store_snapshot)
+
+    class _DirtyDetector:
+        name = "dirty_bit"
+
+        def has_synced_watermark(self):
+            return False
+
+        def compute_masks(self, names, tensors, version):
+            raise AssertionError("initial dirty-bit frame should full sync")
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._delta_tracker = _Tracker()
+    adapter._delta_detector = _DirtyDetector()
+    adapter._awex_weight_converter = object()
+
+    params = {"w": torch.arange(4)}
+    names, tensors, zero_copy_full_payload = adapter._delta_encode(params, version=1)
+
+    assert names == ["w"]
+    assert tensors == [params["w"]]
+    assert zero_copy_full_payload is True
+    assert adapter._delta_tracker.seed_args == (list(params.items()), 1, False)
+
+
+def test_delta_encode_consumes_dirty_bit_external_indices(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+
+    class _Tracker:
+        def __init__(self):
+            self.encode_args = None
+
+        def full_sync_reason(self, version):
+            assert version == 2
+            return None
+
+        def encode(self, params_list, version, masks=None):
+            self.encode_args = (params_list, version, masks)
+            return type(
+                "_Encoded",
+                (),
+                {
+                    "names": ["w@delta_idx", "w@delta_val"],
+                    "tensors": [
+                        masks["w"],
+                        params_list[0][1].reshape(-1)[masks["w"].long()],
+                    ],
+                    "changed_elements": int(masks["w"].numel()),
+                    "total_elements": int(params_list[0][1].numel()),
+                    "num_sparse": 1,
+                    "num_dense_fallback": 0,
+                    "num_unchanged": 0,
+                    "payload_bytes": int(masks["w"].numel() * 8),
+                    "dense_bytes": int(params_list[0][1].numel() * 4),
+                },
+            )()
+
+    class _DirtyDetector:
+        name = "dirty_bit"
+
+        def has_synced_watermark(self):
+            return True
+
+        def compute_masks(self, names, tensors, version):
+            assert names == ["w"]
+            assert version == 2
+            return {"w": torch.tensor([1, 3], dtype=torch.int32)}
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._delta_tracker = _Tracker()
+    adapter._delta_detector = _DirtyDetector()
+    adapter._awex_weight_converter = object()
+
+    param = torch.arange(4, dtype=torch.float32)
+    names, tensors, zero_copy_full_payload = adapter._delta_encode({"w": param}, 2)
+
+    assert names == ["w@delta_idx", "w@delta_val"]
+    assert torch.equal(tensors[0], torch.tensor([1, 3], dtype=torch.int32))
+    assert torch.equal(tensors[1], torch.tensor([1.0, 3.0]))
+    assert zero_copy_full_payload is False
+    _params, _version, masks = adapter._delta_tracker.encode_args
+    assert torch.equal(masks["w"], torch.tensor([1, 3], dtype=torch.int32))
+
+
+def test_bounded_full_ipc_payload_uses_independent_storage(monkeypatch):
+    """Bounded full payload must use compact exporter-owned storage."""
+    mod = _load_megatron_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+
+    live = torch.arange(4, dtype=torch.float32)
+    owned = torch.arange(4, dtype=torch.float32) + 10
+    adapter._live_module_storage_ptrs = lambda: {live.untyped_storage().data_ptr()}
+    monkeypatch.setenv("DTE_COLOCATE_FULL_GROUP_MAX_BYTES", str(32))
+
+    groups, metadata = adapter._full_tensors_for_ipc([live, owned])
+
+    assert len(groups) == 1
+    assert groups[0].data_ptr() not in {live.data_ptr(), owned.data_ptr()}
+    assert metadata[0]["group_index"] == 0
+    assert metadata[1]["group_index"] == 0
+    rebuilt = []
+    for meta in metadata:
+        start = meta["offset"]
+        end = start + meta["size"]
+        rebuilt.append(
+            groups[meta["group_index"]].view(-1)[start:end].view(meta["shape"])
+        )
+    assert torch.equal(rebuilt[0], live)
+    assert torch.equal(rebuilt[1], owned)
+
+
+def test_bounded_full_ipc_payload_respects_group_cap(monkeypatch):
+    """Same-shape tensors are packed only up to the configured byte cap."""
+    mod = _load_megatron_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._live_module_storage_ptrs = lambda: set()
+    monkeypatch.setenv("DTE_COLOCATE_FULL_GROUP_MAX_BYTES", str(32))
+
+    tensors = [torch.full((4,), i, dtype=torch.float32) for i in range(3)]
+    groups, metadata = adapter._full_tensors_for_ipc(tensors)
+
+    assert [g.numel() for g in groups] == [8, 4]
+    assert [m["group_index"] for m in metadata] == [0, 0, 1]
+
+
+def test_bounded_full_ipc_payload_handles_empty_tensors(monkeypatch):
+    """CUDA IPC cannot export a zero-sized storage; use a dummy group."""
+    mod = _load_megatron_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+
+    empty = torch.empty(0, 3)
+    adapter._live_module_storage_ptrs = lambda: set()
+
+    groups, metadata = adapter._full_tensors_for_ipc([empty])
+
+    assert groups[0].numel() == 1
+    assert metadata[0]["shape"] == empty.shape
+    assert metadata[0]["size"] == 0
+
+
+def test_inversion_detector_dispatch_and_gating(monkeypatch):
+    """Detector dispatch + inversion gating (CPU).
+
+    The mcore reconstruction / DP all-reduce / convert are GPU-only and can't be
+    unit-tested here; this covers the dispatch and the gating fallbacks that
+    decide snapshot-vs-inversion and inversion-vs-dense.
+    """
+    dd = _load_delta_detect(monkeypatch)
+
+    # snapshot detector is a no-op marker -> None (dte snapshot path downstream)
+    snap = dd.build_detector("snapshot", None)
+    assert snap.name == "snapshot"
+    assert snap.compute_masks(["a"], [torch.zeros(4)], 1) is None
+    # unknown / empty mode also falls back to snapshot
+    assert dd.build_detector("", None).name == "snapshot"
+
+    # inversion detector builds, but with no optimizers the hard gate fails and
+    # compute_masks returns None -> writer ships a dense full sync that step.
+    class _NoOptAdapter:
+        def _get_inner_optimizers(self):
+            return []
+
+    inv = dd.build_detector("inversion", _NoOptAdapter())
+    assert inv.name == "inversion"
+    assert inv.compute_masks(["a"], [torch.zeros(4)], 1) is None
+
+
+def test_dirty_bit_detector_dispatch_and_watermark(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    class _Adapter:
+        def __init__(self):
+            self.cleared = []
+
+        def _dirty_bitset_masks_from_optimizer(self, names, tensors, version):
+            assert names == ["w"]
+            assert version == 2
+            return {"w": torch.tensor([1], dtype=torch.int32)}
+
+        def _clear_optimizer_dirty_bitsets(self, version):
+            self.cleared.append(version)
+
+    adapter = _Adapter()
+    detector = dd.build_detector("dirty_bit", adapter)
+
+    assert detector.name == "dirty_bit"
+    assert detector.has_synced_watermark() is False
+    detector.mark_synced(version=1)
+    assert detector.has_synced_watermark() is True
+    assert adapter.cleared == [1]
+
+    masks = detector.compute_masks(["w"], [torch.arange(3)], version=2)
+    assert torch.equal(masks["w"], torch.tensor([1], dtype=torch.int32))
+
+
+def test_dirty_bit_after_skipped_optimizer_step_records_empty_masks(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+    monkeypatch.delenv("DTE_STEP_DIRTY_DRY_RUN", raising=False)
+    mod.delta_transfer_enabled = lambda: True
+    mod.dirty_bit_detector_enabled = lambda mode=None: True
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+
+    stats = adapter.after_optimizer_step(update_successful=False, grad_norm=None)
+    masks = adapter._dirty_bitset_masks_from_optimizer(
+        ["w"],
+        [torch.arange(4)],
+        version=2,
+    )
+
+    assert stats["perf/dirty_bit_complete"] == 1.0
+    assert stats["perf/dirty_bit_records"] == 0.0
+    assert torch.equal(masks["w"], torch.empty(0, dtype=torch.int32))
+
+
+def test_dirty_bit_provider_records_optimizer_bitsets(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+    monkeypatch.delenv("DTE_STEP_DIRTY_DRY_RUN", raising=False)
+    monkeypatch.setenv("DTE_DIRTY_BIT_PROVIDER", "optimizer")
+    mod.delta_transfer_enabled = lambda: True
+    mod.dirty_bit_detector_enabled = lambda mode=None: True
+
+    record = {
+        "name": "module.module.decoder.layers.0.self_attention.linear_proj.weight",
+        "packed_bitset": torch.tensor([0b0000_1010], dtype=torch.uint8),
+        "shape": (2, 4),
+        "shard_start": 0,
+        "shard_numel": 8,
+    }
+
+    class _Provider:
+        def areal_consume_dirty_bitsets(self):
+            return {"records": [record], "complete": True}
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._get_inner_optimizers = lambda: [_Provider()]
+    adapter._engine = type(
+        "_Engine",
+        (),
+        {
+            "tf_config": type(
+                "_Config",
+                (),
+                {
+                    "hidden_size": 4,
+                    "num_attention_heads": 2,
+                    "num_query_groups": 1,
+                    "kv_channels": 2,
+                },
+            )()
+        },
+    )()
+
+    stats = adapter.after_optimizer_step(update_successful=True, grad_norm=1.0)
+    masks = adapter._dirty_bitset_masks_from_optimizer(
+        ["model.layers.0.self_attn.o_proj.weight"],
+        [torch.arange(8)],
+        version=2,
+    )
+
+    assert stats["perf/dirty_bit_complete"] == 1.0
+    assert stats["perf/dirty_bit_records"] == 1.0
+    assert torch.equal(
+        masks["model.layers.0.self_attn.o_proj.weight"],
+        torch.tensor([1, 3], dtype=torch.int32),
+    )
+
+
+def test_dirty_bit_provider_dp_gather_fills_non_expert_masks(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+
+    local_record = mod.MCoreShardDirtyBitset(
+        name="module.module.decoder.layers.0.self_attention.linear_proj.weight",
+        packed_bitset=torch.tensor([0b0000_0010], dtype=torch.uint8),
+        shape=(4, 4),
+        shard_start=0,
+        shard_numel=8,
+    )
+    remote_record = mod.MCoreShardDirtyBitset(
+        name="module.module.decoder.layers.0.self_attention.linear_proj.weight",
+        packed_bitset=torch.tensor([0b0000_0100], dtype=torch.uint8),
+        shape=(4, 4),
+        shard_start=8,
+        shard_numel=8,
+    )
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._optimizer_dirty_bitsets = [local_record]
+    adapter._optimizer_dirty_bitsets_complete = True
+    adapter._optimizer_dirty_bitsets_version = None
+    adapter._build_rank_info = lambda: SimpleNamespace(
+        dp_size=2,
+        ep_size=1,
+        ep_rank=0,
+    )
+    adapter._engine = type(
+        "_Engine",
+        (),
+        {
+            "tf_config": type(
+                "_Config",
+                (),
+                {
+                    "hidden_size": 4,
+                    "num_attention_heads": 2,
+                    "num_query_groups": 1,
+                    "kv_channels": 2,
+                },
+            )(),
+            "hf_config": type("_HFConfig", (), {})(),
+        },
+    )()
+    adapter._gather_non_expert_dirty_bitsets_across_dp = lambda records: list(
+        records
+    ) + [remote_record]
+
+    masks = adapter._dirty_bitset_masks_from_optimizer(
+        ["model.layers.0.self_attn.o_proj.weight"],
+        [torch.arange(16)],
+        version=2,
+    )
+
+    assert torch.equal(
+        masks["model.layers.0.self_attn.o_proj.weight"],
+        torch.tensor([1, 10], dtype=torch.int32),
+    )
+
+
+def test_dirty_bit_provider_marks_missing_inner_optimizer_incomplete(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+    monkeypatch.delenv("DTE_STEP_DIRTY_DRY_RUN", raising=False)
+    monkeypatch.setenv("DTE_DIRTY_BIT_PROVIDER", "optimizer")
+    mod.delta_transfer_enabled = lambda: True
+    mod.dirty_bit_detector_enabled = lambda mode=None: True
+
+    class _Provider:
+        def areal_consume_dirty_bitsets(self):
+            return {"records": [], "complete": True}
+
+    class _NoProvider:
+        pass
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._get_inner_optimizers = lambda: [_Provider(), _NoProvider()]
+
+    stats = adapter.after_optimizer_step(update_successful=True, grad_norm=1.0)
+
+    assert stats["perf/dirty_bit_complete"] == 0.0
+    assert (
+        adapter._dirty_bitset_masks_from_optimizer(
+            ["w"],
+            [torch.arange(4)],
+            version=2,
+        )
+        is None
+    )
+
+
+def test_dirty_bit_sparse_indices_verify_against_snapshot(monkeypatch):
+    mod = _load_megatron_adapter(monkeypatch)
+
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter._delta_tracker = type(
+        "_Tracker",
+        (),
+        {
+            "_snapshot": {"w": torch.tensor([1, 2, 3, 4], dtype=torch.int32)},
+            "_snapshot_names": {"w"},
+        },
+    )()
+    adapter._delta_detector = type("_Detector", (), {"name": "dirty_bit"})()
+
+    cur = torch.tensor([1, 2, 30, 4], dtype=torch.int32)
+
+    assert adapter._delta_verify_masks_against_snapshot(
+        [("w", cur)],
+        {"w": torch.tensor([2], dtype=torch.int32)},
+        version=2,
+    )
+    assert not adapter._delta_verify_masks_against_snapshot(
+        [("w", cur)],
+        {"w": torch.empty(0, dtype=torch.int32)},
+        version=2,
+    )
+    assert adapter._delta_verify_masks_against_snapshot(
+        [("w", cur)],
+        {},
+        version=2,
+    )
+
+
+def test_bf16_boundary_mask_uses_asymmetric_neighbors(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    cur = torch.tensor([1.0], dtype=torch.bfloat16)
+    lower = torch.nextafter(cur, torch.full_like(cur, float("-inf"))).to(torch.float32)
+    lower_half_ulp = (cur.to(torch.float32) - lower) * 0.5
+    old_inside_current_bin = cur.to(torch.float32) - lower_half_ulp * 0.99995
+
+    assert old_inside_current_bin.to(torch.bfloat16).item() == cur.item()
+    assert dd._bf16_rounding_boundary_mask(old_inside_current_bin, cur).item()
+
+
+def test_inversion_defaults_router_gate_params_to_dense(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    assert dd._inversion_force_dense_param("model.layers.9.mlp.gate.weight")
+    assert not dd._inversion_force_dense_param("model.layers.9.mlp.gate_proj.weight")
+
+    monkeypatch.setenv("DTE_DELTA_INVERSION_DENSE_PARAM_SUFFIXES", "")
+    assert not dd._inversion_force_dense_param("model.layers.9.mlp.gate.weight")
+
+
+def test_inversion_compute_device_follows_payload_unless_forced_cpu(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    # Meta device stands in for a non-CPU payload without requiring CUDA.
+    flat_meta = torch.empty(4, device="meta")
+    assert dd._inversion_compute_device(flat_meta).type == "meta"
+    flat_cpu = torch.zeros(4)
+    assert dd._inversion_compute_device(flat_cpu) == flat_cpu.device
+
+    monkeypatch.setenv("DTE_INVERSION_COMPUTE_ON_CPU", "1")
+    assert dd._inversion_compute_device(flat_meta) == torch.device("cpu")
+
+
+def test_inversion_gates_non_decoupled_fused_adam(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    class _BaseOpt:
+        adam_w_mode = 0
+
+    class _Opt:
+        optimizer = _BaseOpt()
+
+    inv = dd.build_detector("inversion", object())
+    assert inv._inversion_feasible([_Opt()]) is False
+
+
+def test_inversion_detector_computes_masks_from_adamw_state(monkeypatch):
+    """Exercise the inversion detector's real reconstruct -> mask path.
+
+    This uses a tiny fake adapter/optimizer that exposes the Megatron distributed
+    optimizer fields the detector consumes, but avoids launching mcore or
+    torch.distributed. The reconstructed pre-step tensor is converted through
+    the adapter override path and compared against the live tensor, which is the
+    core inversion logic used by the AWEX colocate sender.
+    """
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(1)
+    theta_prev = torch.randn(64, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    lr, wd, b1, b2, eps = 3e-3, 0.02, 0.9, 0.999, 1e-8
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=lr,
+        betas=(b1, b2),
+        eps=eps,
+        weight_decay=wd,
+    )
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+    offloaded_state = {
+        k: v.detach().clone() if isinstance(v, torch.Tensor) else v
+        for k, v in base_opt.state[param].items()
+    }
+    group_step = offloaded_state.pop("step")
+    base_opt.param_groups[0]["step"] = group_step
+    base_opt.state[param]["exp_avg"] = torch.empty(0)
+    base_opt.state[param]["exp_avg_sq"] = torch.empty(0)
+    if isinstance(base_opt.state[param].get("step"), torch.Tensor):
+        base_opt.state[param]["step"] = torch.empty(0)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {param: offloaded_state}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    # Simulate that version 1 synced the pre-step weights. AdamW inversion is
+    # only valid for the next optimizer step relative to that synced watermark.
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert masks is not None
+    assert set(masks) == {"w"}
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_t, theta_prev)),
+    )
+    assert masks["w"].numel() > 0
+
+    # After version 2 is synced, reusing the same AdamW moments without another
+    # optimizer step must not replay the old update and report false positives.
+    inv.mark_synced(version=2)
+    same_step_masks = inv.compute_masks(["w"], [theta_t], version=3)
+    assert same_step_masks is not None
+    assert same_step_masks["w"].numel() == 0
+
+    # If the optimizer step counter advances but the synced-payload fingerprint
+    # is missing, old moments must not be replayed as a fake weight delta.
+    # The detector cannot prove whether weights changed, so it asks the sender
+    # to do a dense fallback for this step.
+    base_opt.param_groups[0]["step"] = group_step + 1
+    inv._last_synced_fingerprints.clear()
+    missing_fingerprint_masks = inv.compute_masks(["w"], [theta_t], version=4)
+    assert missing_fingerprint_masks is None
+
+
+def test_precompute_masks_cached_and_consumed_without_recompute(monkeypatch):
+    """precompute_masks caches; the next compute_masks returns the cached obj."""
+    dd = _load_delta_detect(monkeypatch)
+
+    torch.manual_seed(3)
+    theta_prev = torch.randn(64, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    base_opt = torch.optim.AdamW(
+        [param], lr=3e-3, betas=(0.9, 0.999), eps=1e-8, weight_decay=0.02
+    )
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+    group_step = base_opt.state[param].pop("step")
+    base_opt.param_groups[0]["step"] = group_step
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    _bind_inversion_param_names(inv, ("w", param))
+    inv._last_synced_steps["w"] = 0.0
+    inv._last_synced_fingerprints["w"] = dd._tensor_fingerprint(theta_prev)
+
+    payload = theta_t.to(torch.bfloat16)
+    assert inv.precompute_masks(["w"], [payload], version=2) is True
+    cached = inv._precomputed_masks
+    assert cached is not None and cached[0] == 2 and cached[1] == ("w",)
+    cached_masks = cached[2]
+    assert cached_masks is not None
+
+    # The consuming call must return the exact cached object (no recompute)
+    # and clear the single-slot cache.
+    masks = inv.compute_masks(["w"], [payload], version=2)
+    assert masks is cached_masks
+    assert inv._precomputed_masks is None
+
+
+def test_precomputed_masks_stale_version_or_names_discarded(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+    inv = dd.build_detector("inversion", object())
+    sentinel = {"w": torch.tensor([0], dtype=torch.int32)}
+
+    inv._precomputed_masks = (2, ("w",), sentinel)
+    hit, masks = inv._pop_precomputed_masks(["w"], 3)
+    assert (hit, masks) == (False, None)
+    assert inv._precomputed_masks is None
+
+    inv._precomputed_masks = (2, ("w",), sentinel)
+    hit, masks = inv._pop_precomputed_masks(["other"], 2)
+    assert (hit, masks) == (False, None)
+    assert inv._precomputed_masks is None
+
+    inv._precomputed_masks = (2, ("w",), sentinel)
+    hit, masks = inv._pop_precomputed_masks(["w"], 2)
+    assert hit is True and masks is sentinel
+    assert inv._precomputed_masks is None
+
+
+def test_mark_synced_drops_unconsumed_precomputed_masks(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+    inv = dd.build_detector("inversion", object())
+    inv._precomputed_masks = (2, ("w",), {"w": torch.tensor([0])})
+    inv.mark_synced(version=2, captured_state=({}, {}, {}, {}))
+    assert inv._precomputed_masks is None
+
+
+def test_inversion_detector_streams_old_hf_conversion(monkeypatch):
+    """AdamW inversion should not require materializing the full old-HF dict."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    theta_prev = torch.linspace(-1.0, 1.0, 32, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    base_opt = torch.optim.AdamW([param], lr=1e-3, weight_decay=0.01)
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def __init__(self):
+            self.stream_calls = 0
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _iter_hf_with_overrides(self, theta_by_id):
+            self.stream_calls += 1
+            yield "w", theta_by_id.get(id(param), param.detach())
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            del theta_by_id
+            raise AssertionError("streaming path should avoid full old-HF dict")
+
+    adapter = _FakeAdapter()
+    inv = dd.build_detector("inversion", adapter)
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert adapter.stream_calls == 1
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_t, theta_prev)),
+    )
+
+
+def test_inversion_stream_survives_adapter_consuming_theta_old(monkeypatch):
+    """Adapters pop theta_old entries during streaming; masks must not change.
+
+    The real megatron adapter's ``_iter_hf_with_overrides`` consumes
+    ``theta_by_id`` (pops each entry after conversion) so reconstructed fp32
+    tensors free incrementally. The detector must tolerate the dict draining
+    under it and still log/compute based on the pre-drain count.
+    """
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    theta_prev = torch.linspace(-2.0, 2.0, 48, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    base_opt = torch.optim.AdamW([param], lr=1e-3, weight_decay=0.01)
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _iter_hf_with_overrides(self, theta_by_id):
+            # Mirror the real adapter: pop the override once converted.
+            theta = theta_by_id.pop(id(param), param.detach())
+            yield "w", theta
+
+    adapter = _FakeAdapter()
+    inv = dd.build_detector("inversion", adapter)
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_t, theta_prev)),
+    )
+
+
+def test_inversion_detector_uses_lr_from_completed_optimizer_step(monkeypatch):
+    """LR scheduler may update param_group['lr'] before weight sync runs."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(21)
+    theta_prev = torch.randn(64, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    step_lr = 3e-3
+    next_lr = 9e-3
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=step_lr,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0.02,
+    )
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+    base_opt.param_groups[0]["_areal_last_step_lr"] = step_lr
+    base_opt.param_groups[0]["lr"] = next_lr
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_t, theta_prev)),
+    )
+
+
+def test_inversion_detector_falls_back_when_non_adamw_payload_changes(monkeypatch):
+    """Payload tensors not owned by AdamW cannot be inverted safely."""
+    dd = _load_delta_detect(monkeypatch)
+
+    torch.manual_seed(22)
+    theta_prev = torch.randn(32, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    aux = torch.nn.Parameter(torch.randn(8, dtype=torch.float32), requires_grad=False)
+    aux_synced = aux.detach().clone()
+
+    base_opt = torch.optim.AdamW([param], lr=1e-3)
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    aux.data[0] += 1.0
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _iter_model_params_for_delta(self):
+            return [param, aux]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {
+                "w": theta_by_id.get(id(param), param.detach()),
+                "expert_bias": theta_by_id.get(id(aux), aux.detach()),
+            }
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+    inv._last_synced_payload_fingerprints["expert_bias"] = dd._tensor_fingerprint(
+        aux_synced
+    )
+
+    masks = inv.compute_masks(
+        ["w", "expert_bias"], [param.detach(), aux.detach()], version=2
+    )
+    assert masks is None
+
+
+def test_inversion_detector_allows_unchanged_non_adamw_payload(monkeypatch):
+    """Unchanged non-AdamW payload tensors must not force a dense fallback."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(23)
+    theta_prev = torch.randn(32, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    aux = torch.nn.Parameter(torch.randn(8, dtype=torch.float32), requires_grad=False)
+    aux_synced = aux.detach().clone()
+
+    base_opt = torch.optim.AdamW([param], lr=1e-3)
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _iter_model_params_for_delta(self):
+            return [param, aux]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {
+                "w": theta_by_id.get(id(param), param.detach()),
+                "expert_bias": theta_by_id.get(id(aux), aux.detach()),
+            }
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+    inv._last_synced_payload_fingerprints["expert_bias"] = dd._tensor_fingerprint(
+        aux_synced
+    )
+
+    masks = inv.compute_masks(["w", "expert_bias"], [theta_t, aux.detach()], version=2)
+
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_t, theta_prev)),
+    )
+    assert masks["w"].numel() > 0
+    assert masks["expert_bias"].numel() == 0
+
+
+def test_inversion_detector_densifies_changed_non_adamw_payload(monkeypatch):
+    """Changed non-AdamW payload with no reconstructed old tensor must go dense."""
+    dd = _load_delta_detect(monkeypatch)
+
+    torch.manual_seed(29)
+    theta_prev = torch.randn(32, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    aux_prev = torch.randn(8, dtype=torch.float32)
+    aux = torch.nn.Parameter(aux_prev.clone() + 1.0, requires_grad=False)
+
+    base_opt = torch.optim.AdamW([param], lr=1e-3)
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _iter_model_params_for_delta(self):
+            return [param, aux]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {
+                "w": theta_by_id.get(id(param), param.detach()),
+                "expert_bias": theta_by_id.get(id(aux), aux.detach()),
+            }
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+    inv._last_synced_payload_fingerprints["expert_bias"] = dd._tensor_fingerprint(
+        aux_prev
+    )
+
+    assert inv.compute_masks(["w", "expert_bias"], [theta_t, aux.detach()], 2) is None
+
+
+def test_inversion_detector_does_not_gate_one_step_on_fingerprint(monkeypatch):
+    """A fingerprint collision must not hide a valid one-step AdamW update."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(11)
+    theta_prev = torch.randn(128, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=2e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0.01,
+    )
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+
+    # Force the synced/current fingerprints to collide. A correct detector still
+    # reconstructs a one-step AdamW update from moments instead of trusting this
+    # compact fingerprint as a proof of no change.
+    monkeypatch.setattr(dd, "_tensor_fingerprint", lambda _tensor: ("collision",))
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = ("collision",)
+
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_t, theta_prev)),
+    )
+    assert masks["w"].numel() > 0
+
+
+def test_inversion_detector_zero_grad_step_uses_fingerprint_guard(monkeypatch):
+    """Zero current grad can still be a valid AdamW delta if the shard changed."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(2)
+    param = torch.nn.Parameter(torch.randn(32, dtype=torch.float32))
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0.01,
+    )
+
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_synced = param.detach().clone()
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv.mark_synced(version=2)
+
+    param.grad = torch.zeros_like(param)
+    base_opt.step()
+    theta_after_zero_grad = param.detach().clone()
+    assert not torch.equal(theta_after_zero_grad, theta_synced)
+
+    masks = inv.compute_masks(["w"], [theta_after_zero_grad], version=3)
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        _changed_indices(bitwise_changed_mask(theta_after_zero_grad, theta_synced)),
+    )
+    assert masks["w"].numel() > 0
+
+
+def test_inversion_detector_zero_grad_bf16_unchanged_fastpath(monkeypatch):
+    """A zero-grad AdamW step can update fp32 while leaving BF16 payload empty."""
+    dd = _load_delta_detect(monkeypatch)
+
+    main = torch.nn.Parameter(torch.tensor([1.0, -2.0, 3.0], dtype=torch.float32))
+    model_param = torch.nn.Parameter(
+        main.detach().to(torch.bfloat16), requires_grad=False
+    )
+    synced_bf16 = model_param.detach().clone()
+    base_opt = torch.optim.AdamW([main], lr=1e-3, weight_decay=0.01)
+    main.grad = torch.zeros_like(main)
+    base_opt.step()
+    model_param.data.copy_(main.detach().to(torch.bfloat16))
+
+    assert not torch.equal(main.detach(), synced_bf16.to(torch.float32))
+    assert torch.equal(model_param.detach(), synced_bf16)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[main]]
+        model_float16_groups = [[model_param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, param):
+            assert param is model_param
+
+            class _Range:
+                start = 0
+                end = model_param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+        _last_optimizer_update_successful = True
+        _last_optimizer_grad_norm = 0.0
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            raise AssertionError("zero fast path should not convert HF overrides")
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(model_param)] = 0.0
+    inv._last_synced_fingerprints[id(model_param)] = dd._tensor_fingerprint(synced_bf16)
+
+    masks = inv.compute_masks(["w"], [model_param.detach()], version=2)
+
+    assert masks is not None
+    assert set(masks) == {"w"}
+    assert masks["w"].dtype == torch.int32
+    assert masks["w"].numel() == 0
+
+
+def test_inversion_zero_probe_uses_fingerprint_dirty_fast_miss(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+    import dte.core
+
+    main = torch.nn.Parameter(torch.tensor([1.0, -2.0, 3.0], dtype=torch.float32))
+    model_param = torch.nn.Parameter(
+        main.detach().to(torch.bfloat16),
+        requires_grad=False,
+    )
+    synced_bf16 = model_param.detach().clone()
+    model_param.data[0] = torch.tensor(1.25, dtype=torch.bfloat16)
+    base_opt = torch.optim.AdamW([main], lr=1e-3, weight_decay=0.01)
+    base_opt.param_groups[0]["step"] = torch.tensor(1.0)
+
+    def _fail_invert(*args, **kwargs):
+        raise AssertionError("fingerprint-dirty probe should not invert AdamW")
+
+    monkeypatch.setattr(dte.core, "invert_adamw", _fail_invert)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[main]]
+        model_float16_groups = [[model_param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, param):
+            assert param is model_param
+
+            class _Range:
+                start = 0
+                end = model_param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+        _last_optimizer_update_successful = True
+        _last_optimizer_grad_norm = 0.0
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(model_param)] = 0.0
+    inv._last_synced_fingerprints[id(model_param)] = dd._tensor_fingerprint(synced_bf16)
+
+    assert inv._probe_bf16_payload_unchanged([_FakeDistOpt()]) is False
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required to cover CPU optimizer shard + CUDA payload mismatch",
+)
+def test_inversion_zero_fastpath_handles_cpu_main_shard_cuda_payload(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    main = torch.nn.Parameter(torch.tensor([1.0, -2.0, 3.0], dtype=torch.float32))
+    model_param = torch.nn.Parameter(
+        main.detach().to(device="cuda", dtype=torch.bfloat16),
+        requires_grad=False,
+    )
+    synced_bf16 = model_param.detach().clone()
+    base_opt = torch.optim.AdamW([main], lr=1e-3, weight_decay=0.01)
+    main.grad = torch.zeros_like(main)
+    base_opt.step()
+    model_param.data.copy_(main.detach().to(device="cuda", dtype=torch.bfloat16))
+
+    assert main.device.type == "cpu"
+    assert model_param.device.type == "cuda"
+    assert torch.equal(model_param.detach(), synced_bf16)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[main]]
+        model_float16_groups = [[model_param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, param):
+            assert param is model_param
+
+            class _Range:
+                start = 0
+                end = model_param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+        _last_optimizer_update_successful = True
+        _last_optimizer_grad_norm = 0.0
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            raise AssertionError("zero fast path should not convert HF overrides")
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(model_param)] = 0.0
+    inv._last_synced_fingerprints[id(model_param)] = dd._tensor_fingerprint(synced_bf16)
+
+    masks = inv.compute_masks(["w"], [model_param.detach()], version=2)
+
+    assert masks is not None
+    assert masks["w"].dtype == torch.int32
+    assert masks["w"].device.type == "cuda"
+    assert masks["w"].numel() == 0
+
+
+def test_inversion_fingerprint_detects_value_changes(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    before = torch.arange(128, dtype=torch.float32)
+    after = before.clone()
+    after[17] += 1
+
+    assert dd._tensor_fingerprint(before) != dd._tensor_fingerprint(after)
+    assert dd._tensor_fingerprint(before) == dd._tensor_fingerprint(before.clone())
+
+
+@pytest.mark.parametrize("window_mb", ["512", "0"])
+def test_inversion_reconstruct_missing_local_state_joins_dp_allreduce(
+    monkeypatch, window_mb
+):
+    """A DP rank without local moments must still join per-param collectives.
+
+    In Megatron's distributed optimizer a rank can see the full bf16 model
+    param while not owning a usable optimizer-state shard for that param. The
+    detector must contribute zeros and enter the same all-reduces as ranks that
+    do own a shard; otherwise colocate v2 can hang waiting for one rank.
+
+    Runs under both the pipelined (async window) and the synchronous
+    (``DTE_INVERSION_ALLREDUCE_WINDOW_MB=0``) reduce paths; the collective
+    sequence must be identical.
+    """
+    monkeypatch.setenv("DTE_INVERSION_ALLREDUCE_WINDOW_MB", window_mb)
+    dd = _load_delta_detect(monkeypatch)
+
+    param = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
+    base_opt = torch.optim.AdamW([param], lr=1e-3)
+    dp_group = object()
+    calls = []
+
+    class _FakeWork:
+        def wait(self):
+            return None
+
+    def _fake_all_reduce(tensor, op=None, group=None, async_op=False):
+        del op
+        assert group is dp_group
+        calls.append((tuple(tensor.shape), tensor.dtype))
+        if tensor.dtype in {torch.int32, torch.int64}:
+            # Simulate another DP rank contributing this param's optimizer shard.
+            assert tuple(tensor.shape) == (3,)
+            tensor[0] = 1
+            tensor[1] = 0
+            tensor[2] = param.numel()
+        return _FakeWork() if async_op else None
+
+    monkeypatch.setattr(dd.torch.distributed, "all_reduce", _fake_all_reduce)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = dp_group
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    theta_old = inv._reconstruct_pre_step_mcore([_FakeDistOpt()])
+
+    assert theta_old is not None
+    assert id(param) in theta_old
+    assert torch.equal(theta_old[id(param)], param.detach())
+    assert calls == [((param.numel(),), torch.float32), ((3,), torch.int64)]
+
+
+def test_inversion_allows_multiple_optimizer_dp_topologies(monkeypatch):
+    """MoE models can mix regular DP params with smaller expert-DP params."""
+    dd = _load_delta_detect(monkeypatch)
+
+    torch.manual_seed(33)
+    dense_prev = torch.randn(16, dtype=torch.float32)
+    expert_prev = torch.randn(12, dtype=torch.float32)
+    dense_param = torch.nn.Parameter(dense_prev.clone())
+    expert_param = torch.nn.Parameter(expert_prev.clone())
+    dense_opt = torch.optim.AdamW([dense_param], lr=2e-3)
+    expert_opt = torch.optim.AdamW([expert_param], lr=4e-3)
+    dense_param.grad = torch.randn_like(dense_param)
+    expert_param.grad = torch.randn_like(expert_param)
+    dense_opt.step()
+    expert_opt.step()
+
+    dense_group = object()
+    expert_group = object()
+    group_signature = {
+        id(dense_group): (0, 16),
+        id(expert_group): (0, 2),
+    }
+    calls = []
+
+    def _fake_rank(group=None):
+        return group_signature.get(id(group), (-1, 1))[0]
+
+    def _fake_world_size(group=None):
+        return group_signature.get(id(group), (-1, 1))[1]
+
+    class _FakeWork:
+        def wait(self):
+            return None
+
+    def _fake_all_reduce(tensor, op=None, group=None, async_op=False):
+        del op
+        calls.append((group, tuple(tensor.shape), tensor.dtype))
+        return _FakeWork() if async_op else None
+
+    monkeypatch.setattr(dd, "_dist_rank", _fake_rank)
+    monkeypatch.setattr(dd, "_dist_world_size", _fake_world_size)
+    monkeypatch.setattr(dd.torch.distributed, "all_reduce", _fake_all_reduce)
+
+    class _FakeDistOpt:
+        model_param_group_index_map = None
+
+        def __init__(self, base_opt, param, dp_group):
+            self.optimizer = base_opt
+            self.shard_fp32_from_float16_groups = [[param]]
+            self.model_float16_groups = [[param]]
+            self.data_parallel_group = dp_group
+            self._param = param
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is self._param
+
+            class _Range:
+                start = 0
+                end = model_param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    dense_key = "model.layers.0.mlp.dense_h_to_4h.weight"
+    expert_key = "model.layers.0.mlp.experts.0.w1.weight"
+    inv._module_param_key_maps = lambda: (
+        {id(dense_param): dense_key, id(expert_param): expert_key},
+        {},
+    )
+    for key, prev in ((dense_key, dense_prev), (expert_key, expert_prev)):
+        inv._last_synced_steps[key] = 0.0
+        inv._last_synced_fingerprints[key] = dd._tensor_fingerprint(prev)
+
+    theta_old = inv._reconstruct_pre_step_mcore(
+        [
+            _FakeDistOpt(dense_opt, dense_param, dense_group),
+            _FakeDistOpt(expert_opt, expert_param, expert_group),
+        ]
+    )
+
+    assert theta_old is not None
+    assert id(dense_param) in theta_old
+    assert id(expert_param) in theta_old
+    assert [call[0] for call in calls] == [
+        dense_group,
+        dense_group,
+        expert_group,
+        expert_group,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Precompute reuse (release critical-path opts)
+# ---------------------------------------------------------------------------
+
+
+def test_pop_precomputed_synced_state_sentinel_semantics(monkeypatch):
+    """A cached None (infeasible) is a valid value, distinct from a miss."""
+    mod = _load_megatron_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+
+    adapter._precomputed_synced_state = None
+    assert adapter._pop_precomputed_synced_state(3) is mod._CAPTURE_MISS
+
+    adapter._precomputed_synced_state = (3, None)
+    assert adapter._pop_precomputed_synced_state(3) is None
+    # Consumed: second pop misses.
+    assert adapter._pop_precomputed_synced_state(3) is mod._CAPTURE_MISS
+
+    state = object()
+    adapter._precomputed_synced_state = (3, state)
+    assert adapter._pop_precomputed_synced_state(4) is mod._CAPTURE_MISS
+
+
+def test_precompute_param_sync_covers_local_only(monkeypatch):
+    """Without torch.distributed the decision is purely the local marker,
+    and the marker is consumed either way."""
+    mod = _load_megatron_adapter(monkeypatch)
+    adapter = object.__new__(mod.AwexMegatronAdapter)
+
+    adapter._precompute_param_synced_version = 5
+    assert adapter._precompute_param_sync_covers(5) is True
+    assert adapter._precompute_param_synced_version is None
+
+    adapter._precompute_param_synced_version = 5
+    assert adapter._precompute_param_sync_covers(6) is False
+    assert adapter._precompute_param_synced_version is None
+
+    adapter._precompute_param_synced_version = None
+    assert adapter._precompute_param_sync_covers(5) is False

--- a/tests/test_dte_delta_index_remap.py
+++ b/tests/test_dte_delta_index_remap.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+
+def _load_remap_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "areal"
+        / "v2"
+        / "weight_update"
+        / "awex"
+        / "delta_index_remap.py"
+    )
+    spec = importlib.util.spec_from_file_location("delta_index_remap", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_REMAP = _load_remap_module()
+Qwen3MoeIndexRemapConfig = _REMAP.Qwen3MoeIndexRemapConfig
+MCoreShardDirtyBitset = _REMAP.MCoreShardDirtyBitset
+remap_qwen3_moe_mcore_indices_to_hf = _REMAP.remap_qwen3_moe_mcore_indices_to_hf
+remap_qwen3_moe_mcore_bitset_to_hf = _REMAP.remap_qwen3_moe_mcore_bitset_to_hf
+remap_qwen3_moe_mcore_shard_bitset_to_hf = (
+    _REMAP.remap_qwen3_moe_mcore_shard_bitset_to_hf
+)
+remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks = (
+    _REMAP.remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks
+)
+
+
+def _cfg() -> Qwen3MoeIndexRemapConfig:
+    return Qwen3MoeIndexRemapConfig(
+        hidden_size=8,
+        num_attention_heads=4,
+        num_query_groups=2,
+        head_dim=2,
+    )
+
+
+def _as_dict(remapped):
+    return {item.name: item.indices for item in remapped}
+
+
+def _pack_indices(indices: torch.Tensor, numel: int) -> torch.Tensor:
+    mask = torch.zeros(numel, dtype=torch.bool)
+    mask[indices.to(torch.long)] = True
+    padded = ((numel + 7) // 8) * 8
+    if padded != numel:
+        mask = torch.cat((mask, torch.zeros(padded - numel, dtype=torch.bool)))
+    bits = mask.view(-1, 8).to(torch.uint8)
+    return sum(bits[:, bit] << bit for bit in range(8))
+
+
+def _assert_same_remap_from_bitset(
+    name: str,
+    indices: torch.Tensor,
+    shape: tuple[int, ...],
+    *,
+    packed: torch.Tensor | None = None,
+    chunk_bytes: int = 1,
+) -> None:
+    expected = _as_dict(
+        remap_qwen3_moe_mcore_indices_to_hf(name, indices, shape, _cfg())
+    )
+    actual = _as_dict(
+        remap_qwen3_moe_mcore_bitset_to_hf(
+            name,
+            _pack_indices(indices, int(torch.tensor(shape).prod()))
+            if packed is None
+            else packed,
+            shape,
+            _cfg(),
+            chunk_bytes=chunk_bytes,
+        )
+    )
+
+    assert set(actual) == set(expected)
+    for key, expected_indices in expected.items():
+        assert torch.equal(actual[key], expected_indices)
+
+
+def test_remap_identity_parameter_keeps_flat_indices() -> None:
+    indices = torch.tensor([0, 3, 7], dtype=torch.int32)
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.0.self_attention.linear_proj.weight",
+        indices,
+        (8, 8),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert set(by_name) == {"model.layers.0.self_attn.o_proj.weight"}
+    assert torch.equal(by_name["model.layers.0.self_attn.o_proj.weight"], indices)
+
+
+def test_remap_dense_mlp_linear_fc1_splits_gate_and_up_rows() -> None:
+    indices = torch.tensor([1, 8, 17, 31], dtype=torch.int32)
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.3.mlp.linear_fc1.weight",
+        indices,
+        (4, 8),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert torch.equal(
+        by_name["model.layers.3.mlp.gate_proj.weight"],
+        torch.tensor([1, 8], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.3.mlp.up_proj.weight"],
+        torch.tensor([1, 15], dtype=torch.int32),
+    )
+
+
+def test_remap_expert_linear_fc1_splits_gate_and_up_rows() -> None:
+    indices = torch.tensor([0, 16, 31], dtype=torch.int32)
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.5.mlp.experts.linear_fc1.weight12",
+        indices,
+        (4, 8),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert torch.equal(
+        by_name["model.layers.5.mlp.experts.12.gate_proj.weight"],
+        torch.tensor([0], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.5.mlp.experts.12.up_proj.weight"],
+        torch.tensor([0, 15], dtype=torch.int32),
+    )
+
+
+def test_remap_qkv_weight_matches_qwen3_moe_row_permutation() -> None:
+    # cfg: G=2, value_num_per_group=2, D=2, H=8
+    # mcore rows per group: q0,q1,k,v where each slot has D rows.
+    indices = torch.tensor(
+        [
+            0 * 8 + 3,  # group0 q slot0 d0 -> q row 0, col 3
+            3 * 8 + 4,  # group0 q slot1 d1 -> q row 3, col 4
+            4 * 8 + 5,  # group0 k d0 -> k row 0, col 5
+            7 * 8 + 6,  # group0 v d1 -> v row 1, col 6
+            8 * 8 + 7,  # group1 q slot0 d0 -> q row 4, col 7
+            12 * 8 + 1,  # group1 k d0 -> k row 2, col 1
+            15 * 8 + 2,  # group1 v d1 -> v row 3, col 2
+        ],
+        dtype=torch.int32,
+    )
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.1.self_attention.linear_qkv.weight",
+        indices,
+        (16, 8),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.q_proj.weight"],
+        torch.tensor([3, 28, 39], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.k_proj.weight"],
+        torch.tensor([5, 17], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.v_proj.weight"],
+        torch.tensor([14, 26], dtype=torch.int32),
+    )
+
+
+def test_remap_qkv_weight_accepts_tp_local_groups() -> None:
+    # Local TP shards use the same GQA group layout as AWEX's Qwen3-MoE
+    # converter, but only contain a subset of the KV groups.
+    indices = torch.tensor(
+        [
+            0 * 8 + 3,  # local group0 q slot0 d0 -> local q row 0, col 3
+            3 * 8 + 4,  # local group0 q slot1 d1 -> local q row 3, col 4
+            4 * 8 + 5,  # local group0 k d0 -> local k row 0, col 5
+            7 * 8 + 6,  # local group0 v d1 -> local v row 1, col 6
+        ],
+        dtype=torch.int32,
+    )
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.1.self_attention.linear_qkv.weight",
+        indices,
+        (8, 8),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.q_proj.weight"],
+        torch.tensor([3, 28], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.k_proj.weight"],
+        torch.tensor([5], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.v_proj.weight"],
+        torch.tensor([14], dtype=torch.int32),
+    )
+
+
+def test_remap_qkv_bias_matches_qwen3_moe_split() -> None:
+    indices = torch.tensor([0, 3, 4, 7, 8, 12, 15], dtype=torch.int32)
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.1.self_attention.linear_qkv.bias",
+        indices,
+        (16,),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.q_proj.bias"],
+        torch.tensor([0, 3, 4], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.k_proj.bias"],
+        torch.tensor([0, 2], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.v_proj.bias"],
+        torch.tensor([1, 3], dtype=torch.int32),
+    )
+
+
+def test_remap_qkv_bias_accepts_tp_local_groups() -> None:
+    indices = torch.tensor([0, 3, 4, 7], dtype=torch.int32)
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.1.self_attention.linear_qkv.bias",
+        indices,
+        (8,),
+        _cfg(),
+    )
+
+    by_name = _as_dict(result)
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.q_proj.bias"],
+        torch.tensor([0, 3], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.k_proj.bias"],
+        torch.tensor([0], dtype=torch.int32),
+    )
+    assert torch.equal(
+        by_name["model.layers.1.self_attn.v_proj.bias"],
+        torch.tensor([1], dtype=torch.int32),
+    )
+
+
+def test_remap_empty_dirty_indices_returns_empty_result() -> None:
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.0.self_attention.linear_proj.weight",
+        torch.tensor([], dtype=torch.int32),
+        (8, 8),
+        _cfg(),
+    )
+
+    assert result == []
+
+
+def test_remap_unsupported_parameter_name_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported Qwen3-MoE"):
+        remap_qwen3_moe_mcore_indices_to_hf(
+            "module.module.decoder.layers.0.unknown.weight",
+            torch.tensor([0], dtype=torch.int32),
+            (8,),
+            _cfg(),
+        )
+
+
+def test_remap_qkv_weight_shape_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="qkv rows mismatch"):
+        remap_qwen3_moe_mcore_indices_to_hf(
+            "module.module.decoder.layers.0.self_attention.linear_qkv.weight",
+            torch.tensor([0], dtype=torch.int32),
+            (15, 8),
+            _cfg(),
+        )
+
+
+def test_remap_expert_local_id_uses_ep_global_offset() -> None:
+    cfg = Qwen3MoeIndexRemapConfig(
+        hidden_size=8,
+        num_attention_heads=4,
+        num_query_groups=2,
+        head_dim=2,
+        num_moe_experts=8,
+        expert_model_parallel_size=4,
+        expert_model_parallel_rank=2,
+    )
+
+    result = remap_qwen3_moe_mcore_indices_to_hf(
+        "module.module.decoder.layers.5.mlp.experts.linear_fc1.weight1",
+        torch.tensor([0, 16], dtype=torch.int32),
+        (4, 8),
+        cfg,
+    )
+
+    by_name = _as_dict(result)
+    assert set(by_name) == {
+        "model.layers.5.mlp.experts.5.gate_proj.weight",
+        "model.layers.5.mlp.experts.5.up_proj.weight",
+    }
+
+
+def test_bitset_remap_identity_ignores_padding_bits() -> None:
+    indices = torch.tensor([0, 3, 9], dtype=torch.int32)
+    packed = _pack_indices(indices, 10)
+    packed[-1] |= 0b1111_1100
+
+    _assert_same_remap_from_bitset(
+        "module.module.decoder.layers.0.self_attention.linear_proj.weight",
+        indices,
+        (2, 5),
+        packed=packed,
+        chunk_bytes=1,
+    )
+
+
+def test_bitset_remap_row_split_matches_indices_path() -> None:
+    _assert_same_remap_from_bitset(
+        "module.module.decoder.layers.3.mlp.linear_fc1.weight",
+        torch.tensor([1, 8, 17, 31], dtype=torch.int32),
+        (4, 8),
+        chunk_bytes=1,
+    )
+
+
+def test_bitset_remap_qkv_weight_matches_indices_path() -> None:
+    indices = torch.tensor(
+        [
+            0 * 8 + 3,
+            3 * 8 + 4,
+            4 * 8 + 5,
+            7 * 8 + 6,
+            8 * 8 + 7,
+            12 * 8 + 1,
+            15 * 8 + 2,
+        ],
+        dtype=torch.int32,
+    )
+
+    _assert_same_remap_from_bitset(
+        "module.module.decoder.layers.1.self_attention.linear_qkv.weight",
+        indices,
+        (16, 8),
+        chunk_bytes=1,
+    )
+
+
+def test_bitset_remap_numel_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="numel mismatch"):
+        remap_qwen3_moe_mcore_bitset_to_hf(
+            "module.module.decoder.layers.0.self_attention.linear_proj.weight",
+            torch.zeros(2, dtype=torch.uint8),
+            (2, 5),
+            _cfg(),
+            numel=9,
+        )
+
+
+def test_shard_bitset_remap_offsets_local_indices() -> None:
+    name = "module.module.decoder.layers.0.self_attention.linear_proj.weight"
+    full_indices = torch.tensor([9, 11, 14], dtype=torch.int32)
+    local_indices = full_indices - 8
+    expected = _as_dict(
+        remap_qwen3_moe_mcore_indices_to_hf(
+            name,
+            full_indices,
+            (4, 4),
+            _cfg(),
+        )
+    )
+    actual = _as_dict(
+        remap_qwen3_moe_mcore_shard_bitset_to_hf(
+            name,
+            _pack_indices(local_indices, 8),
+            (4, 4),
+            _cfg(),
+            shard_start=8,
+            shard_numel=8,
+            chunk_bytes=1,
+        )
+    )
+
+    assert set(actual) == set(expected)
+    for key, expected_indices in expected.items():
+        assert torch.equal(actual[key], expected_indices)
+
+
+def test_shard_bitset_remap_qkv_weight_matches_full_indices_path() -> None:
+    name = "module.module.decoder.layers.1.self_attention.linear_qkv.weight"
+    full_indices = torch.tensor(
+        [
+            4 * 8 + 5,
+            7 * 8 + 6,
+            8 * 8 + 7,
+            12 * 8 + 1,
+        ],
+        dtype=torch.int32,
+    )
+    shard_start = 4 * 8
+    shard_numel = 9 * 8
+    local_indices = full_indices - shard_start
+    expected = _as_dict(
+        remap_qwen3_moe_mcore_indices_to_hf(
+            name,
+            full_indices,
+            (16, 8),
+            _cfg(),
+        )
+    )
+    actual = _as_dict(
+        remap_qwen3_moe_mcore_shard_bitset_to_hf(
+            name,
+            _pack_indices(local_indices, shard_numel),
+            (16, 8),
+            _cfg(),
+            shard_start=shard_start,
+            shard_numel=shard_numel,
+            chunk_bytes=2,
+        )
+    )
+
+    assert set(actual) == set(expected)
+    for key, expected_indices in expected.items():
+        assert torch.equal(actual[key], expected_indices)
+
+
+def test_shard_bitset_remap_range_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="out of bounds"):
+        remap_qwen3_moe_mcore_shard_bitset_to_hf(
+            "module.module.decoder.layers.0.self_attention.linear_proj.weight",
+            torch.zeros(2, dtype=torch.uint8),
+            (2, 5),
+            _cfg(),
+            shard_start=8,
+            shard_numel=3,
+        )
+
+
+def test_shard_bitsets_to_hf_masks_merge_and_fill_empty() -> None:
+    name = "module.module.decoder.layers.3.mlp.linear_fc1.weight"
+    records = [
+        MCoreShardDirtyBitset(
+            name=name,
+            packed_bitset=_pack_indices(torch.tensor([1, 3], dtype=torch.int32), 8),
+            shape=(4, 8),
+            shard_start=0,
+            shard_numel=8,
+        ),
+        MCoreShardDirtyBitset(
+            name=name,
+            packed_bitset=_pack_indices(torch.tensor([1, 7], dtype=torch.int32), 8),
+            shape=(4, 8),
+            shard_start=16,
+            shard_numel=8,
+        ),
+    ]
+
+    masks = remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks(
+        records,
+        _cfg(),
+        hf_names=[
+            "model.layers.3.mlp.gate_proj.weight",
+            "model.layers.3.mlp.up_proj.weight",
+            "model.layers.3.mlp.down_proj.weight",
+        ],
+    )
+
+    assert torch.equal(
+        masks["model.layers.3.mlp.gate_proj.weight"],
+        torch.tensor([1, 3], dtype=torch.int32),
+    )
+    assert torch.equal(
+        masks["model.layers.3.mlp.up_proj.weight"],
+        torch.tensor([1, 7], dtype=torch.int32),
+    )
+    assert masks["model.layers.3.mlp.down_proj.weight"].dtype == torch.int32
+    assert masks["model.layers.3.mlp.down_proj.weight"].numel() == 0
+
+
+def test_shard_bitsets_to_hf_masks_fill_only_covered_names() -> None:
+    name = "module.module.decoder.layers.3.mlp.experts.linear_fc1.weight1"
+    cfg = Qwen3MoeIndexRemapConfig(
+        hidden_size=8,
+        num_attention_heads=4,
+        num_query_groups=2,
+        head_dim=2,
+        num_moe_experts=8,
+        expert_model_parallel_size=4,
+        expert_model_parallel_rank=2,
+    )
+    records = [
+        MCoreShardDirtyBitset(
+            name=name,
+            packed_bitset=_pack_indices(torch.tensor([], dtype=torch.int32), 32),
+            shape=(4, 8),
+            shard_start=0,
+            shard_numel=32,
+        )
+    ]
+
+    masks = remap_qwen3_moe_mcore_shard_bitsets_to_hf_masks(
+        records,
+        cfg,
+        hf_names=[
+            "model.layers.3.mlp.experts.5.gate_proj.weight",
+            "model.layers.3.mlp.experts.5.up_proj.weight",
+            "model.layers.3.self_attn.q_proj.weight",
+        ],
+        fill_all_hf_names=False,
+    )
+
+    assert set(masks) == {
+        "model.layers.3.mlp.experts.5.gate_proj.weight",
+        "model.layers.3.mlp.experts.5.up_proj.weight",
+    }
+    assert masks["model.layers.3.mlp.experts.5.gate_proj.weight"].numel() == 0
+    assert masks["model.layers.3.mlp.experts.5.up_proj.weight"].numel() == 0

--- a/tests/test_dte_step_dirty_dryrun.py
+++ b/tests/test_dte_step_dirty_dryrun.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+
+def _load_dryrun_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "areal"
+        / "v2"
+        / "weight_update"
+        / "awex"
+        / "step_dirty_dryrun.py"
+    )
+    spec = importlib.util.spec_from_file_location("step_dirty_dryrun", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DRYRUN = _load_dryrun_module()
+capture_bf16_optimizer_shards = _DRYRUN.capture_bf16_optimizer_shards
+collect_copyback_dirty_bitsets = _DRYRUN.collect_copyback_dirty_bitsets
+compare_bf16_optimizer_shards = _DRYRUN.compare_bf16_optimizer_shards
+iter_optimizer_shard_refs = _DRYRUN.iter_optimizer_shard_refs
+
+
+class _FakeOptimizer:
+    def __init__(
+        self, main_shards: list[torch.Tensor], model_params: list[torch.Tensor]
+    ):
+        self.shard_fp32_from_float16_groups = [main_shards]
+        self.model_float16_groups = [model_params]
+
+
+def test_iter_optimizer_shard_refs_uses_resolver_names() -> None:
+    main0 = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    main1 = torch.tensor([3.0, 4.0], dtype=torch.float32)
+    model0 = torch.empty(2)
+    model1 = torch.empty(2)
+    opt = _FakeOptimizer([main0, main1], [model0, model1])
+
+    refs = iter_optimizer_shard_refs(
+        [opt],
+        name_resolver=lambda param: "param0" if param is model0 else "param1",
+    )
+
+    assert [ref.name for ref in refs] == ["param0", "param1"]
+    assert refs[0].tensor is main0
+    assert refs[1].tensor is main1
+
+
+def test_compare_bf16_optimizer_shards_uses_bitwise_payload_semantics() -> None:
+    main = torch.tensor([0.0, -0.0, 1.0, float("nan")], dtype=torch.float32)
+    opt = _FakeOptimizer([main], [torch.empty(4)])
+    refs = iter_optimizer_shard_refs([opt])
+    capture = capture_bf16_optimizer_shards(refs, storage="cpu")
+
+    main.copy_(torch.tensor([-0.0, -0.0, 1.0001, float("nan")], dtype=torch.float32))
+    result = compare_bf16_optimizer_shards(capture)
+
+    # +0.0 -> -0.0 changes the bf16 bit pattern. 1.0 -> 1.0001 does not cross
+    # a bf16 boundary. NaN with the same casted payload bit pattern is unchanged.
+    assert result.captured_params == 1
+    assert result.captured_elements == 4
+    assert result.changed_elements == 1
+    assert result.bitset_bytes == 1
+    assert result.indices_elements == 0
+    assert result.indices_bytes == 0
+
+
+def test_compare_bf16_optimizer_shards_can_materialize_indices(monkeypatch) -> None:
+    def pack_bool_mask_to_uint8(mask: torch.Tensor) -> torch.Tensor:
+        flat = mask.reshape(-1).to(torch.bool)
+        padded = ((flat.numel() + 7) // 8) * 8
+        if padded != flat.numel():
+            flat = torch.cat(
+                (flat, torch.zeros(padded - flat.numel(), dtype=torch.bool))
+            )
+        bits = flat.view(-1, 8).to(torch.uint8)
+        return sum(bits[:, i] << i for i in range(8))
+
+    def packed_bool_mask_to_indices(
+        packed: torch.Tensor,
+        numel: int,
+        *,
+        dtype: torch.dtype = torch.int64,
+    ) -> torch.Tensor:
+        values = []
+        for i in range(numel):
+            if int(packed[i // 8]) & (1 << (i % 8)):
+                values.append(i)
+        return torch.tensor(values, dtype=dtype)
+
+    dte_module = ModuleType("dte")
+    core_module = ModuleType("dte.core")
+    core_module.pack_bool_mask_to_uint8 = pack_bool_mask_to_uint8
+    core_module.packed_bool_mask_to_indices = packed_bool_mask_to_indices
+    monkeypatch.setitem(sys.modules, "dte", dte_module)
+    monkeypatch.setitem(sys.modules, "dte.core", core_module)
+
+    main = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)
+    opt = _FakeOptimizer([main], [torch.empty(4)])
+    refs = iter_optimizer_shard_refs([opt])
+    capture = capture_bf16_optimizer_shards(refs, storage="cpu")
+
+    main.copy_(torch.tensor([-0.0, 1.0, 2.25, 3.0], dtype=torch.float32))
+    result = compare_bf16_optimizer_shards(
+        capture,
+        pack_bitset=True,
+        materialize_indices=True,
+    )
+
+    assert result.changed_elements == 2
+    assert result.bitset_bytes == 1
+    assert result.indices_elements == 2
+    assert result.indices_bytes == 8
+    assert result.pack_ms >= 0
+    assert result.indices_ms >= 0
+
+
+def test_capture_bf16_optimizer_shards_respects_byte_cap() -> None:
+    main0 = torch.ones(4, dtype=torch.float32)
+    main1 = torch.ones(4, dtype=torch.float32)
+    opt = _FakeOptimizer([main0, main1], [torch.empty(4), torch.empty(4)])
+    refs = iter_optimizer_shard_refs([opt])
+
+    capture = capture_bf16_optimizer_shards(
+        refs,
+        max_snapshot_bytes=8,
+        storage="cpu",
+    )
+
+    assert capture.total_params == 2
+    assert capture.captured_params == 1
+    assert capture.skipped_by_cap == 1
+    assert capture.total_snapshot_bytes == 16
+    assert capture.captured_snapshot_bytes == 8
+
+
+def test_capture_bf16_optimizer_shards_rejects_invalid_options() -> None:
+    with pytest.raises(ValueError, match="storage"):
+        capture_bf16_optimizer_shards([], storage="disk")
+    with pytest.raises(ValueError, match="non-negative"):
+        capture_bf16_optimizer_shards([], max_snapshot_bytes=-1)
+
+
+def test_collect_copyback_dirty_bitsets_compares_before_copy(monkeypatch) -> None:
+    def bitwise_changed_mask(current: torch.Tensor, baseline: torch.Tensor):
+        return current.contiguous().view(torch.int16) != baseline.contiguous().view(
+            torch.int16
+        )
+
+    def pack_bool_mask_to_uint8(mask: torch.Tensor) -> torch.Tensor:
+        flat = mask.reshape(-1).to(torch.bool)
+        padded = ((flat.numel() + 7) // 8) * 8
+        if padded != flat.numel():
+            flat = torch.cat(
+                (flat, torch.zeros(padded - flat.numel(), dtype=torch.bool))
+            )
+        bits = flat.view(-1, 8).to(torch.uint8)
+        return sum(bits[:, i] << i for i in range(8))
+
+    dte_module = ModuleType("dte")
+    core_module = ModuleType("dte.core")
+    core_module.bitwise_changed_mask = bitwise_changed_mask
+    core_module.pack_bool_mask_to_uint8 = pack_bool_mask_to_uint8
+    monkeypatch.setitem(sys.modules, "dte", dte_module)
+    monkeypatch.setitem(sys.modules, "dte.core", core_module)
+
+    model_param = torch.empty(8, dtype=torch.bfloat16)
+    main_shard = torch.tensor([1.0, 20.0, 3.0, 40.0], dtype=torch.float32)
+    old_buffer = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.bfloat16)
+
+    class _Optimizer:
+        shard_fp32_from_float16_groups = [[main_shard]]
+        model_float16_groups = [[model_param]]
+        shard_fp32_groups = []
+        model_fp32_groups = []
+        model_param_gbuf_map = {model_param: (0, None, 0)}
+        buffers = [SimpleNamespace(buckets=[SimpleNamespace(param_data=old_buffer)])]
+
+        def _get_model_param_range_map(self, param):
+            assert param is model_param
+            return {
+                "param": SimpleNamespace(start=2, end=6, size=4),
+                "gbuf_world_in_bucket": SimpleNamespace(start=0, end=4, size=4),
+            }
+
+    result = collect_copyback_dirty_bitsets(
+        _Optimizer(),
+        name_resolver=lambda param: "module.module.decoder.layers.0.mlp.linear_fc2.weight",
+    )
+
+    assert result.complete is True
+    assert len(result.records) == 1
+    record = result.records[0]
+    assert record["name"] == "module.module.decoder.layers.0.mlp.linear_fc2.weight"
+    assert record["shape"] == (8,)
+    assert record["shard_start"] == 2
+    assert record["shard_numel"] == 4
+    assert int(record["packed_bitset"][0]) == 0b0000_1010

--- a/tests/test_inference_engines.py
+++ b/tests/test_inference_engines.py
@@ -1,6 +1,7 @@
 """Test suite for remote inference engines (vLLM and SGLang)."""
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch.distributed as dist
@@ -25,6 +26,60 @@ MODEL_PATH = get_model_path(
 
 IS_VLLM_INSTALLED = is_available("vllm")
 IS_SGLANG_INSTALLED = is_available("sglang")
+
+
+def test_wait_for_server_raises_when_subprocess_exits() -> None:
+    from areal.infra.remote_inf_engine import RemoteInfEngine
+
+    engine = RemoteInfEngine(
+        InferenceEngineConfig(setup_timeout=60),
+        backend=SimpleNamespace(),
+    )
+    engine.check_health = lambda _: False
+    process = SimpleNamespace(
+        args=["python3", "-m", "sglang.launch_server"],
+        returncode=42,
+        poll=lambda: 42,
+    )
+
+    with pytest.raises(RuntimeError, match="returncode=42"):
+        engine._wait_for_server("127.0.0.1:1", process=process)
+
+
+def test_awex_sglang_child_drops_training_ld_preload(monkeypatch) -> None:
+    from areal.engine.sglang_remote import SGLangBackend
+
+    backend = SGLangBackend()
+    monkeypatch.setenv("LD_PRELOAD", "/tmp/torch_memory_saver.so")
+    monkeypatch.delenv("AREAL_SGLANG_DROP_LD_PRELOAD", raising=False)
+    monkeypatch.setenv("AWEX_META_SERVER_ADDR", "127.0.0.1:1234")
+
+    captured = {}
+
+    class Process:
+        pid = 1
+
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, *, env, stdout, stderr):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return Process()
+
+    monkeypatch.setattr("areal.engine.sglang_remote.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "areal.engine.sglang_remote.SGLangConfig.build_cmd_from_args",
+        lambda args: ["sglang.launch_server"],
+    )
+    monkeypatch.setattr(
+        "areal.engine.sglang_remote._start_process_monitor",
+        lambda *args, **kwargs: None,
+    )
+
+    backend.launch_server({"model_path": "model"})
+
+    assert "LD_PRELOAD" not in captured["env"]
 
 
 def _dummy_reward_fn(*args, **kwargs):

--- a/tests/test_rl_trainer_colocate_offload.py
+++ b/tests/test_rl_trainer_colocate_offload.py
@@ -1,0 +1,114 @@
+import ast
+import inspect
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+from areal.api.cli_args import SchedulingStrategy, SchedulingStrategyType
+from areal.trainer.rl_trainer import PPOTrainer
+
+
+def _config(*, version="v2", mode="awex", use_lora=False, dte=None):
+    return SimpleNamespace(
+        actor=SimpleNamespace(
+            _version=version,
+            offload=False,
+            weight_update_mode=mode,
+            use_lora=use_lora,
+            dte=dte,
+            scheduling_strategy=SchedulingStrategy(),
+        ),
+        rollout=SimpleNamespace(
+            scheduling_strategy=SchedulingStrategy(
+                type=SchedulingStrategyType.colocation,
+                target="actor",
+            )
+        ),
+    )
+
+
+def test_awex_colocation_keeps_rollout_and_actor_offload_enabled():
+    trainer = object.__new__(PPOTrainer)
+    config = _config()
+
+    offload_rollout, offload_actor = trainer._resolve_actor_rollout_offload(config)
+
+    assert offload_rollout is True
+    assert offload_actor is True
+
+
+def test_dte_colocation_keeps_initial_rollout_weights():
+    trainer = object.__new__(PPOTrainer)
+    trainer._should_offload_rollout = True
+    config = _config(
+        dte=SimpleNamespace(
+            enabled=True,
+            release_initial_rollout_weights=None,
+        )
+    )
+
+    release_weights = trainer._resolve_release_initial_rollout_weights(config)
+
+    assert release_weights is False
+
+
+@pytest.mark.parametrize(
+    "version,mode,use_lora,expected",
+    [
+        ("v1", "awex", False, True),
+        ("v1", "disk", False, False),
+        ("v2", "awex", False, True),
+        ("v2", "disk", False, True),
+        ("v2", "awex", True, False),
+    ],
+)
+def test_awex_transport_selection(version, mode, use_lora, expected):
+    trainer = object.__new__(PPOTrainer)
+
+    assert (
+        trainer._uses_awex_weight_update(
+            _config(version=version, mode=mode, use_lora=use_lora)
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "version,use_lora,expected",
+    [("v1", False, True), ("v2", False, True), ("v2", True, False)],
+)
+def test_awex_checkpoint_is_saved_before_weight_update(version, use_lora, expected):
+    trainer = object.__new__(PPOTrainer)
+
+    assert (
+        trainer._should_save_before_weight_update(
+            _config(version=version, use_lora=use_lora)
+        )
+        is expected
+    )
+
+
+def test_trainer_startup_creates_one_awex_meta_server_and_forwards_it():
+    tree = ast.parse(textwrap.dedent(inspect.getsource(PPOTrainer._init_impl)))
+    start_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "start_meta_server"
+    ]
+    awex_meta_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "from_awex"
+    ]
+
+    assert len(start_calls) == 1
+    assert awex_meta_calls
+    assert all(
+        any(keyword.arg == "meta_server_addr" for keyword in call.keywords)
+        for call in awex_meta_calls
+    )

--- a/tests/test_rollout_controller.py
+++ b/tests/test_rollout_controller.py
@@ -17,6 +17,7 @@ from areal.api.cli_args import (
     GenerationHyperparameters,
     InferenceEngineConfig,
     SchedulingSpec,
+    SchedulingStrategy,
     SGLangConfig,
 )
 from areal.infra import RolloutController
@@ -43,6 +44,7 @@ def create_test_config(backend="sglang:d2", **kwargs):
 class MockScheduler:
     def __init__(self):
         self.workers = []
+        self.jobs = []
         self.call_count = 0
         self.engine_calls = []
         self._pending_results = {}  # worker_id -> dict[task_id -> result]
@@ -50,6 +52,7 @@ class MockScheduler:
 
     def create_workers(self, job, *args, **kwargs):
         """Create workers based on Job specification."""
+        self.jobs.append(job)
         role = job.role
         replicas = job.replicas
         worker_ids = [f"{role}/{i}" for i in range(replicas)]
@@ -76,7 +79,9 @@ class MockScheduler:
     async def async_call_engine(self, worker_id, method, *args, **kwargs):
         self.engine_calls.append((worker_id, method, args, kwargs))
         self.call_count += 1
-        if method == "agenerate":
+        if method == "launch_server":
+            return Mock(host="127.0.0.1", port=8000)
+        elif method == "agenerate":
             return Mock()
         # Handle submit method - return a task_id and store the result
         elif method == "submit":
@@ -213,6 +218,27 @@ class TestRolloutControllerInitialization:
 
         assert len(controller.workers) == 2
         assert controller.staleness_manager is not None
+
+        controller.destroy()
+
+    def test_initialize_colocated_rollout_skips_second_gpu_gres_request(self):
+        config = create_test_config(
+            backend="sglang:d2",
+            scheduling_strategy=SchedulingStrategy(
+                type="colocation",
+                target="actor",
+            ),
+        )
+        scheduler = MockScheduler()
+        controller = RolloutController(
+            inf_engine=MockInferenceEngine,
+            config=config,
+            scheduler=scheduler,
+        )
+
+        controller.initialize(role="rollout", server_args={})
+
+        assert scheduler.jobs[0].tasks[0].request_gpu_gres is False
 
         controller.destroy()
 

--- a/tests/test_sglang_lora_unload.py
+++ b/tests/test_sglang_lora_unload.py
@@ -6,8 +6,15 @@ never unloads old versions, so sglang accumulates adapters until it hangs
 version that falls outside the retention window (kept for off-policy rollouts).
 """
 
-from areal.api.io_struct import WeightUpdateMeta
+from areal.api.cli_args import GenerationHyperparameters
+from areal.api.io_struct import ModelRequest, WeightUpdateMeta
 from areal.engine.sglang_remote import SGLangBackend
+
+
+def _request(top_k):
+    gconfig = GenerationHyperparameters()
+    gconfig.top_k = top_k
+    return ModelRequest(input_ids=[1, 2, 3], gconfig=gconfig)
 
 
 def _lora_meta(version, keep, lora_name="lora-gsm8k", path="/tmp/wu"):
@@ -63,3 +70,22 @@ def test_disk_update_full_model_unchanged():
     meta = WeightUpdateMeta(type="disk", path="/tmp/wu", use_lora=False)
     reqs = SGLangBackend().build_disk_weight_update_requests(meta)
     assert [r.endpoint for r in reqs.requests] == ["/update_weights_from_disk"]
+
+
+def test_generation_request_large_top_k_maps_to_all_vocab_sentinel():
+    """AReaL's large top_k sentinel maps to SGLang's -1 all-vocab value."""
+    backend = SGLangBackend()
+
+    http_req = backend.build_generation_request(
+        _request(top_k=100_000_000),
+        with_lora=False,
+        version=0,
+    )
+    assert http_req.payload["sampling_params"]["top_k"] == -1
+
+    http_req = backend.build_generation_request(
+        _request(top_k=128),
+        with_lora=False,
+        version=0,
+    )
+    assert http_req.payload["sampling_params"]["top_k"] == 128

--- a/tests/test_slurm_scheduler.py
+++ b/tests/test_slurm_scheduler.py
@@ -351,6 +351,47 @@ def test_scheduler_no_config_no_gpus_fails():
         SlurmScheduler()
 
 
+@pytest.mark.parametrize(
+    ("request_gpu_gres", "expects_gres"),
+    [(True, True), (False, False)],
+)
+def test_generate_sbatch_script_respects_gpu_gres_request(
+    tmp_path, request_gpu_gres, expects_gres
+):
+    name_resolve_root = tmp_path / "name_resolve"
+    name_resolve_root.mkdir()
+    config = BaseExperimentConfig(
+        experiment_name="test_gpu_gres_request",
+        trial_name="test_generate_script",
+    )
+    config.cluster.n_gpus_per_node = 8
+    config.cluster.fileroot = str(tmp_path)
+    config.cluster.name_resolve.nfs_record_root = str(name_resolve_root)
+    scheduler = SlurmScheduler(exp_config=config)
+
+    spec = SchedulingSpec(
+        cpu=4,
+        gpu=1,
+        mem=1024,
+        request_gpu_gres=request_gpu_gres,
+    )
+
+    script = scheduler._generate_sbatch_script(
+        role="gpu_gres_test",
+        replicas=8,
+        nodes=1,
+        total_gpus=8,
+        cpus_per_task=4,
+        mem_per_task=1024,
+        schedulings=[spec],
+        nodelist=None,
+        exclude=None,
+    )
+
+    assert ("#SBATCH --gres=gpu:8" in script) is expects_gres
+    assert ("--gres=gpu:8" in script.split("srun", maxsplit=1)[1]) is expects_gres
+
+
 # ============================================================================
 # Colocation Tests
 # ============================================================================

--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 
+import areal.infra.controller.train_controller as train_controller_module
 from areal.api import (
     FinetuneSpec,
     ParallelStrategy,
@@ -487,6 +488,44 @@ class TestTrainControllerEdgeCases:
 
         # parallel_strategy should be set by constructor (from backend="fsdp:d4t2")
         assert train_controller.parallel_strategy is not None
+
+    def test_create_process_group_retries_port_in_use(
+        self, monkeypatch, train_controller, parallel_strategy
+    ):
+        ports = iter([12345, 12346])
+        init_methods = []
+
+        def fake_find_free_ports(count, exclude_ports=None):
+            assert count == 1
+            return [next(ports)]
+
+        def fake_init_process_group(*, backend, init_method, rank, world_size):
+            del backend, rank, world_size
+            init_methods.append(init_method)
+            if len(init_methods) == 1:
+                raise RuntimeError("EADDRINUSE: address already in use")
+
+        monkeypatch.setattr(
+            train_controller_module.dist, "is_initialized", lambda: False
+        )
+        monkeypatch.setattr(
+            train_controller_module.dist,
+            "init_process_group",
+            fake_init_process_group,
+        )
+        monkeypatch.setattr(
+            train_controller_module,
+            "find_free_ports",
+            fake_find_free_ports,
+        )
+
+        train_controller.create_process_group(parallel_strategy)
+
+        assert init_methods == [
+            "tcp://localhost:12345",
+            "tcp://localhost:12346",
+        ]
+        assert train_controller._own_process_group is True
 
     def test_method_chaining(self, train_controller, ft_spec):
         """Test that train() and eval() support method chaining."""

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -12,6 +12,8 @@ from areal.api.cli_args import AgentConfig, InferenceEngineConfig
 from areal.utils import stats_tracker
 from areal.v2.inference_service.controller.controller import (
     RolloutControllerV2,
+    _get_inference_base_gpu_id,
+    _prepare_inference_server_args,
 )
 from areal.v2.inference_service.controller.workflow import (
     InferenceServiceWorkflow,
@@ -78,6 +80,45 @@ class TestInferenceEngineConfigForInferenceService:
 
 
 # =============================================================================
+# RolloutControllerV2 — backend launch arguments
+
+
+def test_prepare_inference_server_args_strips_private_awex_sglang_controls():
+    args = _prepare_inference_server_args(
+        {
+            "model_path": "/tmp/model",
+            "awex_colocate_mode": True,
+            "awex_meta_server_addr": "127.0.0.1:12345",
+        },
+        "sglang",
+    )
+
+    assert args == {"model_path": "/tmp/model"}
+
+
+def test_prepare_inference_server_args_preserves_backend_specific_controls():
+    args = _prepare_inference_server_args(
+        {"awex_colocate_mode": True, "custom_flag": "value"},
+        "vllm",
+    )
+
+    assert args == {"awex_colocate_mode": True, "custom_flag": "value"}
+
+
+def test_inference_base_gpu_id_uses_worker_slot_on_each_node():
+    workers = [
+        MagicMock(ip="node-a"),
+        MagicMock(ip="node-a"),
+        MagicMock(ip="node-b"),
+        MagicMock(ip="node-b"),
+    ]
+
+    assert [
+        _get_inference_base_gpu_id(workers, index, gpus_per_worker=4)
+        for index in range(len(workers))
+    ] == [0, 4, 0, 4]
+
+
 # RolloutControllerV2 — workflow resolution helpers
 # =============================================================================
 

--- a/tests/v2/inference_service/test_data_proxy_pause.py
+++ b/tests/v2/inference_service/test_data_proxy_pause.py
@@ -125,6 +125,8 @@ async def app_client(config, mock_tokenizer, mock_areal_client):
 
     inf_bridge.pause = AsyncMock(side_effect=_mock_pause)
     inf_bridge.resume = AsyncMock(side_effect=_mock_resume)
+    inf_bridge.offload = AsyncMock()
+    inf_bridge.onload = AsyncMock()
 
     app.state.tokenizer = mock_tokenizer
     app.state.inf_bridge = inf_bridge
@@ -236,3 +238,25 @@ class TestPauseResumeEndpoints:
         resp = await client.get("/health")
         assert resp.status_code == 200
         assert resp.json()["paused"] is True
+
+    @pytest.mark.asyncio
+    async def test_release_memory_forwards_tags(self, app_client):
+        client, app, _ = app_client
+
+        resp = await client.post(
+            "/release_memory_occupation", json={"tags": ["kv_cache"]}
+        )
+
+        assert resp.status_code == 200
+        app.state.inf_bridge.offload.assert_awaited_once_with(tags=["kv_cache"])
+
+    @pytest.mark.asyncio
+    async def test_release_memory_rejects_non_list_tags(self, app_client):
+        client, app, _ = app_client
+
+        resp = await client.post(
+            "/release_memory_occupation", json={"tags": "kv_cache"}
+        )
+
+        assert resp.status_code == 400
+        app.state.inf_bridge.offload.assert_not_awaited()

--- a/tests/v2/inference_service/test_guard.py
+++ b/tests/v2/inference_service/test_guard.py
@@ -12,6 +12,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("torchdata")
+
+from areal.infra.rpc.guard import app as base_guard_app
 from areal.v2.inference_service.guard import app as guard_module
 from areal.v2.inference_service.guard.app import app, cleanup_forked_children
 
@@ -102,6 +105,26 @@ class TestAllocPorts:
             9005,
         }
 
+    @patch(f"{GUARD_APP}.find_free_ports")
+    def test_alloc_ports_uses_node_wide_reservations(
+        self, mock_find, client, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "AREAL_GUARD_PORT_REGISTRY", str(tmp_path / "guard_ports.json")
+        )
+        mock_find.side_effect = [[9101], [9102]]
+
+        resp = client.post("/alloc_ports", json={"count": 1})
+        assert resp.status_code == 200
+
+        guard_module._state.allocated_ports = set()
+        resp = client.post("/alloc_ports", json={"count": 1})
+        assert resp.status_code == 200
+
+        _, kwargs = mock_find.call_args
+        assert 9101 in kwargs.get("exclude_ports", set())
+        assert base_guard_app._port_registry_path().name == "guard_ports.json"
+
     def test_alloc_ports_missing_count(self, client):
         resp = client.post("/alloc_ports", json={})
         assert resp.status_code == 400
@@ -188,6 +211,24 @@ class TestFork:
         call_kwargs = mock_run.call_args
         child_env = call_kwargs[1]["env"]
         assert child_env["MY_VAR"] == "my_value"
+
+    @patch(f"{GUARD_APP}.run_with_streaming_logs")
+    def test_fork_uses_worker_specific_log_file(self, mock_run, client, tmp_path):
+        mock_run.return_value = _make_mock_process()
+        guard_module._state.fileroot = str(tmp_path)
+
+        resp = client.post(
+            "/fork",
+            json={
+                "role": "train-worker",
+                "worker_index": 3,
+                "raw_cmd": ["echo", "hello"],
+            },
+        )
+
+        assert resp.status_code == 200
+        log_file = mock_run.call_args.args[1]
+        assert log_file.name == "train-worker-3.log"
 
 
 class TestForkErrorHandling:

--- a/tests/v2/inference_service/test_inf_bridge.py
+++ b/tests/v2/inference_service/test_inf_bridge.py
@@ -67,6 +67,7 @@ def _make_request(
     n_samples: int = 1,
     greedy: bool = False,
     temperature: float = 1.0,
+    top_k: int | None = None,
     metadata: dict[str, Any] | None = None,
     lora_name: str | None = None,
 ) -> ModelRequest:
@@ -80,6 +81,8 @@ def _make_request(
         greedy=greedy,
         temperature=temperature,
     )
+    if top_k is not None:
+        gconfig.top_k = top_k
     if lora_name is not None:
         gconfig.lora_name = lora_name
     return ModelRequest(
@@ -340,6 +343,24 @@ class TestInfBridge:
 
         assert resp.output_versions == [7]
 
+    @pytest.mark.asyncio
+    async def test_output_versions_use_send_time_version(self):
+        """A response is stamped with the version used to send that request."""
+        sglang_resp = _make_sglang_response([(-0.5, 100)], "stop")
+
+        bridge = _make_bridge(version=7)
+
+        async def _send_and_advance(*_args, **_kwargs):
+            bridge.set_version(8)
+            return sglang_resp
+
+        bridge._send_request = AsyncMock(side_effect=_send_and_advance)
+
+        req = _make_request(input_ids=[1, 2, 3])
+        resp = await bridge.agenerate(req)
+
+        assert resp.output_versions == [7]
+
     # -- 10. n_samples validation ------------------------------------------------
 
     @pytest.mark.asyncio
@@ -413,7 +434,21 @@ class TestInfBridge:
 
         assert calls[0]["params"]["temperature"] == 0.0
 
-    # -- 14. length stop reason passthrough --------------------------------------
+    # -- 14. SGLang top_k all-vocab sentinel ------------------------------------
+
+    def test_sglang_large_top_k_maps_to_all_vocab_sentinel(self):
+        """AReaL's large top_k sentinel maps to SGLang's -1 all-vocab value."""
+        backend = SGLangBridgeBackend()
+
+        req = _make_request(input_ids=[1, 2, 3], top_k=100_000_000)
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+        assert http_req.payload["sampling_params"]["top_k"] == -1
+
+        req = _make_request(input_ids=[1, 2, 3], top_k=128)
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+        assert http_req.payload["sampling_params"]["top_k"] == 128
+
+    # -- 15. length stop reason passthrough --------------------------------------
 
     @pytest.mark.asyncio
     async def test_length_stop_reason_passthrough(self):

--- a/tests/v2/training_service/fake_train_engine.py
+++ b/tests/v2/training_service/fake_train_engine.py
@@ -34,7 +34,9 @@ class FakeTrainEngine(TrainEngine):
         self._lr_step_calls = 0
         self._last_saved_meta: Any = None
         self._last_loaded_meta: Any = None
+        self._last_awex_meta_server_addr: str | None = None
         self._init_kwargs = dict(kwargs)
+        self._is_dp_head = bool(kwargs.get("is_dp_head", True))
 
     def create_process_group(self, parallel_strategy=None):
         return None
@@ -59,7 +61,7 @@ class FakeTrainEngine(TrainEngine):
         return 0
 
     def is_data_parallel_head(self) -> bool:
-        return True
+        return self._is_dp_head
 
     @property
     def context_and_model_parallel_group(self):
@@ -196,6 +198,9 @@ class FakeTrainEngine(TrainEngine):
 
     def offload(self) -> None:
         self._offloaded = True
+
+    def init_awex_adapter(self, meta_server_addr: str | None = None) -> None:
+        self._last_awex_meta_server_addr = meta_server_addr
 
     def get_device_stats(self):
         return {"device": "cpu"}

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -72,6 +72,18 @@ class _FakeAsyncClient:
 
 
 class TestGatewayTrainControllerInitialization:
+    def test_init_awex_adapter_forwards_meta_server_address(self):
+        controller = _make_controller()
+        controller._worker_addrs = ["http://worker-0:18000", "http://worker-1:18000"]
+
+        with patch("requests.post") as mock_post:
+            controller.init_awex_adapter("127.0.0.1:12345")
+
+        assert mock_post.call_count == 2
+        for call in mock_post.call_args_list:
+            assert call.args[0].endswith("/awex/init_adapter")
+            assert call.kwargs["json"] == {"meta_server_addr": "127.0.0.1:12345"}
+
     @pytest.mark.asyncio
     async def test_async_initialize_offloads_scheduler_and_uses_async_helpers(self):
         worker0 = MagicMock(ip="127.0.0.1", worker_ports=[18000], id="guard-0")
@@ -162,3 +174,30 @@ class TestGatewayTrainControllerInitialization:
         assert controller._gateway_addr == "http://127.0.0.1:18080"
         assert controller.api_key is not None
         assert controller.api_key.startswith("ak-train-role-")
+
+
+def test_prepare_batch_forwards_partial_group_error_policy():
+    controller = _make_controller()
+    controller.rollout = MagicMock()
+    expected = [object()]
+    controller.rollout.prepare_batch.return_value = expected
+
+    result = controller.prepare_batch(
+        dataloader=object(),
+        workflow=object(),
+        workflow_kwargs={"key": "value"},
+        keep_partial_group_on_error=True,
+    )
+
+    assert result is expected
+    controller.rollout.prepare_batch.assert_called_once_with(
+        dataloader=controller.rollout.prepare_batch.call_args.kwargs["dataloader"],
+        workflow=controller.rollout.prepare_batch.call_args.kwargs["workflow"],
+        workflow_kwargs={"key": "value"},
+        should_accept_fn=None,
+        group_size=1,
+        dynamic_bs=False,
+        reward_normalization=False,
+        drop_incomplete_group=False,
+        keep_partial_group_on_error=True,
+    )

--- a/tests/v2/training_service/test_gateway_unit.py
+++ b/tests/v2/training_service/test_gateway_unit.py
@@ -255,6 +255,34 @@ class TestGatewayRoutingAndForwarding:
         assert resp.json()["status"] == "success"
 
     @pytest.mark.asyncio
+    @patch(f"{MODULE}.streaming.forward_request", new_callable=AsyncMock)
+    @patch(f"{MODULE}.streaming.query_router", new_callable=AsyncMock)
+    async def test_init_awex_adapter_forwards_response(
+        self,
+        mock_query_router,
+        mock_forward_request,
+        client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward_request.return_value = httpx.Response(
+            200,
+            json={"status": "success", "result": None},
+        )
+
+        resp = await client.post(
+            "/init_awex_adapter",
+            json={"args": [], "kwargs": {"meta_server_addr": "127.0.0.1:12345"}},
+            headers={"Authorization": f"Bearer {SESSION_KEY}"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+        mock_forward_request.assert_awaited_once()
+        assert mock_forward_request.await_args.args[0] == (
+            f"{WORKER_ADDR}/init_awex_adapter"
+        )
+
+    @pytest.mark.asyncio
     @patch(f"{MODULE}.streaming.query_router", new_callable=AsyncMock)
     async def test_get_version_uses_shared_clients(
         self,

--- a/tests/v2/training_service/test_worker_unit.py
+++ b/tests/v2/training_service/test_worker_unit.py
@@ -107,6 +107,34 @@ class TestWorkerEndpoints:
         assert isinstance(result, dict)
         assert "total" in result
 
+    def test_init_awex_adapter_after_create_engine(self, client):
+        create_resp = client.post(
+            "/create_engine",
+            json={
+                "engine_class": "tests.v2.training_service.fake_train_engine.FakeTrainEngine",
+                "init_args": serialize_value([]),
+                "init_kwargs": serialize_value({"world_size": 1}),
+            },
+        )
+        assert create_resp.status_code == 200
+
+        init_resp = client.post(
+            "/init_awex_adapter",
+            json={
+                "args": serialize_value([]),
+                "kwargs": serialize_value({"meta_server_addr": "127.0.0.1:12345"}),
+            },
+        )
+
+        assert init_resp.status_code == 200
+        assert deserialize_value(init_resp.get_json()["result"]) is None
+
+        awex_resp = client.post(
+            "/awex/init_adapter",
+            json={"meta_server_addr": "127.0.0.1:12345"},
+        )
+        assert awex_resp.status_code == 200
+
     def test_topology_after_create_engine(self, client):
         create_resp = client.post(
             "/create_engine",
@@ -191,6 +219,38 @@ class TestWorkerEndpoints:
         result = deserialize_value(forward_resp.get_json()["result"])
         assert isinstance(result, dict)
         assert result["output_seqlens"] == [3]
+
+    def test_compute_route_skips_non_dp_head_result_after_initialize(self, client):
+        create_resp = client.post(
+            "/create_engine",
+            json={
+                "engine_class": "tests.v2.training_service.fake_train_engine.FakeTrainEngine",
+                "init_args": serialize_value([]),
+                "init_kwargs": serialize_value({"is_dp_head": False}),
+            },
+        )
+        assert create_resp.status_code == 200
+
+        init_resp = client.post(
+            "/initialize",
+            json={
+                "args": serialize_value([]),
+                "kwargs": serialize_value({"addr": None, "ft_spec": None}),
+            },
+        )
+        assert init_resp.status_code == 200
+
+        train_resp = client.post(
+            "/train_batch",
+            json={
+                "args": serialize_value(
+                    [{"token_ids": [1, 2, 3], "metadata": {"weight": 2.0}}]
+                ),
+                "kwargs": serialize_value({}),
+            },
+        )
+        assert train_resp.status_code == 200
+        assert deserialize_value(train_resp.get_json()["result"]) is None
 
     def test_sft_route_succeeds_without_distributed_group_for_single_worker(
         self, client

--- a/tests/v2/weight_update/test_gateway_metadata.py
+++ b/tests/v2/weight_update/test_gateway_metadata.py
@@ -1,0 +1,67 @@
+import pytest
+
+pytest.importorskip("fastapi")
+
+from areal.v2.weight_update.gateway.app import _merge_meta_by_name
+
+
+def _serialized_shard(rank: int, offset: int, length: int) -> dict:
+    return {
+        "type": "dataclass",
+        "class_path": "awex.meta.weight_meta.ParameterShardMeta",
+        "data": {
+            "name": "model.layers.0.mlp.gate_proj.weight",
+            "global_rank": rank,
+            "global_offset": [offset],
+            "shape": [length],
+            "dtype": {"type": "torch_dtype", "value": "torch.float32"},
+            "sharding_type": {
+                "type": "enum",
+                "class_path": "awex.sharding.param_sharding.ShardingType",
+                "value": "TP_SHARDING",
+            },
+            "sharding_dim": 0,
+            "num_shards": 4,
+        },
+    }
+
+
+def _serialized_param(shard: dict) -> dict:
+    return {
+        "type": "dataclass",
+        "class_path": "awex.meta.weight_meta.ParameterMeta",
+        "data": {
+            "name": "model.layers.0.mlp.gate_proj.weight",
+            "global_numel": 16,
+            "global_shape": [16],
+            "dtype": {"type": "torch_dtype", "value": "torch.float32"},
+            "shards": [shard],
+            "replicas": [
+                {
+                    "type": "dataclass",
+                    "class_path": "awex.meta.weight_meta.ParameterReplicaMeta",
+                    "data": {"shards": [shard]},
+                }
+            ],
+        },
+    }
+
+
+def test_merge_inference_meta_dedupes_engines_and_keeps_tp_shards():
+    # Two SGLang engines report the same per-engine TP metadata. The gateway
+    # should keep one logical engine with all TP shards; TransferPlanBuilder
+    # expands it across engines via num_infer_engines later.
+    metas = []
+    for _engine in range(2):
+        for rank in range(4):
+            metas.append(_serialized_param(_serialized_shard(rank, rank * 4, 4)))
+
+    merged = _merge_meta_by_name(metas, "inference")
+
+    assert len(merged) == 1
+    data = merged[0]["data"]
+    assert sorted(s["data"]["global_rank"] for s in data["shards"]) == [0, 1, 2, 3]
+    assert len(data["shards"]) == 4
+    replica_shards = data["replicas"][0]["data"]["shards"]
+    assert sorted(s["data"]["global_rank"] for s in replica_shards) == [0, 1, 2, 3]
+    assert len(replica_shards) == 4

--- a/tests/v2/weight_update/test_megatron_adapter_optimizer.py
+++ b/tests/v2/weight_update/test_megatron_adapter_optimizer.py
@@ -1,0 +1,197 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("awex.util.tensor_util")
+pytest.importorskip("awex.meta.weight_meta")
+pytest.importorskip("awex.sharding.param_sharding")
+pytest.importorskip("awex.transfer.transfer_plan")
+
+from awex.util.tensor_util import reconstruct_tensors_from_groups
+
+from areal.v2.weight_update.awex.megatron_adapter import (
+    AwexMegatronAdapter,
+    _install_awex_qwen_converter,
+)
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    ["Qwen2ForCausalLM", "Qwen3ForCausalLM", "Qwen3MoeForCausalLM"],
+)
+def test_qwen_converter_uses_unfused_hf_attention_names(architecture):
+    from awex.models.registry import ModelRegistry
+
+    original = ModelRegistry.models.get(architecture)
+    try:
+        _install_awex_qwen_converter(architecture)
+        assert architecture in ModelRegistry.models
+        model_config = ModelRegistry.get_model_config(architecture)
+        converter_cls = (
+            model_config["mcore_converter"]
+            if isinstance(model_config, dict)
+            else model_config.mcore_converter
+        )
+        converter = object.__new__(converter_cls)
+
+        assert not converter._fuse_qkv("self_attention.linear_qkv.weight")
+        assert (
+            converter._normalize_attn_name("self_attn.o_proj.weight")
+            == "self_attn.o_proj.weight"
+        )
+    finally:
+        if original is None:
+            ModelRegistry.models.pop(architecture, None)
+        else:
+            ModelRegistry.models[architecture] = original
+
+
+def test_get_weight_metadata_restores_legacy_offloaded_weights(monkeypatch):
+    calls = []
+
+    class _LegacyAdapter:
+        _released_tags = {"weights", "optimizer"}
+
+        def resume_memory(self, tags):
+            calls.append(("resume", tags))
+
+        def release_memory(self, tags):
+            calls.append(("release", tags))
+
+    adapter = object.__new__(AwexMegatronAdapter)
+    adapter._engine = SimpleNamespace(_awex_adapter=_LegacyAdapter())
+    adapter._released_tags = set()
+    adapter._awex_train_meta = None
+    expected = [object()]
+    monkeypatch.setattr(adapter, "_ensure_awex_converter", lambda _: (expected, None))
+
+    assert adapter.get_weight_metadata({"model": "test"}) is expected
+    assert calls == [("resume", ["weights"]), ("release", ["weights"])]
+
+
+class _BaseOptimizer:
+    def __init__(self):
+        self.param = object()
+        self.state = {self.param: {"step": torch.tensor(1.0)}}
+
+
+class _OptimizerWrapper:
+    def __init__(self, base):
+        self.optimizer = base
+
+
+class _AssertingChainedOptimizer:
+    def __init__(self, children):
+        self.chained_optimizers = children
+
+    @property
+    def optimizer(self):
+        raise AssertionError(
+            "ChainedOptimizer has more than one optimizer when accessing self.optimizer"
+        )
+
+
+class _Engine:
+    def __init__(self, optimizer):
+        self.optimizer = optimizer
+        self.device = torch.device("cpu")
+
+
+def test_optimizer_state_offload_flattens_chained_optimizer_without_optimizer_attr(
+    monkeypatch,
+):
+    child_a = _OptimizerWrapper(_BaseOptimizer())
+    child_b = _OptimizerWrapper(_BaseOptimizer())
+    chained = _AssertingChainedOptimizer([child_a, child_b])
+    adapter = AwexMegatronAdapter(_Engine(chained))
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    assert adapter._get_inner_optimizers() == [child_a, child_b]
+
+    adapter._offload_optimizer_states()
+    adapter._reload_optimizer_states()
+    assert adapter._offloaded_optimizer_states == {}
+
+
+def test_colocate_full_ipc_grouping_owns_storage_and_reconstructs_order():
+    contiguous = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    noncontiguous = torch.arange(12, dtype=torch.float32).reshape(3, 4).t()
+    adapter = object.__new__(AwexMegatronAdapter)
+    adapter._live_module_storage_ptrs = lambda: {
+        contiguous.untyped_storage().data_ptr()
+    }
+
+    groups, metadata = adapter._full_tensors_for_ipc([contiguous, noncontiguous])
+
+    live_storage = contiguous.untyped_storage().data_ptr()
+    assert all(g.untyped_storage().data_ptr() != live_storage for g in groups)
+    assert all(g.is_contiguous() for g in groups)
+
+    reconstructed = reconstruct_tensors_from_groups(groups, metadata)
+    assert torch.equal(reconstructed[0], contiguous)
+    assert torch.equal(reconstructed[1], noncontiguous)
+
+
+def test_delta_sync_full_reason_promotes_peer_full_sync(monkeypatch):
+    adapter = object.__new__(AwexMegatronAdapter)
+
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.is_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.is_initialized",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.get_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.torch.cuda.is_available",
+        lambda: False,
+    )
+
+    def fake_all_reduce(tensor, op):
+        del op
+        tensor.fill_(1)
+
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.all_reduce",
+        fake_all_reduce,
+    )
+
+    assert adapter._delta_sync_full_reason(None, version=4) == "global_full_sync"
+
+
+def test_delta_sync_full_reason_keeps_global_delta(monkeypatch):
+    adapter = object.__new__(AwexMegatronAdapter)
+
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.is_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.is_initialized",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.get_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.torch.cuda.is_available",
+        lambda: False,
+    )
+
+    def fake_all_reduce(tensor, op):
+        del op
+        assert int(tensor.item()) == 0
+
+    monkeypatch.setattr(
+        "areal.v2.weight_update.awex.megatron_adapter.dist.all_reduce",
+        fake_all_reduce,
+    )
+
+    assert adapter._delta_sync_full_reason(None, version=4) is None

--- a/tests/v2/weight_update/test_nccl_integration.py
+++ b/tests/v2/weight_update/test_nccl_integration.py
@@ -348,6 +348,45 @@ def _validate_weight_update_correctness_megatron(
     )
 
 
+def _resume_awex_memory(
+    train_worker_urls: list[str], tags: list[str], timeout: float = 120.0
+) -> None:
+    for url in train_worker_urls:
+        resp = httpx.post(
+            f"{url}/awex/resume_memory",
+            json={"tags": tags},
+            timeout=timeout,
+        )
+        assert resp.status_code == 200, (
+            f"resume_memory({tags}) failed on {url}: {resp.text}"
+        )
+
+
+def _run_minimal_sft_train_step(train_ctrl) -> None:
+    """Run one real Megatron optimizer step through the training service."""
+    from areal.infra.rpc.serialization import serialize_value
+
+    batch: list[dict[str, torch.Tensor]] = []
+    seq_len = 16
+    for i in range(4):
+        input_ids = (torch.arange(seq_len, dtype=torch.long).unsqueeze(0) + i) % 100
+        batch.append(
+            {
+                "input_ids": input_ids,
+                "attention_mask": torch.ones((1, seq_len), dtype=torch.bool),
+                "loss_mask": torch.ones((1, seq_len), dtype=torch.bool),
+            }
+        )
+
+    payload = {
+        "args": serialize_value([batch]),
+        "kwargs": serialize_value({}),
+    }
+    print("[inversion-smoke] Running one SFT train step before version 2 ...")
+    train_ctrl._gateway_post_result("/sft/train", payload)
+    print("[inversion-smoke] SFT train step completed; AdamW state should exist")
+
+
 @pytest.mark.multi_gpu
 @pytest.mark.slow
 @pytest.mark.sglang
@@ -983,6 +1022,7 @@ def _run_megatron_colocate_e2e(
         inf_ctrl.initialize(
             role="rollout",
             server_args={"model_path": model_path, "mem_fraction_static": 0.7},
+            wait=True,
         )
         inf_worker_urls = list(inf_ctrl._inf_addrs)
 
@@ -997,6 +1037,7 @@ def _run_megatron_colocate_e2e(
             ft_spec=FinetuneSpec(
                 total_train_epochs=1, dataset_size=100, train_batch_size=2
             ),
+            wait=True,
         )
         train_worker_urls = list(train_ctrl._worker_addrs)
 
@@ -1079,8 +1120,8 @@ def test_awex_megatron_colocate_dp_multi_version_e2e(tmp_path_factory):
     """Colocated weight update with multiple sequential versions.
 
     Verifies that the colocated IPC path correctly handles version
-    sequencing: version 1 → version 2.  The KV store keys include
-    the version number, so each round must produce fresh IPC handles.
+    sequencing: version 1 → train step → version 2. The train step creates
+    AdamW moment state so inversion mode can exercise the real mask path.
     """
     n_gpus = 2
     if current_platform.device_count() < n_gpus:
@@ -1152,6 +1193,7 @@ def test_awex_megatron_colocate_dp_multi_version_e2e(tmp_path_factory):
         inf_ctrl.initialize(
             role="rollout",
             server_args={"model_path": model_path, "mem_fraction_static": 0.7},
+            wait=True,
         )
         inf_worker_urls = list(inf_ctrl._inf_addrs)
 
@@ -1164,6 +1206,7 @@ def test_awex_megatron_colocate_dp_multi_version_e2e(tmp_path_factory):
             ft_spec=FinetuneSpec(
                 total_train_epochs=1, dataset_size=100, train_batch_size=2
             ),
+            wait=True,
         )
         train_worker_urls = list(train_ctrl._worker_addrs)
 
@@ -1184,6 +1227,11 @@ def test_awex_megatron_colocate_dp_multi_version_e2e(tmp_path_factory):
         result1 = wu_ctrl.update_weights(version=1)
         assert result1.status == "ok"
         assert result1.version == 1
+
+        # Create real post-v1 optimizer state before v2. The v1 colocate
+        # transfer offloads train weights at the end, so bring them back first.
+        _resume_awex_memory(train_worker_urls, ["weights", "optimizer"])
+        _run_minimal_sft_train_step(train_ctrl)
 
         # Version 2
         result2 = wu_ctrl.update_weights(version=2)

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,9 @@ cli = [
     { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "colorlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+delta = [
+    { name = "delta-transfer-engine", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 cuda = [
     { name = "flash-linear-attention", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "kernels", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -491,6 +494,7 @@ requires-dist = [
     { name = "cookiecutter", specifier = ">2.1.1" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.167.0" },
+    { name = "delta-transfer-engine", marker = "extra == 'delta'", git = "https://github.com/areal-project/AReaL-DTE.git?rev=6b2bc13e2b626d2677e9997f159b5a3269c97e3e" },
     { name = "distro-info", specifier = ">=1.0" },
     { name = "einops" },
     { name = "fastapi", specifier = ">=0.115.12" },
@@ -579,7 +583,7 @@ requires-dist = [
     { name = "word2number" },
     { name = "zstandard" },
 ]
-provides-extras = ["sglang", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli"]
+provides-extras = ["sglang", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli", "delta"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1417,6 +1421,16 @@ dependencies = [
     { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/61/5ea1c63b139fe7530b196b68ce0bdffa9cde79882e527dcecae58bd6c770/deepspeed-0.18.9.tar.gz", hash = "sha256:ee4818dcf342794f74f429a0aeebef90291ec808fa82609c5140c23e665c4011", size = 1663466, upload-time = "2026-03-30T16:43:16.566Z" }
+
+[[package]]
+name = "delta-transfer-engine"
+version = "0.0.1"
+source = { git = "https://github.com/areal-project/AReaL-DTE.git?rev=6b2bc13e2b626d2677e9997f159b5a3269c97e3e#6b2bc13e2b626d2677e9997f159b5a3269c97e3e" }
+dependencies = [
+    { name = "torch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.9.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+]
 
 [[package]]
 name = "deprecated"

--- a/uv.vllm.lock
+++ b/uv.vllm.lock
@@ -452,6 +452,9 @@ cli = [
     { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "colorlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+delta = [
+    { name = "delta-transfer-engine", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 cuda = [
     { name = "flash-linear-attention", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "kernels", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -537,6 +540,7 @@ requires-dist = [
     { name = "cookiecutter", specifier = ">2.1.1" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.167.0" },
+    { name = "delta-transfer-engine", marker = "extra == 'delta'", git = "https://github.com/areal-project/AReaL-DTE.git?rev=6b2bc13e2b626d2677e9997f159b5a3269c97e3e" },
     { name = "distro-info", specifier = ">=1.0" },
     { name = "einops" },
     { name = "fastapi", specifier = ">=0.115.12" },
@@ -625,7 +629,7 @@ requires-dist = [
     { name = "word2number" },
     { name = "zstandard" },
 ]
-provides-extras = ["vllm", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli"]
+provides-extras = ["vllm", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli", "delta"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1604,6 +1608,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/5c/f4c2eb8d481fe8784a7e2331fbaab820079c06676185fa6d2177b386d590/diffusers-0.37.1.tar.gz", hash = "sha256:2346c21f77f835f273b7aacbaada1c34a596a3a2cc6ddc99d149efcd0ec298fa", size = 4135139, upload-time = "2026-03-25T08:04:04.515Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl", hash = "sha256:0537c0b28cb53cf39d6195489bcf8f833986df556c10f5e28ab7427b86fc8b90", size = 5001536, upload-time = "2026-03-25T08:04:02.385Z" },
+]
+
+[[package]]
+name = "delta-transfer-engine"
+version = "0.0.1"
+source = { git = "https://github.com/areal-project/AReaL-DTE.git?rev=6b2bc13e2b626d2677e9997f159b5a3269c97e3e#6b2bc13e2b626d2677e9997f159b5a3269c97e3e" }
+dependencies = [
+    { name = "torch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "torch", version = "2.10.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add DTE-backed colocated weight transfer on top of the upstream AWEX runtime.
The implementation supports full transfer and incremental delta transfer using
snapshot or AdamW-based change detection for Megatron-to-SGLang updates.

Key changes:

- Integrate DTE encoding into the real AWEX Megatron send path.
- Preserve versioned metadata and inference-to-training rank mapping.
- Keep rollout weights valid across tagged offload/resume transitions.
- Support Qwen2, Qwen3, and Qwen3-MoE conversion paths.
- Pin the public `areal-project/AReaL-DTE` dependency in both package variants.
- Add compact GSM8K full/delta examples and focused regression tests.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the Contributing Guide
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Validation

- Focused Slurm/SIF unit tests: `120 passed, 2 skipped`.
- Qwen3-30B-A3B two-step Slurm E2E before the final upstream rebase:
  - v1 full synchronization completed.
  - v2 AdamW delta changed nonzero elements and completed inference update.
  - Generated trajectories were structurally valid and training completed.
- A post-rebase E2E was submitted, but its actor allocation remained pending with
  a scheduler estimate of September 6, 2026. The parent and child jobs were
  cancelled individually to avoid leaked jobs.

Pre-commit formatting, Ruff, YAML, pyproject consistency, generated CLI docs,
and license checks pass. The lock regeneration hook could not complete because
the compute node timed out while accessing the PyTorch wheel metadata endpoint.
Both package variants and lockfiles include the pinned public DTE revision.

## Review Fixes

- Use one AWEX MetaServer and one startup offload path for both controller versions.
- Forward the MetaServer address into v2 `WeightUpdateMeta`.
- Save v2 AWEX checkpoints before weight transfer, matching the memory-safe v1 order.
- Add regression coverage for transport selection, startup initialization, and checkpoint timing.

## Risk Areas

- Colocated actor/rollout memory state transitions.
- Megatron parameter conversion and MoE rank mapping.
- Delta base lifetime across SGLang release/resume cycles.
- Compatibility between legacy AWEX entrypoints and the upstream AWEX package.
