### PR TITLE
fix(infra): stabilize inference worker routing and caches

### DIFF
--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -432,6 +432,7 @@ class RolloutControllerV2:
                 inf_workers,
                 dp_size,
                 nnodes_per_instance,
+                dict(inf_spec.env_vars),
                 server_args,
             )
         logger.info("Inference servers: %s", self._inf_addrs)
@@ -549,6 +550,7 @@ class RolloutControllerV2:
         inf_workers: list,
         dp_size: int,
         nnodes_per_instance: int,
+        worker_env: dict[str, str],
         server_args: dict[str, Any] | None,
     ) -> None:
         if inf_backend == "sglang":
@@ -615,6 +617,30 @@ class RolloutControllerV2:
                     "worker_index": group_idx * nnodes_per_instance + node_rank,
                     "raw_cmd": cmd,
                 }
+                if inf_backend == "sglang":
+                    from areal.infra.utils.launcher import (
+                        TRITON_CACHE_PATH as _TRITON_CACHE,
+                    )
+
+                    cache_suffix = (
+                        f"inf-server-{fork_payload['worker_index']}-{uuid.uuid4()}"
+                    )
+                    triton_cache_dir = worker_env.get(
+                        "TRITON_CACHE_DIR",
+                        os.environ.get("TRITON_CACHE_DIR", _TRITON_CACHE),
+                    )
+                    triton_cache_path = worker_env.get(
+                        "TRITON_CACHE_PATH",
+                        os.environ.get("TRITON_CACHE_PATH", triton_cache_dir),
+                    )
+                    fork_payload["env"] = {
+                        "TRITON_CACHE_DIR": os.path.join(
+                            triton_cache_dir, cache_suffix
+                        ),
+                        "TRITON_CACHE_PATH": os.path.join(
+                            triton_cache_path, cache_suffix
+                        ),
+                    }
                 if inf_backend == "vllm":
                     from areal.infra.utils.launcher import (
                         TRITON_CACHE_PATH as _TRITON_CACHE,

--- a/areal/v2/inference_service/router/app.py
+++ b/areal/v2/inference_service/router/app.py
@@ -318,8 +318,12 @@ def create_app(config: RouterConfig) -> FastAPI:
         def _filter_by_model(workers: list, addrs: list[str] | None) -> list:
             if addrs is None:
                 return workers
-            addr_set = set(addrs)
-            return [w for w in workers if w.worker_addr in addr_set]
+            workers_by_addr = {w.worker_addr: w for w in workers}
+            return [
+                workers_by_addr[addr]
+                for addr in dict.fromkeys(addrs)
+                if addr in workers_by_addr
+            ]
 
         # Step B: session_id lookup
         if body.session_id is not None:

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -733,9 +733,12 @@ class TestMultiNodeConfig:
         assert len(data_proxy_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_async_initialize_multinode_fork_path(self):
+    async def test_async_initialize_multinode_fork_path(self, monkeypatch):
         """Exercise the full multi-node fork path (server_infos=None)."""
         from areal.api.cli_args import SchedulingSpec
+
+        monkeypatch.setenv("TRITON_CACHE_DIR", "/tmp/controller-triton-dir")
+        monkeypatch.setenv("TRITON_CACHE_PATH", "/tmp/controller-triton-path")
 
         worker0 = MagicMock()
         worker0.ip = "10.0.0.1"
@@ -823,6 +826,19 @@ class TestMultiNodeConfig:
         assert fork_calls[0]["worker_index"] == 0
         assert fork_calls[1]["role"] == "inf-server"
         assert fork_calls[1]["worker_index"] == 1
+
+        cache_dirs = [fc["env"]["TRITON_CACHE_DIR"] for fc in fork_calls]
+        cache_paths = [fc["env"]["TRITON_CACHE_PATH"] for fc in fork_calls]
+        assert all(
+            path.startswith("/tmp/controller-triton-dir/inf-server-")
+            for path in cache_dirs
+        )
+        assert all(
+            path.startswith("/tmp/controller-triton-path/inf-server-")
+            for path in cache_paths
+        )
+        assert len(set(cache_dirs)) == 2
+        assert len(set(cache_paths)) == 2
 
         # Verify dist_init_addr propagated to fork commands
         for fc in fork_calls:

--- a/tests/v2/inference_service/test_router.py
+++ b/tests/v2/inference_service/test_router.py
@@ -425,6 +425,105 @@ class TestRouterEndpoints:
 
         assert addr1 == addr2
 
+    @pytest.mark.asyncio
+    async def test_route_model_preserves_model_address_order(self, client):
+        """Model routing follows logical DP order, not registration arrival order."""
+        for worker_addr in [WORKER_2, WORKER_1]:
+            resp = await client.post(
+                "/register",
+                json={"worker_addr": worker_addr},
+                headers=admin_headers(),
+            )
+            assert resp.status_code == 200
+
+        register_model = await client.post(
+            "/register_model",
+            json={
+                "model": "test-model",
+                "data_proxy_addrs": [WORKER_1, WORKER_2],
+            },
+            headers=admin_headers(),
+        )
+        assert register_model.status_code == 200
+
+        routed = []
+        for _ in range(2):
+            resp = await client.post(
+                "/route",
+                json={"model": "test-model"},
+                headers=admin_headers(),
+            )
+            assert resp.status_code == 200
+            routed.append(resp.json()["worker_addr"])
+
+        assert routed == [WORKER_1, WORKER_2]
+
+    @pytest.mark.asyncio
+    async def test_route_admin_key_uses_model_order_before_sticky_pin(self, client):
+        """The admin session pins the first logical model worker it selects."""
+        for worker_addr in [WORKER_2, WORKER_1]:
+            resp = await client.post(
+                "/register",
+                json={"worker_addr": worker_addr},
+                headers=admin_headers(),
+            )
+            assert resp.status_code == 200
+
+        register_model = await client.post(
+            "/register_model",
+            json={
+                "model": "test-model",
+                "data_proxy_addrs": [WORKER_1, WORKER_2],
+            },
+            headers=admin_headers(),
+        )
+        assert register_model.status_code == 200
+
+        routed = []
+        for _ in range(2):
+            resp = await client.post(
+                "/route",
+                json={"api_key": ADMIN_KEY, "path": "/rl/start_session"},
+                headers=admin_headers(),
+            )
+            assert resp.status_code == 200
+            routed.append(resp.json()["worker_addr"])
+
+        assert routed == [WORKER_1, WORKER_1]
+
+    @pytest.mark.asyncio
+    async def test_route_model_deduplicates_model_addresses(self, client):
+        """Duplicate model addresses do not change round-robin weighting."""
+        for worker_addr in [WORKER_1, WORKER_2]:
+            resp = await client.post(
+                "/register",
+                json={"worker_addr": worker_addr},
+                headers=admin_headers(),
+            )
+            assert resp.status_code == 200
+
+        register_model = await client.post(
+            "/register_model",
+            json={
+                "model": "test-model",
+                "data_proxy_addrs": [WORKER_1, WORKER_1, WORKER_2],
+            },
+            headers=admin_headers(),
+        )
+        assert register_model.status_code == 200
+
+        routed = []
+        for _ in range(3):
+            resp = await client.post(
+                "/route",
+                json={"model": "test-model"},
+                headers=admin_headers(),
+            )
+            assert resp.status_code == 200
+            routed.append(resp.json()["worker_addr"])
+
+        assert routed == [WORKER_1, WORKER_2, WORKER_1]
+
     # ----- /route — session key -----
 
     @pytest.mark.asyncio


### PR DESCRIPTION
  ## Description

  Stabilize inference worker routing and isolate SGLang Triton caches.

  Data proxies register concurrently, so their HTTP registration order can differ
  from `ModelInfo.data_proxy_addrs`. The router previously retained registration
  order when filtering workers, making model-scoped round-robin routing depend on
  HTTP arrival timing.

  Additionally, multiple SGLang InfServer processes forked from the same worker
  inherited the same Triton cache directory. Concurrent servers could therefore
  compile and load the same cache entries.

  This PR:

  - rebuilds model-scoped Router candidates in `data_proxy_addrs` order;
  - skips unavailable workers and deduplicates repeated model addresses;
  - assigns every SGLang InfServer fork an isolated cache directory:

    `<cache-root>/inf-server-<worker-index>-<uuid>/`;

  - isolates both `TRITON_CACHE_DIR` and `TRITON_CACHE_PATH`;
  - preserves the existing controller/launcher-to-worker cache-root precedence;
  - leaves the existing vLLM cache behavior unchanged.

  This PR does not modify scheduler environment precedence, weight transfer,
  AWEX, recovery, NCCL, health checks, sticky-session semantics, or routing
  strategy.

  ## Related Issue

  N/A — discovered while investigating inference routing reproducibility and
  concurrent Triton cache initialization.

  ## Type of Change

  - [x] Bug fix
  - [x] Test coverage improvement
  - [ ] Breaking change
  - [ ] New feature
  - [ ] Documentation update

  ## Verification

  Targeted static checks passed:

  - pre-commit hooks
  - Ruff lint and formatting
  - `git diff --check`
  - Python compilation

  Slurm CPU + training SIF regression tests:

  ```text
  tests/v2/inference_service/test_controller.py
  tests/v2/inference_service/test_router.py

  91 passed, 1 skipped, 1 existing warning

  Regression coverage verifies:

  - reverse worker registration still follows logical model order;
  - duplicate model addresses do not alter round-robin weighting;
  - worker cache roots are inherited when no worker-specific cache is configured;
  - every SGLang InfServer receives distinct TRITON_CACHE_DIR and
    TRITON_CACHE_PATH subdirectories.