### PR TITLE
fix: isolate AWEX control barriers from payload transfer

### DIFF
--- a/areal/v2/weight_update/awex/fsdp_adapter.py
+++ b/areal/v2/weight_update/awex/fsdp_adapter.py
@@ -45,6 +45,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
         self._engine = engine
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
+        self._weights_update_group_gloo = None
         self._transfer_rank: int | None = None
 
     @property
@@ -160,6 +161,24 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             group_name=f"awex_{pair_name}",
             role="training",
         )
+        self._weights_update_group_gloo = init_weights_update_group(
+            master_address=master_addr,
+            master_port=master_port,
+            rank=transfer_rank,
+            world_size=world_size,
+            group_name=f"awex_{pair_name}_gloo",
+            backend="gloo",
+            role="training",
+        )
+        logger.info(
+            "Initialized AWEX weight update groups for pair=%s role=training "
+            "rank=%s world_size=%s nccl=awex_%s gloo=awex_%s_gloo",
+            pair_name,
+            transfer_rank,
+            world_size,
+            pair_name,
+            pair_name,
+        )
 
     def execute_weight_update(self, version: int) -> None:
         del version
@@ -167,6 +186,8 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             raise RuntimeError("Transfer plan is not initialized")
         if self._weights_update_group is None:
             raise RuntimeError("Weight update group is not initialized")
+        if self._weights_update_group_gloo is None:
+            raise RuntimeError("Gloo weight update group is not initialized")
         if self._transfer_rank is None:
             raise RuntimeError("Transfer rank is not initialized")
 
@@ -183,14 +204,19 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             blocking=True,
             use_group=awex_wu_use_group(),
         )
-        torch.distributed.barrier(group=self._weights_update_group)
+        torch.distributed.barrier(group=self._weights_update_group_gloo)
 
     def batch_isend_irecv(self, **kwargs) -> None:
-        setup_kwargs = {k: v for k, v in kwargs.items() if k != "world_size"}
+        if self._weights_update_group_gloo is None:
+            raise RuntimeError("Gloo weight update group is not initialized")
+        setup_kwargs = {
+            k: v for k, v in kwargs.items() if k not in ("world_size", "barrier_group")
+        }
         setup_batch_isend_irecv(
             self._weights_update_group,
             self._transfer_rank,
             kwargs.get("world_size", 0),
+            barrier_group=self._weights_update_group_gloo,
             **setup_kwargs,
         )
 
@@ -200,7 +226,13 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             and torch.distributed.is_initialized()
         ):
             torch.distributed.destroy_process_group(self._weights_update_group)
+        if (
+            self._weights_update_group_gloo is not None
+            and torch.distributed.is_initialized()
+        ):
+            torch.distributed.destroy_process_group(self._weights_update_group_gloo)
         self._weights_update_group = None
+        self._weights_update_group_gloo = None
         self._transfer_plan = None
         self._transfer_rank = None
 

--- a/areal/v2/weight_update/awex/megatron_adapter.py
+++ b/areal/v2/weight_update/awex/megatron_adapter.py
@@ -61,6 +61,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         self._engine = engine
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
+        self._weights_update_group_gloo = None
         self._transfer_rank: int | None = None
         self._offloaded_optimizer_states: dict = {}
         self._offloaded_weights: dict[str, torch.Tensor] = {}
@@ -184,6 +185,24 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             group_name=f"awex_{pair_name}",
             role="training",
         )
+        self._weights_update_group_gloo = init_weights_update_group(
+            master_address=master_addr,
+            master_port=master_port,
+            rank=transfer_rank,
+            world_size=world_size,
+            group_name=f"awex_{pair_name}_gloo",
+            backend="gloo",
+            role="training",
+        )
+        logger.info(
+            "Initialized AWEX weight update groups for pair=%s role=training "
+            "rank=%s world_size=%s nccl=awex_%s gloo=awex_%s_gloo",
+            pair_name,
+            transfer_rank,
+            world_size,
+            pair_name,
+            pair_name,
+        )
 
     def execute_weight_update(self, version: int) -> None:
         del version
@@ -191,6 +210,8 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             raise RuntimeError("Transfer plan is not initialized")
         if self._weights_update_group is None:
             raise RuntimeError("Weight update group is not initialized")
+        if self._weights_update_group_gloo is None:
+            raise RuntimeError("Gloo weight update group is not initialized")
         if self._transfer_rank is None:
             raise RuntimeError("Transfer rank is not initialized")
 
@@ -207,21 +228,29 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             blocking=True,
             use_group=awex_wu_use_group(),
         )
-        dist.barrier(group=self._weights_update_group)
+        dist.barrier(group=self._weights_update_group_gloo)
 
     def batch_isend_irecv(self, **kwargs) -> None:
-        setup_kwargs = {k: v for k, v in kwargs.items() if k != "world_size"}
+        if self._weights_update_group_gloo is None:
+            raise RuntimeError("Gloo weight update group is not initialized")
+        setup_kwargs = {
+            k: v for k, v in kwargs.items() if k not in ("world_size", "barrier_group")
+        }
         setup_batch_isend_irecv(
             self._weights_update_group,
             self._transfer_rank,
             kwargs.get("world_size", 0),
+            barrier_group=self._weights_update_group_gloo,
             **setup_kwargs,
         )
 
     def teardown_weight_update_group(self) -> None:
         if self._weights_update_group is not None and dist.is_initialized():
             dist.destroy_process_group(self._weights_update_group)
+        if self._weights_update_group_gloo is not None and dist.is_initialized():
+            dist.destroy_process_group(self._weights_update_group_gloo)
         self._weights_update_group = None
+        self._weights_update_group_gloo = None
         self._transfer_plan = None
         self._transfer_rank = None
         if self._colocate_http_client is not None:

--- a/areal/v2/weight_update/awex/sglang_adapter.py
+++ b/areal/v2/weight_update/awex/sglang_adapter.py
@@ -30,6 +30,7 @@ from awex.util.tensor_util import (
     reconstruct_tensors_from_groups,
 )
 
+from areal.infra.platforms import current_platform
 from areal.utils import logging
 from areal.v2.weight_update.awex import (
     awex_wu_use_group,
@@ -53,6 +54,7 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._scheduler = scheduler
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
+        self._weights_update_group_gloo = None
         self._transfer_rank: int | None = None
         self._rank_info: RankInfo | None = None
         self._parameters: dict[str, torch.Tensor] | None = None
@@ -398,6 +400,24 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             group_name=f"awex_{pair_name}",
             role="inference",
         )
+        self._weights_update_group_gloo = init_weights_update_group(
+            master_address=master_addr,
+            master_port=master_port,
+            rank=global_rank,
+            world_size=world_size,
+            group_name=f"awex_{pair_name}_gloo",
+            backend="gloo",
+            role="inference",
+        )
+        logger.info(
+            "Initialized AWEX weight update groups for pair=%s role=inference "
+            "rank=%s world_size=%s nccl=awex_%s gloo=awex_%s_gloo",
+            pair_name,
+            global_rank,
+            world_size,
+            pair_name,
+            pair_name,
+        )
 
     def execute_weight_update(self, version: int) -> None:
         del version
@@ -405,6 +425,8 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             raise RuntimeError("Transfer plan is not initialized")
         if self._weights_update_group is None:
             raise RuntimeError("Weight update group is not initialized")
+        if self._weights_update_group_gloo is None:
+            raise RuntimeError("Gloo weight update group is not initialized")
 
         params = self.get_local_shard_parameters()
         recv_ops, non_contiguous_pairs, _ = nccl_build_recv_ops(
@@ -422,21 +444,30 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         for original, contiguous in non_contiguous_pairs:
             original.copy_(contiguous)
 
-        dist.barrier(group=self._weights_update_group)
+        current_platform.synchronize()
+        dist.barrier(group=self._weights_update_group_gloo)
 
     def batch_isend_irecv(self, **kwargs) -> None:
-        setup_kwargs = {k: v for k, v in kwargs.items() if k != "world_size"}
+        if self._weights_update_group_gloo is None:
+            raise RuntimeError("Gloo weight update group is not initialized")
+        setup_kwargs = {
+            k: v for k, v in kwargs.items() if k not in ("world_size", "barrier_group")
+        }
         setup_batch_isend_irecv(
             self._weights_update_group,
             self._transfer_rank,
             kwargs.get("world_size", 0),
+            barrier_group=self._weights_update_group_gloo,
             **setup_kwargs,
         )
 
     def teardown_weight_update_group(self) -> None:
         if self._weights_update_group is not None and dist.is_initialized():
             dist.destroy_process_group(self._weights_update_group)
+        if self._weights_update_group_gloo is not None and dist.is_initialized():
+            dist.destroy_process_group(self._weights_update_group_gloo)
         self._weights_update_group = None
+        self._weights_update_group_gloo = None
         self._transfer_plan = None
         self._transfer_rank = None
         self._rank_info = None

--- a/areal/v2/weight_update/nccl_group.py
+++ b/areal/v2/weight_update/nccl_group.py
@@ -136,13 +136,21 @@ def init_weights_update_group(
 
 
 def setup_batch_isend_irecv(
-    process_group, rank, world_size, tensor_size=10 * 10, dtype=torch.float32
+    process_group,
+    rank,
+    world_size,
+    tensor_size=10 * 10,
+    dtype=torch.float32,
+    barrier_group=None,
 ):
     """
     Perform a simple communication using batch_isend_irecv to avoid the hang for later sub-ranks.
 
     Args:
     process_group (ProcessGroup): The process group to work on.
+    barrier_group (ProcessGroup | None): Optional sidecar group for the final
+        control-plane barrier. When omitted, use process_group for backward
+        compatibility.
     tensor_size (int): Size of the tensor to send/receive.
     dtype (torch.dtype): Data type of the tensor.
     """
@@ -201,7 +209,14 @@ def setup_batch_isend_irecv(
 
     # Synchronize
     current_platform.synchronize()
-    dist.barrier(group=process_group, device_ids=[current_platform.current_device()])
+    if barrier_group is None:
+        logger.info("Setup batch isend irecv final barrier on weight update group")
+        dist.barrier(
+            group=process_group, device_ids=[current_platform.current_device()]
+        )
+    else:
+        logger.info("Setup batch isend irecv final barrier on sidecar group")
+        dist.barrier(group=barrier_group)
 
     logger.info(
         f"Simple communication completed for process group of size {world_size}"

--- a/tests/v2/weight_update/test_nccl_group.py
+++ b/tests/v2/weight_update/test_nccl_group.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, call
+
+import pytest
+import torch
+
+from areal.v2.weight_update import nccl_group
+from areal.v2.weight_update.awex import fsdp_adapter, megatron_adapter, sglang_adapter
+
+
+def test_setup_batch_isend_irecv_uses_sidecar_for_final_barrier(monkeypatch):
+    """The liveness payload uses NCCL while its final barrier uses the sidecar."""
+    process_group = MagicMock(name="nccl_group")
+    barrier_group = MagicMock(name="gloo_group")
+    barrier = MagicMock()
+
+    monkeypatch.setattr(nccl_group.current_platform, "current_device", lambda: 0)
+    monkeypatch.setattr(nccl_group.current_platform, "device_type", "cpu")
+    monkeypatch.setattr(nccl_group.current_platform, "synchronize", lambda: None)
+    monkeypatch.setattr(torch, "full", lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr(torch, "zeros", lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr(nccl_group.dist, "barrier", barrier)
+
+    nccl_group.setup_batch_isend_irecv(
+        process_group,
+        rank=0,
+        world_size=1,
+        barrier_group=barrier_group,
+    )
+
+    barrier.assert_called_once_with(group=barrier_group)
+
+
+def test_setup_batch_isend_irecv_defaults_to_payload_group(monkeypatch):
+    """Callers without a sidecar retain the existing payload-group barrier."""
+    process_group = MagicMock(name="nccl_group")
+    barrier = MagicMock()
+
+    monkeypatch.setattr(nccl_group.current_platform, "current_device", lambda: 0)
+    monkeypatch.setattr(nccl_group.current_platform, "device_type", "cpu")
+    monkeypatch.setattr(nccl_group.current_platform, "synchronize", lambda: None)
+    monkeypatch.setattr(torch, "full", lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr(torch, "zeros", lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr(nccl_group.dist, "barrier", barrier)
+
+    nccl_group.setup_batch_isend_irecv(
+        process_group,
+        rank=0,
+        world_size=1,
+    )
+
+    barrier.assert_called_once_with(group=process_group, device_ids=[0])
+
+
+def test_megatron_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
+    """The training adapter creates matching payload and sidecar groups."""
+    adapter = megatron_adapter.AwexMegatronAdapter(MagicMock())
+    builder = MagicMock()
+    builder.build_local_transfer_plan.return_value = MagicMock()
+    initializer = MagicMock(side_effect=[MagicMock(), MagicMock()])
+
+    monkeypatch.setattr(
+        megatron_adapter, "fetch_kv_metadata", lambda *args: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr(
+        megatron_adapter, "TransferPlanBuilder", lambda **kwargs: builder
+    )
+    monkeypatch.setattr(megatron_adapter, "init_weights_update_group", initializer)
+
+    adapter.init_weight_update_group(
+        pair_name="actor-rollout",
+        master_addr="127.0.0.1",
+        master_port=29500,
+        transfer_rank=2,
+        world_size=4,
+        kv_store_url="http://kv-store",
+        infer_world_size=2,
+        train_world_size=2,
+        num_engines=1,
+    )
+
+    assert initializer.call_args_list == [
+        call(
+            master_address="127.0.0.1",
+            master_port=29500,
+            rank=2,
+            world_size=4,
+            group_name="awex_actor-rollout",
+            role="training",
+        ),
+        call(
+            master_address="127.0.0.1",
+            master_port=29500,
+            rank=2,
+            world_size=4,
+            group_name="awex_actor-rollout_gloo",
+            backend="gloo",
+            role="training",
+        ),
+    ]
+
+
+def test_fsdp_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
+    """The FSDP training adapter creates matching payload and sidecar groups."""
+    adapter = fsdp_adapter.AwexFSDPAdapter(MagicMock())
+    builder = MagicMock()
+    builder.build_local_transfer_plan.return_value = MagicMock()
+    initializer = MagicMock(side_effect=[MagicMock(), MagicMock()])
+
+    monkeypatch.setattr(
+        fsdp_adapter, "fetch_kv_metadata", lambda *args: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr(fsdp_adapter, "TransferPlanBuilder", lambda **kwargs: builder)
+    monkeypatch.setattr(fsdp_adapter, "init_weights_update_group", initializer)
+
+    adapter.init_weight_update_group(
+        pair_name="actor-rollout",
+        master_addr="127.0.0.1",
+        master_port=29500,
+        transfer_rank=2,
+        world_size=4,
+        kv_store_url="http://kv-store",
+        infer_world_size=2,
+        train_world_size=2,
+        num_engines=1,
+    )
+
+    assert initializer.call_args_list == [
+        call(
+            master_address="127.0.0.1",
+            master_port=29500,
+            rank=2,
+            world_size=4,
+            group_name="awex_actor-rollout",
+            role="training",
+        ),
+        call(
+            master_address="127.0.0.1",
+            master_port=29500,
+            rank=2,
+            world_size=4,
+            group_name="awex_actor-rollout_gloo",
+            backend="gloo",
+            role="training",
+        ),
+    ]
+
+
+def test_sglang_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
+    """The inference adapter creates matching payload and sidecar groups."""
+    adapter = sglang_adapter.AwexSGLangAdapter(MagicMock())
+    builder = MagicMock()
+    builder.build_local_transfer_plan.return_value = MagicMock()
+    initializer = MagicMock(side_effect=[MagicMock(), MagicMock()])
+
+    monkeypatch.setattr(
+        adapter,
+        "_get_model_context",
+        lambda: {"tp_size": 1, "tp_rank": 0, "pp_size": 1, "pp_rank": 0},
+    )
+    monkeypatch.setattr(
+        sglang_adapter, "fetch_kv_metadata", lambda *args: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr(sglang_adapter, "TransferPlanBuilder", lambda **kwargs: builder)
+    monkeypatch.setattr(sglang_adapter, "init_weights_update_group", initializer)
+
+    adapter.init_weight_update_group(
+        pair_name="actor-rollout",
+        master_addr="127.0.0.1",
+        master_port=29500,
+        transfer_rank=1,
+        world_size=4,
+        kv_store_url="http://kv-store",
+        infer_world_size=2,
+        train_world_size=2,
+        num_engines=2,
+    )
+
+    assert initializer.call_args_list == [
+        call(
+            master_address="127.0.0.1",
+            master_port=29500,
+            rank=1,
+            world_size=4,
+            group_name="awex_actor-rollout",
+            role="inference",
+        ),
+        call(
+            master_address="127.0.0.1",
+            master_port=29500,
+            rank=1,
+            world_size=4,
+            group_name="awex_actor-rollout_gloo",
+            backend="gloo",
+            role="inference",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "module"),
+    [
+        (fsdp_adapter.AwexFSDPAdapter, fsdp_adapter),
+        (megatron_adapter.AwexMegatronAdapter, megatron_adapter),
+        (sglang_adapter.AwexSGLangAdapter, sglang_adapter),
+    ],
+)
+def test_awex_adapters_use_sidecar_for_setup_barrier(adapter_cls, module, monkeypatch):
+    """Both AWEX adapters retain NCCL payloads and select the Gloo barrier."""
+    adapter = object.__new__(adapter_cls)
+    payload_group = MagicMock(name="nccl_group")
+    sidecar_group = MagicMock(name="gloo_group")
+    adapter._weights_update_group = payload_group
+    adapter._weights_update_group_gloo = sidecar_group
+    adapter._transfer_rank = 3
+    setup = MagicMock()
+    monkeypatch.setattr(module, "setup_batch_isend_irecv", setup)
+
+    adapter.batch_isend_irecv(world_size=4)
+
+    setup.assert_called_once_with(
+        payload_group,
+        3,
+        4,
+        barrier_group=sidecar_group,
+    )
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "module", "build_ops_name"),
+    [
+        (
+            fsdp_adapter.AwexFSDPAdapter,
+            fsdp_adapter,
+            "nccl_build_send_ops",
+        ),
+        (
+            megatron_adapter.AwexMegatronAdapter,
+            megatron_adapter,
+            "nccl_build_send_ops",
+        ),
+        (
+            sglang_adapter.AwexSGLangAdapter,
+            sglang_adapter,
+            "nccl_build_recv_ops",
+        ),
+    ],
+)
+def test_awex_adapters_use_sidecar_for_completion_barrier(
+    adapter_cls, module, build_ops_name, monkeypatch
+):
+    """Payload ops stay on NCCL while the completion barrier uses Gloo."""
+    adapter = adapter_cls(MagicMock())
+    payload_group = MagicMock(name="nccl_group")
+    sidecar_group = MagicMock(name="gloo_group")
+    adapter._transfer_plan = MagicMock()
+    adapter._weights_update_group = payload_group
+    adapter._weights_update_group_gloo = sidecar_group
+    adapter._transfer_rank = 0
+    adapter.get_local_shard_parameters = MagicMock(return_value={})
+    monkeypatch.setattr(module, build_ops_name, lambda *args, **kwargs: ([], [], None))
+    monkeypatch.setattr(module, "batch_send_recv", MagicMock())
+    barrier = MagicMock()
+    distributed = getattr(module, "dist", module.torch.distributed)
+    monkeypatch.setattr(distributed, "barrier", barrier)
+
+    adapter.execute_weight_update(version=1)
+
+    barrier.assert_called_once_with(group=sidecar_group)
+
+
+def test_sglang_synchronizes_weight_copies_before_gloo_barrier(monkeypatch):
+    """The success barrier runs only after inference weights reach the device."""
+    adapter = sglang_adapter.AwexSGLangAdapter(MagicMock())
+    adapter._transfer_plan = MagicMock()
+    adapter._weights_update_group = MagicMock(name="nccl_group")
+    adapter._weights_update_group_gloo = MagicMock(name="gloo_group")
+    adapter._transfer_rank = 0
+    adapter.get_local_shard_parameters = MagicMock(return_value={})
+
+    events = []
+    original = MagicMock()
+    contiguous = MagicMock()
+    original.copy_.side_effect = lambda value: events.append("copy")
+    monkeypatch.setattr(
+        sglang_adapter,
+        "nccl_build_recv_ops",
+        lambda *args, **kwargs: ([], [(original, contiguous)], None),
+    )
+    monkeypatch.setattr(sglang_adapter, "batch_send_recv", MagicMock())
+    platform = MagicMock()
+    platform.synchronize.side_effect = lambda: events.append("synchronize")
+    monkeypatch.setattr(sglang_adapter, "current_platform", platform, raising=False)
+    monkeypatch.setattr(
+        sglang_adapter.dist,
+        "barrier",
+        lambda **kwargs: events.append("barrier"),
+    )
+
+    adapter.execute_weight_update(version=1)
+
+    original.copy_.assert_called_once_with(contiguous)
+    assert events == ["copy", "synchronize", "barrier"]
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "module"),
+    [
+        (fsdp_adapter.AwexFSDPAdapter, fsdp_adapter),
+        (megatron_adapter.AwexMegatronAdapter, megatron_adapter),
+        (sglang_adapter.AwexSGLangAdapter, sglang_adapter),
+    ],
+)
+def test_awex_adapters_destroy_payload_and_sidecar_groups(
+    adapter_cls, module, monkeypatch
+):
+    """Adapter teardown destroys both process groups and clears their handles."""
+    adapter = adapter_cls(MagicMock())
+    payload_group = MagicMock(name="nccl_group")
+    sidecar_group = MagicMock(name="gloo_group")
+    adapter._weights_update_group = payload_group
+    adapter._weights_update_group_gloo = sidecar_group
+    destroy = MagicMock()
+    distributed = getattr(module, "dist", module.torch.distributed)
+    monkeypatch.setattr(distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(distributed, "destroy_process_group", destroy)
+
+    adapter.teardown_weight_update_group()
+
+    assert destroy.call_args_list == [call(payload_group), call(sidecar_group)]
+    assert adapter._weights_update_group is None
+    assert adapter._weights_update_group_gloo is None


### PR DESCRIPTION
  ## Summary

  Use a Gloo sidecar process group for control barriers in separated AWEX weight
  updates, while keeping the NCCL process group dedicated to model-weight payload
  transfer.

  The implementation now maintains process-group symmetry for both supported
  training backends:

  - FSDP → SGLang
  - Megatron → SGLang

  ## Problem

  The existing implementation uses the same NCCL process group for:

  - liveness P2P communication;
  - the liveness completion barrier;
  - model-weight payload transfer;
  - the weight-update completion barrier.

  This mixes data-plane transfers and control-plane collectives on the same NCCL
  group. During large weight transfers, control barriers can stall behind payload
  operations or encounter inconsistent collective progress across ranks.

  Increasing an outer HTTP timeout does not resolve this process-group coordination
  problem.

  ## Changes

  Each separated AWEX endpoint now creates two matching process groups:

  ```text
  awex_<pair_name>       # NCCL: payload communication
  awex_<pair_name>_gloo  # Gloo: control barriers

  The groups use matching:

  - master address and port;
  - transfer rank;
  - world size.

  The communication responsibilities are separated as follows:

  NCCL payload group:
    - liveness P2P payload
    - model-weight send/receive

  Gloo sidecar group:
    - liveness completion barrier
    - weight-update completion barrier

  The Gloo sidecar is created by all separated AWEX adapters:

  - AwexFSDPAdapter
  - AwexMegatronAdapter
  - AwexSGLangAdapter

  Adapter teardown destroys and clears both process groups.

  setup_batch_isend_irecv() keeps barrier_group=None as the default. Existing
  callers that do not provide a sidecar retain the original payload-group barrier.

  ## FSDP symmetry regression

  The initial implementation created the Gloo sidecar on Megatron and SGLang, but
  not on FSDP. That made FSDP → SGLang asymmetric:

  FSDP:
    NCCL only

  SGLang:
    NCCL + Gloo

  In that state, SGLang could block while initializing the Gloo group because the
  corresponding FSDP ranks never joined it.

  A focused regression test reproduced the issue before the fix:

  expected: NCCL init + Gloo init
  actual:   NCCL init only

  FSDP now follows the same group initialization, barrier selection, and teardown
  contract as Megatron.

  ## Scope

  This PR changes separated AWEX weight updates for:

  - FSDP → SGLang
  - Megatron → SGLang

  It does not change:

  - colocated weight updates;
  - recover or reconnect behavior;
  - weight-update timeout configuration;
  - Router behavior;
  - inference-worker cache behavior;
  - model-weight payload format;
  - AWEX transfer-plan construction.

  ## Tests

  Added coverage for:

  - legacy fallback without a sidecar;
  - FSDP NCCL/Gloo group initialization;
  - Megatron NCCL/Gloo group initialization;
  - SGLang NCCL/Gloo group initialization;
  - setup barrier selection on all three adapters;
  - weight-update completion barrier selection;
  - destruction and cleanup of both groups.

  Focused and adjacent validation in the AReaL Slurm/SIF environment:

  33 passed, 1 warning

  Also passed:

  - targeted pre-commit hooks;
  - Ruff lint and formatting;
  - SPDX header checks;
  - Python compilation;
  - git diff --check.

  The warning is an existing torchao SyntaxWarning from the container
  environment.
