### PR TITLE
fix(lora): regression in megatron+lora support due to missing vllm lora aliases

### DIFF
--- a/examples/math/gsm8k_grpo_megatron_lora.yaml
+++ b/examples/math/gsm8k_grpo_megatron_lora.yaml
@@ -75,7 +75,9 @@ actor:
   ppo_n_minibatches: 1
   recompute_logprob: true
   use_decoupled_loss: true
-  behave_imp_weight_cap: 5.0
+  rejection_sampling:
+    metric: ratio
+    upper: 5.0
   reward_norm:
     mean_level: group
     std_level: group

--- a/examples/math/gsm8k_grpo_megatron_lora_moe.yaml
+++ b/examples/math/gsm8k_grpo_megatron_lora_moe.yaml
@@ -75,7 +75,9 @@ actor:
   ppo_n_minibatches: 1
   recompute_logprob: true
   use_decoupled_loss: true
-  behave_imp_weight_cap: 5.0
+  rejection_sampling:
+    metric: ratio
+    upper: 5.0
   reward_norm:
     mean_level: group
     std_level: group


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->
Keep prior versioned LoRA names registered in the vLLM server so in-flight
rollout requests do not break after adapter refreshes. Also fix LoRA example
YAMLs to match the latest syntax.

Key changes:
- Retain old runtime LoRA aliases in `areal_vllm_server.py`
- Add a regression test for alias retention
- Update LoRA example YAMLs to use the current syntax/path conventions


## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
