### PR TITLE
docs(algorithms): describe metadata-driven group normalization

### DIFF
--- a/docs/en/algorithms/grpo_series.md
+++ b/docs/en/algorithms/grpo_series.md
@@ -91,8 +91,11 @@ The `NormConfig` dataclass controls how rewards and advantages are normalized:
 | `group_size`     | int         | -                            | Group size for group-level normalization                   |
 
 "Batch" level computes the mean/std across the global batch, while "group" level
-computes them within groups (e.g., trajectories sharing the same prompt). For
-group-level normalization, `group_size` must be specified. Setting `mean_level` or
+computes them within groups (e.g., trajectories sharing the same prompt). Group
+boundaries come from the rollout batch metadata (`TrajBatchMeta.traj_group_sizes`)
+rather than from `group_size`, so groups of unequal size (e.g., when some samples are
+filtered out) are still normalized per prompt; `group_size` applies only as a
+fixed-stride fallback when that metadata is unavailable. Setting `mean_level` or
 `std_level` to `None` skips mean subtraction or standard deviation scaling,
 respectively.
 

--- a/docs/zh/algorithms/grpo_series.md
+++ b/docs/zh/algorithms/grpo_series.md
@@ -84,7 +84,9 @@ python3 examples/math/gsm8k_rl.py \
 | `eps`            | float       | -                            | 避免除零的小常数（默认：`1e-5`）   |
 | `group_size`     | int         | -                            | 分组级归一化的组大小               |
 
-"Batch"级在整个全局批次上计算均值/标准差，而"group"级在组内计算（例如，共享相同提示的轨迹）。对于分组级归一化，必须指定 `group_size`。将
+"Batch"级在整个全局批次上计算均值/标准差，而"group"级在组内计算（例如，共享相同提示的轨迹）。分组边界来自 rollout
+批次元数据（`TrajBatchMeta.traj_group_sizes`）而非
+`group_size`，因此即使各组大小不一（例如部分样本被过滤），仍会按提示逐组归一化；仅当该元数据不可用时，`group_size` 才作为固定步长的回退方案生效。将
 `mean_level` 或 `std_level` 设为 `None` 分别跳过均值减法或标准差缩放。
 
 如果整个字段被省略（例如YAML中的 `adv_norm: null`），则不执行归一化。


### PR DESCRIPTION
## Description

`docs/{en,zh}/algorithms/grpo_series.md` still stated that `group_size` must be
specified for group-level reward/advantage normalization. That has not been true since
#1454 (`bbc10f0e`): group boundaries come from the rollout batch metadata
`TrajBatchMeta.traj_group_sizes` (built in `concat_batch`, forwarded by
`batched_call(..., pass_meta=True)`), which `PPOActor._compute_advantages` passes to
`Normalization` for both `reward_norm` and `adv_norm` (`areal/trainer/ppo/actor.py`).
`Normalization._build_group_slices` slices on those per-trajectory sizes and falls back
to fixed-stride `NormConfig.group_size` only when no metadata is present
(`areal/utils/data.py`).

The document's own CLI overrides already relied on the new behavior: the Dr.GRPO example
sets `actor.adv_norm.mean_level=group` on top of `examples/math/gsm8k_grpo.yaml`, whose
`adv_norm` block never sets `group_size`. The example YAML in the same section keeps
`group_size: ${gconfig.n_samples}` under `reward_norm`, matching the shipped configs
under `examples/`, where it now acts as the fallback.

Docs-only change, in English and its Chinese translation.

## Related Issue

Follow-up to #1454, which changed the behavior without updating this page. No separate
issue.

## Type of Change

- [x] 📝 Documentation update

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

## Additional Context

`mdformat` excludes `docs/{en,zh}/algorithms/`, so the paragraph was re-wrapped by hand
to the file's existing 88-column style.
