### PR TITLE
fix(models): configure bridge provider for deterministic builds

### DIFF
--- a/areal/models/mcore/registry.py
+++ b/areal/models/mcore/registry.py
@@ -15,6 +15,7 @@ from megatron.core.transformer import TransformerConfig
 from transformers import AutoConfig, PretrainedConfig
 
 from areal.api.cli_args import MegatronEngineConfig
+from areal.engine.megatron_utils.deterministic import set_deterministic_algorithms
 from areal.models.mcore.bailing_moe import (
     hf_to_mcore_config_bailing_moe,
     make_mcore_layer_specs_bailing_moe,
@@ -488,6 +489,13 @@ def make_mcore_model(
         tf_config.moe_token_dispatcher_type = provider.moe_token_dispatcher_type
         tf_config.batch_p2p_comm = provider.batch_p2p_comm
         tf_config.overlap_p2p_comm = provider.overlap_p2p_comm
+
+        # Megatron-Bridge creates a new provider instead of building from
+        # ``tf_config`` directly. Apply the prebuild deterministic settings to
+        # the actual provider so construction-time consumers (TP layers and TE
+        # attention) see the same configuration.
+        if mcore_config.use_deterministic_algorithms:
+            set_deterministic_algorithms(provider, prebuild=True)
 
         provider.finalize()
 

--- a/tests/test_megatron_bridge_deterministic.py
+++ b/tests/test_megatron_bridge_deterministic.py
@@ -1,0 +1,135 @@
+"""Tests for Megatron-Bridge deterministic provider configuration."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+
+class _FinalizeReached(RuntimeError):
+    pass
+
+
+class _FakeProvider(SimpleNamespace):
+    def finalize(self) -> None:
+        self.config_at_finalize = (
+            self.deterministic_mode,
+            self.attention_backend,
+            self.cross_entropy_loss_fusion,
+            self.bias_dropout_fusion,
+        )
+        raise _FinalizeReached
+
+
+class _FakeBridge:
+    def __init__(self, provider: _FakeProvider) -> None:
+        self.provider = provider
+
+    def to_megatron_provider(self, *, load_weights: bool) -> _FakeProvider:
+        assert load_weights is False
+        return self.provider
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_deterministic_state(monkeypatch):
+    monkeypatch.delenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", raising=False)
+    monkeypatch.delenv("NCCL_ALGO", raising=False)
+    monkeypatch.delenv("CUBLAS_WORKSPACE_CONFIG", raising=False)
+    previous_enabled = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+
+    yield
+
+    torch.use_deterministic_algorithms(
+        previous_enabled,
+        warn_only=previous_warn_only,
+    )
+
+
+def _make_mcore_config(*, deterministic: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        virtual_pipeline_parallel_size=None,
+        recompute_granularity=None,
+        recompute_method=None,
+        recompute_num_layers=None,
+        distribute_saved_activations=False,
+        recompute_modules=None,
+        enable_mtp=False,
+        moe_token_dispatcher_type="alltoall",
+        use_deterministic_algorithms=deterministic,
+    )
+
+
+def _make_provider(attention_backend) -> _FakeProvider:
+    return _FakeProvider(
+        deterministic_mode=False,
+        attention_backend=attention_backend,
+        cross_entropy_loss_fusion=True,
+        bias_dropout_fusion=True,
+        mtp_num_layers=None,
+    )
+
+
+def _run_until_provider_finalize(
+    provider: _FakeProvider,
+    *,
+    deterministic: bool,
+) -> None:
+    pytest.importorskip("mbridge")
+    pytest.importorskip("megatron.core")
+    from areal.models.mcore.registry import make_mcore_model
+
+    tf_config = SimpleNamespace(params_dtype=None)
+    mcore_config = _make_mcore_config(deterministic=deterministic)
+
+    with (
+        mock.patch.multiple(
+            "areal.models.mcore.registry.mpu",
+            get_tensor_model_parallel_world_size=mock.DEFAULT,
+            get_pipeline_model_parallel_world_size=mock.DEFAULT,
+            get_context_parallel_world_size=mock.DEFAULT,
+            get_expert_model_parallel_world_size=mock.DEFAULT,
+            get_expert_tensor_parallel_world_size=mock.DEFAULT,
+        ) as mpu_mocks,
+        pytest.raises(_FinalizeReached),
+    ):
+        for getter in mpu_mocks.values():
+            getter.return_value = 1
+        make_mcore_model(
+            hf_config=SimpleNamespace(),
+            tf_config=tf_config,
+            mcore_config=mcore_config,
+            bridge=_FakeBridge(provider),
+            bridge_type="megatron-bridge",
+        )
+
+
+def test_megatron_bridge_provider_applies_determinism_before_finalize():
+    """Deterministic settings reach the actual provider before finalization."""
+    enums = pytest.importorskip("megatron.core.transformer.enums")
+    provider = _make_provider(enums.AttnBackend.auto)
+
+    _run_until_provider_finalize(provider, deterministic=True)
+
+    assert provider.config_at_finalize == (
+        True,
+        enums.AttnBackend.flash,
+        False,
+        False,
+    )
+
+
+def test_megatron_bridge_provider_preserves_defaults_when_disabled():
+    """The Megatron-Bridge provider remains unchanged without the opt-in."""
+    attention_backend = object()
+    provider = _make_provider(attention_backend)
+
+    _run_until_provider_finalize(provider, deterministic=False)
+
+    assert provider.config_at_finalize == (
+        False,
+        attention_backend,
+        True,
+        True,
+    )


### PR DESCRIPTION
## Description

Megatron-Bridge materializes a provider that is separate from the transformer config prepared by AReaL. Apply deterministic prebuild settings to the actual provider before finalization so tensor-parallel layers and Transformer Engine attention inherit the requested deterministic configuration.

Adds focused regression coverage for both the enabled and disabled paths.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (pre-commit run --all-files)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable; no public API or behavior documentation changed)
- [x] Branch is up to date with main
- [ ] Self-reviewed via /review-pr command
- [x] This PR was created by a coding agent via /create-pr
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None.

## Additional Context

Risk area:
- Deterministic settings must be applied before provider finalization and layer construction. The regression test captures provider state from finalize to verify ordering.
- The helper also updates process-global deterministic state and environment variables, matching the existing deterministic path.

Validation:
- UV_DEFAULT_INDEX=https://pypi.org/simple pre-commit run --all-files
- UV_DEFAULT_INDEX=https://pypi.org/simple uv run pytest -q tests/test_deterministic_prebuild.py tests/test_megatron_bridge_deterministic.py
  - 3 passed, 3 skipped
  - Skips are expected on Darwin because Megatron, MBridge, and CUDA are Linux x86_64 optional dependencies.

Not run:
- Multi-GPU and distributed integration suites; they require Linux CUDA or multi-node hardware and are not needed for this focused provider-configuration fix.