### PR TITLE
feat(engine): enable model-owned THD for Qwen3-VL

### DIFF
--- a/areal/engine/core/model.py
+++ b/areal/engine/core/model.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import Enum
+
 import torch
 
 VALID_VISION_MODELS = [
@@ -83,6 +85,28 @@ def is_qwen3_moe_model(model_type: str) -> bool:
 
 def is_qwen3_5_model(model_type: str) -> bool:
     return model_type in ["qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text"]
+
+
+class SequencePackingMode(str, Enum):
+    WRAPPER_THD = "wrapper_thd"
+    MODEL_THD = "model_thd"
+    PADDED = "padded"
+
+
+def supports_model_packed_seq(model_type: str, bridge_type: str) -> bool:
+    """Whether the bridge model owns BSHD-to-THD packing internally."""
+    return bridge_type == "megatron-bridge" and is_qwen3_vl_model(model_type)
+
+
+def resolve_sequence_packing_mode(
+    model_type: str, bridge_type: str
+) -> SequencePackingMode:
+    """Select one packing path from the model and bridge contract."""
+    if supports_model_packed_seq(model_type, bridge_type):
+        return SequencePackingMode.MODEL_THD
+    if is_valid_vision_model(model_type) or is_qwen3_5_model(model_type):
+        return SequencePackingMode.PADDED
+    return SequencePackingMode.WRAPPER_THD
 
 
 def requires_padded_seq(model_type: str) -> bool:

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -59,10 +59,12 @@ from areal.engine.core.distributed import (
     warmup_process_groups,
 )
 from areal.engine.core.model import (
+    SequencePackingMode,
     disable_dropout_in_model,
     is_valid_vision_model,
     lang_config,
     requires_padded_seq,
+    resolve_sequence_packing_mode,
 )
 from areal.engine.megatron_utils import megatron_bridge_patches  # noqa: F401
 from areal.engine.megatron_utils.checkpointer import MegatronCheckpointManager
@@ -352,6 +354,8 @@ class MegatronEngine(TrainEngine):
         self.bridge_cls: str = getattr(self.mcore_config, "bridge_type", "mbridge")
         self.bridge_lora: MegatronBridgeLoRA | None = None
         self.is_vision_model: bool = False
+        self.sequence_packing_mode: SequencePackingMode | None = None
+        self.use_model_packed_seq: bool = False
         self.processor = None
 
     def create_process_group(self, parallel_strategy: ParallelStrategy | None = None):
@@ -497,9 +501,15 @@ class MegatronEngine(TrainEngine):
                 set_deterministic_algorithms(self.tf_config, prebuild=True)
 
             self.is_vision_model = is_valid_vision_model(self.hf_config.model_type)
-            # GDN/SSM models (e.g. Qwen3.5) reject packed THD input and must run
-            # the padded BSHD forward. Derived from model type rather than a
-            # config flag so the layout can't be mis-set.
+            self.sequence_packing_mode = resolve_sequence_packing_mode(
+                self.hf_config.model_type, self.bridge_cls
+            )
+            self.use_model_packed_seq = (
+                self.sequence_packing_mode == SequencePackingMode.MODEL_THD
+            )
+            # ``PADDED`` is the input-routing fallback for every VLM without a
+            # model-owned THD contract. ``use_padded_seq`` is narrower: it
+            # enables Qwen3.5/GDN-specific dense-mask and LM-head semantics.
             self.use_padded_seq = requires_padded_seq(self.hf_config.model_type)
             if self.is_vision_model:
                 if self.parallel_strategy.context_parallel_size > 1:
@@ -1167,6 +1177,7 @@ class MegatronEngine(TrainEngine):
                 gather_cp_output=not cp_local,
                 is_vision_model=self.is_vision_model,
                 use_padded_seq=self.use_padded_seq,
+                use_model_packed_seq=self.use_model_packed_seq,
                 fp32_output=_float16_wrapper_fp32_output(
                     self.mcore_config.enable_chunked_logits,
                     self.dtype,

--- a/areal/engine/megatron_utils/packed_context_parallel.py
+++ b/areal/engine/megatron_utils/packed_context_parallel.py
@@ -309,12 +309,53 @@ def extract_vision_from_multi_modal(
     _drop_multi_modal_payload(mb)
 
 
+def _reconstruct_padded_2d(
+    input_ids: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Reconstruct padded ``[B, S]`` ids and their validity mask."""
+    batch_size = cu_seqlens.shape[0] - 1
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    # The engine supplies max_seqlen after sequence/page padding, so it covers
+    # every length in cu_seqlens without recomputing a CUDA scalar on the host.
+    if max_seqlen is None:
+        max_seqlen = int(seq_lens.max().item())
+    # Batches may carry int32 ids, while the padded scatter destination and
+    # bridge embedding/position indexing require int64 token ids.
+    input_ids = input_ids.to(torch.long)
+    attention_mask = (
+        torch.arange(max_seqlen, device=input_ids.device)[None, :] < seq_lens[:, None]
+    )
+    input_ids_2d = torch.zeros(
+        batch_size, max_seqlen, dtype=torch.long, device=input_ids.device
+    )
+    input_ids_2d[attention_mask] = input_ids
+    return input_ids_2d, attention_mask, seq_lens, max_seqlen
+
+
+def _build_thd_packed_seq_params(
+    cu_seqlens: torch.Tensor, max_seqlen: int
+) -> PackedSeqParams:
+    """Build THD metadata for sequences already aligned by AReaL."""
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        cu_seqlens_kv=cu_seqlens,
+        max_seqlen_kv=max_seqlen,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+    )
+
+
 def packed_context_parallel_forward(
     model: torch.nn.Module,
     input_: dict[str, Any],
     gather_cp_output: bool = True,
     is_vision_model: bool = False,
     use_padded_seq: bool = False,
+    use_model_packed_seq: bool = False,
     fp32_output: bool | None = None,
     return_hidden_states: bool = False,
 ):
@@ -349,7 +390,22 @@ def packed_context_parallel_forward(
     padded_repack_info = None
 
     if cu_seqlens is not None:
-        if not needs_padded_form:
+        if use_model_packed_seq:
+            if attention_mask is not None or tree_triton_data is not None:
+                raise ValueError(
+                    "Attention mask and tree attention are not supported with "
+                    "the model-packed THD forward."
+                )
+            if mpu.get_context_parallel_world_size() > 1:
+                raise NotImplementedError(
+                    "The model-packed THD forward does not support CP > 1 yet."
+                )
+            input_ids, attention_mask, _, max_seqlen = _reconstruct_padded_2d(
+                input_ids, cu_seqlens, input_.get("max_seqlen")
+            )
+            packed_seq_params = _build_thd_packed_seq_params(cu_seqlens, max_seqlen)
+            position_ids = None
+        elif not needs_padded_form:
             if attention_mask is not None or tree_triton_data is not None:
                 raise ValueError(
                     "Attention mask should be None when using packed sequences."
@@ -359,27 +415,10 @@ def packed_context_parallel_forward(
             )
             input_ids = input_ids.contiguous()
         else:
-            # VLM and BSHD-only models expect [B, S] padded input. Reconstruct
-            # padded 2D tensors from packed 1D via boolean masking — avoids
-            # per-sample Python loop and GPU-CPU sync.
-            batch_size = cu_seqlens.shape[0] - 1
-            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-            max_seqlen = int(seq_lens.max().item())
-            # int64 for input_ids: mbridge's get_rope_index uses input_ids.dtype
-            # for position_ids, and some kernels (_index_put_impl_) require int64.
-            # Upcast to torch.long so the scatter `input_ids_2d[mask] = input_ids`
-            # below has matching source/dest dtypes (data pipeline may emit int32).
-            if input_ids.dtype != torch.long:
-                input_ids = input_ids.to(torch.long)
-            attention_mask = (
-                torch.arange(max_seqlen, device=input_ids.device)[None, :]
-                < seq_lens[:, None]
+            # VLM and BSHD-only models expect [B, S] padded input.
+            input_ids, attention_mask, seq_lens, max_seqlen = _reconstruct_padded_2d(
+                input_ids, cu_seqlens, input_.get("max_seqlen")
             )
-            input_ids_2d = torch.zeros(
-                batch_size, max_seqlen, dtype=torch.long, device=input_ids.device
-            )
-            input_ids_2d[attention_mask] = input_ids
-            input_ids = input_ids_2d
             padded_repack_info = (cu_seqlens, seq_lens, max_seqlen)
 
     # Every VLM forward is mask-free (attention_mask=None): the model
@@ -391,7 +430,9 @@ def packed_context_parallel_forward(
     # layers skip padding. The wrapper-packed path carries no mask either
     # way (enforced above); tree data passes through untouched.
     dense_mask_text_forward = use_padded_seq and not has_vision_inputs
-    if is_vision_model and not dense_mask_text_forward:
+    if use_model_packed_seq:
+        final_attention_mask = attention_mask
+    elif is_vision_model and not dense_mask_text_forward:
         final_attention_mask = None
     else:
         final_attention_mask = (

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -203,6 +203,100 @@ class TestExtractVisionFromMultiModal:
 
 
 class TestPackedContextParallelForward:
+    def test_padding_keeps_model_thd_sequence_offsets_tp_aligned(self):
+        from areal.utils.data import pad_packed_tensor_dict
+
+        padded, _, _, _ = pad_packed_tensor_dict(
+            {
+                "input_ids": torch.tensor([10, 11, 12, 20, 21]),
+                "cu_seqlens": torch.tensor([0, 3, 5], dtype=torch.int32),
+                "max_seqlen": 3,
+            },
+            pad_to_length=16,
+            seq_align_to=4,
+        )
+
+        seq_lens = padded["cu_seqlens"][1:] - padded["cu_seqlens"][:-1]
+        assert seq_lens.tolist() == [4, 4, 248]
+        assert torch.all(seq_lens % 4 == 0)
+
+    @pytest.mark.parametrize(
+        ("use_padded_seq", "expected_mask"),
+        [
+            (False, None),
+            (True, [[True, True, True], [True, True, False]]),
+        ],
+    )
+    def test_padded_vlm_preserves_model_specific_mask_semantics(
+        self, monkeypatch, use_padded_seq, expected_mask
+    ):
+        from areal.engine.megatron_utils import packed_context_parallel
+
+        model = MagicMock(return_value=torch.ones(2, 3, 4))
+        monkeypatch.setattr(
+            packed_context_parallel.mpu,
+            "is_pipeline_last_stage",
+            lambda **_kwargs: True,
+        )
+
+        output = packed_context_parallel.packed_context_parallel_forward(
+            model,
+            {
+                "input_ids": torch.tensor([10, 11, 12, 20, 21]),
+                "cu_seqlens": torch.tensor([0, 3, 5], dtype=torch.int32),
+                "max_seqlen": 3,
+            },
+            is_vision_model=True,
+            use_padded_seq=use_padded_seq,
+        )
+
+        call = model.call_args.kwargs
+        assert call["input_ids"].tolist() == [[10, 11, 12], [20, 21, 0]]
+        if expected_mask is None:
+            assert call["attention_mask"] is None
+        else:
+            assert call["attention_mask"].tolist() == expected_mask
+        assert call["position_ids"] is None
+        assert call["packed_seq_params"] is None
+        assert output.shape == (5, 4)
+
+    def test_model_thd_passes_padded_inputs_and_packed_metadata(self, monkeypatch):
+        from areal.engine.megatron_utils import packed_context_parallel
+
+        model = MagicMock(return_value=torch.ones(1, 5, 3))
+        monkeypatch.setattr(
+            packed_context_parallel.mpu,
+            "is_pipeline_last_stage",
+            lambda **_kwargs: True,
+        )
+        monkeypatch.setattr(
+            packed_context_parallel.mpu,
+            "get_context_parallel_world_size",
+            lambda: 1,
+        )
+
+        output = packed_context_parallel.packed_context_parallel_forward(
+            model,
+            {
+                "input_ids": torch.tensor([10, 11, 12, 20, 21]),
+                "cu_seqlens": torch.tensor([0, 3, 5], dtype=torch.int32),
+                "max_seqlen": 3,
+            },
+            is_vision_model=True,
+            use_model_packed_seq=True,
+        )
+
+        call = model.call_args.kwargs
+        assert call["input_ids"].tolist() == [[10, 11, 12], [20, 21, 0]]
+        assert call["attention_mask"].tolist() == [
+            [True, True, True],
+            [True, True, False],
+        ]
+        assert call["position_ids"] is None
+        assert call["packed_seq_params"].qkv_format == "thd"
+        assert call["packed_seq_params"].cu_seqlens_q.tolist() == [0, 3, 5]
+        assert output.shape == (5, 3)
+
     def test_hidden_state_mode_bypasses_post_process_and_restores_model(self):
         from areal.engine.megatron_utils import packed_context_parallel
 

--- a/tests/test_megatron_engine_vlm_distributed.py
+++ b/tests/test_megatron_engine_vlm_distributed.py
@@ -152,6 +152,29 @@ def test_simple_forward(model_env, tmp_path_factory):
 @pytest.mark.gpu
 @pytest.mark.slow
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+@pytest.mark.parametrize(
+    "backend", ["megatron:d1p1t1", "megatron:d1p1t2"], ids=["tp1", "tp2"]
+)
+def test_qwen3_vl_model_thd_matches_bshd(backend, tmp_path_factory):
+    """Model-owned THD must preserve text-only and image-text logprobs."""
+    required_gpus = ModelAllocation.from_str(backend).parallel.world_size
+    if torch.cuda.device_count() < required_gpus:
+        pytest.skip(f"Qwen3-VL parity with {backend} requires {required_gpus} GPUs")
+    output = str(tmp_path_factory.mktemp("vlm_test") / "thd_bshd_parity.out")
+    _run_vlm_test(
+        "thd_bshd_parity",
+        output,
+        backend=backend,
+        env_overrides={
+            "AREAL_TEST_BRIDGE_TYPE": "megatron-bridge",
+            "VLM_MODEL_PATH": DENSE_MODEL_PATHS["qwen3_vl"],
+        },
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
 @pytest.mark.parametrize("model_env", _VLM_MODELS)
 def test_hf_save_load_weights(model_env, tmp_path_factory):
     """Verify save/load preserves VLM weights and saves processor."""
@@ -193,7 +216,25 @@ def test_train_tensor_parallel(model_env, tmp_path_factory):
 @pytest.mark.slow
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
 def test_qwen3vl_moe_expert_parallel(tmp_path_factory):
-    """Forward smoke test for Qwen3-VL-MoE under ``(attn:d2t4|ffn:d2e4)``.
+    """Legacy mbridge forward smoke under ``(attn:d2t4|ffn:d2e4)``."""
+    if torch.cuda.device_count() < 8:
+        pytest.skip("Qwen3-VL-MoE expert parallel requires 8 GPUs to run")
+    output = str(
+        tmp_path_factory.mktemp("test_output") / "qwen3vl_moe_expert_parallel.out"
+    )
+    _run_vlm_test(
+        "forward",
+        output,
+        backend="megatron:(attn:d2t4|ffn:d2e4)",
+        env_overrides={"VLM_MODEL_PATH": MOE_MODEL_PATHS["qwen3_vl_moe"]},
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_qwen3vl_moe_model_thd_expert_parallel(tmp_path_factory):
+    """Model-owned THD smoke for Qwen3-VL-MoE under ``(attn:d2t4|ffn:d2e4)``.
 
     Allocation: attn DP=2 TP=4 (8 GPUs); ffn DP=2 EP=4 (8 GPUs). World sizes
     must match — earlier ``(attn:d2t2|ffn:d2e4)`` raised
@@ -209,7 +250,11 @@ def test_qwen3vl_moe_expert_parallel(tmp_path_factory):
         "forward",
         output,
         backend="megatron:(attn:d2t4|ffn:d2e4)",
-        env_overrides={"VLM_MODEL_PATH": MOE_MODEL_PATHS["qwen3_vl_moe"]},
+        env_overrides={
+            "AREAL_TEST_BRIDGE_TYPE": "megatron-bridge",
+            "AREAL_TEST_EXPECT_MODEL_THD": "1",
+            "VLM_MODEL_PATH": MOE_MODEL_PATHS["qwen3_vl_moe"],
+        },
     )
 
 

--- a/tests/test_sequence_packing_mode.py
+++ b/tests/test_sequence_packing_mode.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from areal.engine.core.model import (
+    SequencePackingMode,
+    resolve_sequence_packing_mode,
+    supports_model_packed_seq,
+)
+
+
+@pytest.mark.parametrize("model_type", ["qwen3_vl", "qwen3_vl_moe"])
+def test_qwen3_vl_family_uses_model_thd_with_megatron_bridge(model_type):
+    assert supports_model_packed_seq(model_type, "megatron-bridge")
+    assert (
+        resolve_sequence_packing_mode(model_type, "megatron-bridge")
+        == SequencePackingMode.MODEL_THD
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "bridge_type"),
+    [
+        ("qwen3_vl", "mbridge"),
+        ("qwen3_vl_moe", "mbridge"),
+        ("qwen2_5_vl", "megatron-bridge"),
+        ("qwen3_5", "megatron-bridge"),
+        ("qwen3_5_moe", "megatron-bridge"),
+    ],
+)
+def test_models_without_gpu_model_thd_contract_stay_padded(model_type, bridge_type):
+    assert not supports_model_packed_seq(model_type, bridge_type)
+    assert (
+        resolve_sequence_packing_mode(model_type, bridge_type)
+        == SequencePackingMode.PADDED
+    )
+
+
+@pytest.mark.parametrize("model_type", ["qwen3", "qwen3_moe", "llama"])
+def test_text_models_keep_wrapper_thd(model_type):
+    assert (
+        resolve_sequence_packing_mode(model_type, "megatron-bridge")
+        == SequencePackingMode.WRAPPER_THD
+    )

--- a/tests/torchrun/run_megatron_engine_vlm_distributed.py
+++ b/tests/torchrun/run_megatron_engine_vlm_distributed.py
@@ -31,6 +31,7 @@ from areal.api.cli_args import (
     TrainEngineConfig,
 )
 from areal.engine import MegatronEngine
+from areal.engine.core.model import SequencePackingMode
 from areal.utils.data import broadcast_tensor_container
 from areal.utils.testing_utils import DENSE_MODEL_PATHS
 
@@ -85,6 +86,54 @@ def mock_vlm_input(engine: "MegatronEngine") -> dict[str, Any]:
         "attention_mask": attention_mask,
         "multi_modal_input": [
             {"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}
+        ],
+    }
+
+
+def mock_text_only_vlm_input(engine: "MegatronEngine") -> dict[str, Any]:
+    """Create a variable-length text-only batch for a VLM model."""
+    device = engine.device
+    seq_lens = torch.tensor([32, 20], dtype=torch.long, device=device)
+    input_ids = torch.randint(0, 1000, (2, 32), dtype=torch.long, device=device)
+    attention_mask = torch.arange(32, device=device)[None, :] < seq_lens[:, None]
+    input_ids.masked_fill_(~attention_mask, 0)
+    return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+def mock_mixed_vlm_input(engine: "MegatronEngine") -> dict[str, Any]:
+    """Create a variable-length image-text plus text-only batch."""
+    vc = engine.hf_config.vision_config
+    patch_size = getattr(vc, "patch_size", 16)
+    temporal_patch_size = getattr(vc, "temporal_patch_size", 2)
+    spatial_merge_size = getattr(vc, "spatial_merge_size", 2)
+    in_channels = getattr(vc, "in_channels", 3)
+    image_token_id = engine.hf_config.image_token_id
+    device = engine.device
+
+    grid_t, grid_h, grid_w = 1, 4, 4
+    total_patches = grid_t * grid_h * grid_w
+    num_image_tokens = (
+        grid_t * (grid_h // spatial_merge_size) * (grid_w // spatial_merge_size)
+    )
+    seq_lens = torch.tensor([24, 16], dtype=torch.long, device=device)
+    input_ids = torch.randint(0, 1000, (2, 24), dtype=torch.long, device=device)
+    input_ids[0, 8 : 8 + num_image_tokens] = image_token_id
+    attention_mask = torch.arange(24, device=device)[None, :] < seq_lens[:, None]
+    input_ids.masked_fill_(~attention_mask, 0)
+
+    patch_dim = in_channels * temporal_patch_size * patch_size * patch_size
+    pixel_values = torch.randn(
+        total_patches, patch_dim, dtype=torch.float32, device=device
+    )
+    image_grid_thw = torch.tensor(
+        [[grid_t, grid_h, grid_w]], dtype=torch.long, device=device
+    )
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "multi_modal_input": [
+            {"pixel_values": pixel_values, "image_grid_thw": image_grid_thw},
+            {},
         ],
     }
 
@@ -161,6 +210,12 @@ def test_vlm_forward(backend: str, output: str | None = None):
     # No DDP grad buffer — forward is inference-only. Saves ~2× model bytes
     # per rank and avoids NCCL OOMs at the GPU-memory boundary on 30B+ MoE.
     engine = make_vlm_engine(backend, init_optimizer=False, wrap_with_ddp=False)
+    if os.environ.get("AREAL_TEST_EXPECT_MODEL_THD") == "1":
+        assert engine.hf_config.model_type == "qwen3_vl_moe"
+        assert engine.bridge_cls == "megatron-bridge"
+        assert engine.sequence_packing_mode == SequencePackingMode.MODEL_THD
+        assert engine.use_model_packed_seq
+        assert not engine.use_padded_seq
     bcasted_input = _make_input(engine)
 
     engine.eval()
@@ -171,6 +226,75 @@ def test_vlm_forward(backend: str, output: str | None = None):
     if rank == 0 and output is not None:
         write_result(output, "Passed")
     print(f"rank {rank}: test_vlm_forward({backend}) Done.")
+
+
+def test_vlm_thd_bshd_parity(backend: str, output: str | None = None):
+    """Compare model-owned THD and padded BSHD forward outputs."""
+    rank = int(os.environ["RANK"])
+    torch.manual_seed(1234)
+    engine = make_vlm_engine(backend, init_optimizer=False, wrap_with_ddp=False)
+
+    assert engine.hf_config.model_type == "qwen3_vl"
+    assert engine.bridge_cls == "megatron-bridge"
+    assert engine.use_model_packed_seq
+    engine.eval()
+
+    parity_results = []
+    try:
+        cases = [
+            (
+                "text_only",
+                broadcast_tensor_container(
+                    mock_text_only_vlm_input(engine),
+                    src_rank=engine.current_data_parallel_head(),
+                    group=engine.context_and_model_parallel_group,
+                ),
+            ),
+            (
+                "mixed_image_text",
+                broadcast_tensor_container(
+                    mock_mixed_vlm_input(engine),
+                    src_rank=engine.current_data_parallel_head(),
+                    group=engine.context_and_model_parallel_group,
+                ),
+            ),
+        ]
+        bshd_outputs = []
+        engine.use_model_packed_seq = False
+        with torch.no_grad():
+            for _, bcasted_input in cases:
+                bshd_outputs.append(engine.forward(bcasted_input))
+
+        engine.use_model_packed_seq = True
+        for (case_name, bcasted_input), bshd_output in zip(
+            cases, bshd_outputs, strict=True
+        ):
+            with torch.no_grad():
+                thd_output = engine.forward(bcasted_input)
+
+            assert bshd_output.shape == thd_output.shape
+            valid_mask = bcasted_input["attention_mask"].bool()
+            assert valid_mask.shape == thd_output.shape
+            thd_output = thd_output[valid_mask]
+            bshd_output = bshd_output[valid_mask]
+            diff = (thd_output - bshd_output).abs()
+            max_abs = diff.max().item()
+            mean_abs = diff.mean().item()
+            parity_results.append((case_name, max_abs, mean_abs))
+            if rank == 0:
+                print(
+                    f"[thd-bshd] {case_name}: max_abs={max_abs:.6e} "
+                    f"mean_abs={mean_abs:.6e}"
+                )
+    finally:
+        _cleanup(engine)
+
+    for case_name, max_abs, mean_abs in parity_results:
+        assert max_abs <= 1.5e-1, f"{case_name} max_abs={max_abs:.6e}"
+        assert mean_abs <= 3.5e-2, f"{case_name} mean_abs={mean_abs:.6e}"
+    if rank == 0 and output is not None:
+        write_result(output, "Passed")
+    print(f"rank {rank}: test_vlm_thd_bshd_parity({backend}) Done.")
 
 
 def test_vlm_save_load(backend: str, save_dir: str, output: str | None = None):
@@ -312,7 +436,14 @@ def main():
     parser.add_argument(
         "--test_type",
         type=str,
-        choices=["init", "forward", "save_load", "dcp_save_load", "train"],
+        choices=[
+            "init",
+            "forward",
+            "thd_bshd_parity",
+            "save_load",
+            "dcp_save_load",
+            "train",
+        ],
         default="train",
     )
     args = parser.parse_args()
@@ -321,6 +452,8 @@ def main():
         test_vlm_init(args.backend, output=args.output)
     elif args.test_type == "forward":
         test_vlm_forward(args.backend, output=args.output)
+    elif args.test_type == "thd_bshd_parity":
+        test_vlm_thd_bshd_parity(args.backend, output=args.output)
     elif args.test_type == "save_load":
         assert args.save_dir is not None, "--save_dir required for save_load test"
         test_vlm_save_load(args.backend, args.save_dir, output=args.output)


### PR DESCRIPTION
## Description

Enable model-owned THD sequence packing for dense and MoE Qwen3-VL models with Megatron-Bridge.

### What changed

- Add explicit wrapper-THD, model-THD, and padded sequence-packing modes.
- Reconstruct per-sequence BSHD inputs and pass THD `PackedSeqParams` to Qwen3-VL, allowing the model to merge vision embeddings before packing internally.
- Repack valid model outputs into AReaL's packed token layout.
- Preserve padded-only dense-mask behavior for Qwen3.5/GDN and existing behavior for unsupported VLM/bridge combinations.
- Keep VLM context parallelism greater than one unsupported.

### Support boundaries

| Path | Result |
| --- | --- |
| Dense Qwen3-VL + Megatron-Bridge | Model-owned THD enabled and THD/BSHD parity-qualified |
| Qwen3-VL MoE + Megatron-Bridge | Model-owned THD enabled and forward-qualified; strict parity remains unqualified |
| Qwen3.5/GDN | Remains padded BSHD |
| Qwen2.5-VL, Gemma3, and legacy `mbridge` VLMs | Remain padded BSHD |
| Non-VLM text models | Keep wrapper-owned THD |
| VLM with context parallelism greater than one | Rejected |

### Tests added

- `test_qwen3_vl_family_uses_model_thd_with_megatron_bridge`: checks MODEL_THD selection for dense and MoE Qwen3-VL.
- `test_models_without_gpu_model_thd_contract_stay_padded`: checks padded fallback for unsupported model/bridge combinations.
- `test_text_models_keep_wrapper_thd`: checks that non-VLM text models retain wrapper-owned THD.
- `test_padding_keeps_model_thd_sequence_offsets_tp_aligned`: checks TP-aligned sequence offsets, including the appended padding row.
- `test_padded_vlm_preserves_model_specific_mask_semantics`: checks legacy VLM mask behavior and Qwen3.5/GDN dense-mask behavior.
- `test_model_thd_passes_padded_inputs_and_packed_metadata`: checks BSHD reconstruction, THD metadata, and packed output restoration.
- `test_qwen3_vl_model_thd_matches_bshd`: compares dense Qwen3-VL log-probabilities for text-only and mixed image/text batches at TP1 and TP2.
- `test_qwen3vl_moe_expert_parallel`: preserves the legacy `mbridge` TP4/EP4 forward smoke.
- `test_qwen3vl_moe_model_thd_expert_parallel`: checks Qwen3-VL-MoE MODEL_THD forward execution with TP4/EP4.

## Related Issue

Not linked.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

Not applicable.

## Additional Context

### Validation

- Focused unit suites: `127 passed`.
- Focused routing and wrapper tests: `14 passed`.
- 8-GPU Qwen3-VL-MoE MODEL_THD forward smoke with `megatron:(attn:d2t4|ffn:d2e4)`: passed.
- Dense TP2 THD-versus-BSHD parity: passed twice with identical results.
- Restored legacy `mbridge` TP4/EP4 Qwen3-VL-MoE forward smoke: passed.
- Ruff and staged whitespace checks: passed.

### Numerical alignment

| Model, topology, and input | Max absolute log-probability drift | Mean absolute log-probability drift | Status |
| --- | ---: | ---: | --- |
| Dense TP1, text-only | 0.085 | 0.025 | Within 0.150 / 0.035 limits |
| Dense TP1, mixed image/text | 0.131 | 0.030 | Within 0.150 / 0.035 limits |
| Dense TP2, text-only | 0.145 | 0.030 | Within 0.150 / 0.035 limits |
| Dense TP2, mixed image/text | 0.102 | 0.034 | Within 0.150 / 0.035 limits |
| MoE, text-only | 0.489 | 0.105 | Forward-qualified only |
| MoE, mixed image/text | 0.840 | 0.115 | Forward-qualified only |

### Limitations

- MoE strict parity is not established; diagnostics indicate top-k expert-route sensitivity is the dominant source of drift.
- Training and optimizer behavior have not been qualified.
- VLM context parallelism greater than one remains unsupported.
- No documentation change is included.

______________________________________________________________________

**Need help?** Check the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md) or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
