### PR TITLE
fix(megatron): release actor weights after async save

### DIFF
--- a/areal/engine/megatron_utils/checkpointer.py
+++ b/areal/engine/megatron_utils/checkpointer.py
@@ -58,6 +58,13 @@ def get_device_name() -> str:
 
 
 class _UnsupportedMCoreAsyncLayout(RuntimeError):
+    """Raised when MCore's retained async payload cannot be released safely.
+
+    This includes malformed async request arguments, write buckets, bucket
+    payload tuples, or tensor payloads that are not mutable lists. The error
+    is raised before the async save request is scheduled.
+    """
+
     pass
 
 

--- a/areal/engine/megatron_utils/checkpointer.py
+++ b/areal/engine/megatron_utils/checkpointer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import random
+from importlib import metadata
 
 import numpy as np
 import torch
@@ -54,6 +55,72 @@ def get_device_name() -> str:
     else:
         device = "cpu"
     return device
+
+
+class _UnsupportedMCoreAsyncLayout(RuntimeError):
+    pass
+
+
+def _mcore_version() -> str:
+    try:
+        return metadata.version("megatron-core")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _inspect_retained_payload(async_request: AsyncRequest) -> list[list]:
+    """Validate MCore's retained payload layout before scheduling the save."""
+
+    def unsupported(detail: str) -> _UnsupportedMCoreAsyncLayout:
+        return _UnsupportedMCoreAsyncLayout(
+            "Unsupported MCore async checkpoint layout "
+            f"(megatron-core={_mcore_version()}): {detail}. "
+            "Refusing to schedule the save because actor GPU payload references "
+            "cannot be released safely."
+        )
+
+    # TODO(agent): Revalidate this internal contract when MCore's async
+    # checkpoint request or write-bucket layout changes.
+    args = getattr(async_request, "async_fn_args", None)
+    if not isinstance(args, (list, tuple)) or len(args) != 3:
+        raise unsupported("expected three async_fn_args")
+
+    buckets = args[1]
+    if not isinstance(buckets, list):
+        raise unsupported("expected async_fn_args[1] to be a write_buckets list")
+
+    tensor_lists = []
+    for index, bucket in enumerate(buckets):
+        if not isinstance(bucket, tuple) or len(bucket) != 3:
+            raise unsupported(f"write_buckets[{index}] is not a three-item tuple")
+        payload = bucket[2]
+        if not isinstance(payload, tuple) or len(payload) != 2:
+            raise unsupported(
+                f"write_buckets[{index}][2] is not a (bytes_data, tensor_data) tuple"
+            )
+        tensor_data = payload[1]
+        if not isinstance(tensor_data, list):
+            raise unsupported(
+                f"write_buckets[{index}] tensor_data is not a mutable list"
+            )
+        tensor_lists.append(tensor_data)
+
+    return tensor_lists
+
+
+def _release_retained_payload(tensor_lists: list[list]) -> None:
+    """Drop parent-side GPU references after MCore finishes D2H staging.
+
+    MCore retains the original request for finalization, whose writer still owns
+    the original tensor lists through ``write_buckets``. Scheduling returns only
+    after the child owns the staged CPU payload, while finalization needs the
+    writer and outer bucket count but not the tensor contents. Preserve that
+    structure and clear only the parent-side tensor lists.
+    """
+    for tensor_data in tensor_lists:
+        tensor_data.clear()
+    if any(tensor_data for tensor_data in tensor_lists):
+        raise RuntimeError("Failed to release MCore's retained async-save payload")
 
 
 def save_dist_checkpointing(
@@ -470,7 +537,9 @@ class MegatronCheckpointManager:
                 "Megatron returned no AsyncRequest despite async_sharded_save=True."
             )
             assert self._async_queue is not None
+            tensor_lists = _inspect_retained_payload(async_save_request)
             call_idx = self._async_queue.schedule_async_request(async_save_request)
+            _release_retained_payload(tensor_lists)
             # By the time schedule_async_request returns, AsyncCallsQueue has
             # already done torch.cuda.synchronize() and forked the background
             # save process — so weights are durably staged off the GPU. The

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -15,10 +15,12 @@ that the manager correctly:
 
 from __future__ import annotations
 
+import gc
 import importlib
 import importlib.util
 import sys
 import types
+import weakref
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -137,12 +139,17 @@ def test_async_disabled_creates_no_queue():
 def test_save_schedules_async_request(patched_checkpointer, tmp_path):
     mod, manager, queue = patched_checkpointer
     fake_request = object()
+    tensor_lists = [[]]
 
     with (
         patch.object(manager, "generate_state_dict", return_value={"model": {}}),
         patch.object(
             mod, "save_dist_checkpointing", return_value=fake_request
         ) as save_fn,
+        patch.object(
+            mod, "_inspect_retained_payload", return_value=tensor_lists
+        ) as inspect_fn,
+        patch.object(mod, "_release_retained_payload") as release_fn,
         patch("torch.cuda.empty_cache"),
         patch("torch.distributed.barrier"),
     ):
@@ -150,7 +157,9 @@ def test_save_schedules_async_request(patched_checkpointer, tmp_path):
 
     save_fn.assert_called_once()
     assert save_fn.call_args.kwargs["async_save"] is True
+    inspect_fn.assert_called_once_with(fake_request)
     queue.schedule_async_request.assert_called_once_with(fake_request)
+    release_fn.assert_called_once_with(tensor_lists)
 
 
 def test_save_reaps_before_scheduling_next(patched_checkpointer, tmp_path):
@@ -159,6 +168,7 @@ def test_save_reaps_before_scheduling_next(patched_checkpointer, tmp_path):
     with (
         patch.object(manager, "generate_state_dict", return_value={"model": {}}),
         patch.object(mod, "save_dist_checkpointing", side_effect=["r1", "r2"]),
+        patch.object(mod, "_inspect_retained_payload", return_value=[]),
         patch("torch.cuda.empty_cache"),
         patch("torch.distributed.barrier"),
     ):
@@ -220,6 +230,7 @@ def test_async_save_reports_queue_depth_only(patched_checkpointer, tmp_path):
     with (
         patch.object(manager, "generate_state_dict", return_value={"model": {}}),
         patch.object(mod, "save_dist_checkpointing", side_effect=["r1", "r2"]),
+        patch.object(mod, "_inspect_retained_payload", return_value=[]),
         patch("torch.cuda.empty_cache"),
         patch("torch.distributed.barrier"),
     ):
@@ -299,3 +310,78 @@ def test_load_checkpoint_builds_optimizer_template_with_is_loading(
     assert kwargs["is_loading"] is True
     assert kwargs["metadata"] == {"distrib_optim_sharding_type": "dp_reshardable"}
     manager.optimizer.load_state_dict.assert_called_once_with({"step": 1})
+
+
+class _FakeRequest:
+    def __init__(self, args, preload_fn, finalize_fns):
+        self.async_fn_args = args
+        self.preload_fn = preload_fn
+        self.finalize_fns = finalize_fns
+
+
+def _request_with_pending_payload(buckets, finalize_fns=None):
+    return _FakeRequest(
+        args=(0, buckets, "results_queue"),
+        preload_fn=lambda: buckets,
+        finalize_fns=finalize_fns or [lambda: None],
+    )
+
+
+def test_release_retained_payload_clears_tensor_data_and_preserves_finalize():
+    mod = _import_checkpointer()
+
+    class Payload:
+        pass
+
+    tensor = Payload()
+    tensor_ref = weakref.ref(tensor)
+    writer = types.SimpleNamespace(
+        write_buckets=[
+            (
+                "file",
+                "key",
+                ([("byte-item", b"payload")], [("tensor-item", tensor)]),
+            )
+        ]
+    )
+    buckets = writer.write_buckets
+
+    def finalize_fn():
+        return len(writer.write_buckets), writer.write_buckets[0][2][0]
+
+    request = _request_with_pending_payload(buckets, [finalize_fn])
+    tensor_lists = mod._inspect_retained_payload(request)
+    del tensor
+
+    mod._release_retained_payload(tensor_lists)
+    gc.collect()
+
+    assert tensor_ref() is None
+    assert writer.write_buckets is buckets
+    assert writer.write_buckets == [("file", "key", ([("byte-item", b"payload")], []))]
+    assert request.async_fn_args == (0, buckets, "results_queue")
+    assert request.preload_fn() is buckets
+    assert request.finalize_fns == [finalize_fn]
+    assert finalize_fn() == (1, [("byte-item", b"payload")])
+
+
+def test_save_unknown_payload_layout_fails_before_scheduling(
+    patched_checkpointer, tmp_path
+):
+    mod, manager, queue = patched_checkpointer
+    buckets = ["opaque-bucket"]
+    request = _request_with_pending_payload(buckets)
+
+    with (
+        patch.object(manager, "generate_state_dict", return_value={"model": {}}),
+        patch.object(mod, "save_dist_checkpointing", return_value=request),
+        patch.object(mod, "_mcore_version", return_value="0.18.0"),
+        pytest.raises(
+            mod._UnsupportedMCoreAsyncLayout,
+            match=r"megatron-core=0\.18\.0.*write_buckets\[0\]",
+        ),
+    ):
+        manager.save_checkpoint(str(tmp_path / "step0"))
+
+    queue.schedule_async_request.assert_not_called()
+    assert buckets == ["opaque-bucket"]


### PR DESCRIPTION
## Description

MCore asynchronous checkpointing performs device-to-host staging before
forking the background checkpoint writer. However, the parent process still
retains references to the original CUDA tensors through the queued writer
payload until asynchronous finalization completes.

This is particularly problematic for colocated training. After scheduling an
asynchronous checkpoint, AReaL needs to offload the actor weights and return
the GPUs to the inference engine. The retained checkpoint references keep the
actor tensors alive, so the actor memory cannot be fully released while
checkpoint I/O is still running.

This change releases those parent-side references immediately after MCore has
completed staging and scheduled the asynchronous writer:

- Validate the expected MCore async request and write-bucket layout before
  scheduling the request.
- Schedule the request normally so device-to-host staging and process creation
  complete first.
- Clear only the retained CUDA tensor lists from the parent-side payload.
- Preserve byte payloads, bucket structure, writer results, and finalization
  callbacks required by the background checkpoint writer.
- Fail before scheduling if the installed MCore layout is incompatible with
  the expected contract.

This allows actor weights to be offloaded while checkpoint files continue to
be written asynchronously.

The implementation targets Megatron-Core 0.17.0, which is currently pinned by
AReaL.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read and followed the Contributing Guide.
- [ ] I have run `pre-commit run --all-files` and all checks pass.
- [x] I have added relevant tests, and they pass locally.
- [x] I have updated the documentation, if necessary.
- [x] My branch is up to date with the target branch.
- [x] I have self-reviewed this PR.
- [ ] This PR was created by an agent using `/create-pr`.
- [x] This PR does not introduce a breaking change.

## Additional Context

The tests cover the required scheduling order, release of retained tensor
references, preservation of finalization callbacks and writer structure, and
fail-fast handling of incompatible MCore request layouts.

The change deliberately does not modify MCore's background writer or
checkpoint finalization semantics. It only removes CUDA tensor references
that are no longer needed by the parent after staging has completed.

Validation on the final commit includes 9 passing async-save tests with 2
environment-dependent tests skipped, along with Ruff, formatting, license,
and repository hygiene checks.
