### PR TITLE
fix(recover): publish immutable checkpoints via latest pointer

### DIFF
--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -372,6 +372,8 @@ class SaveLoadMeta:
     processor: Optional["AutoProcessor"] = None
     base_model_path: str | None = None
     naive_distributed: bool = False
+    checkpoint_pointer_path: str | None = None
+    checkpoint_pointer_value: str | None = None
 
 
 @dataclass

--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -374,6 +374,8 @@ class SaveLoadMeta:
     naive_distributed: bool = False
     checkpoint_pointer_path: str | None = None
     checkpoint_pointer_value: str | None = None
+    # Drain the engine's pending async DCP queue before save() returns.
+    wait_for_async_save: bool = False
 
 
 @dataclass

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1130,9 +1130,39 @@ class MegatronEngine(TrainEngine):
                         "(e.g., LoRA path without distributed optimizer support). "
                         "Please use weight_format='hf' for adapter/full-model export."
                     )
-                self.checkpointer.save_checkpoint(
-                    meta.path, with_optimizer=meta.with_optim
+                pointer_fields = (
+                    meta.checkpoint_pointer_path,
+                    meta.checkpoint_pointer_value,
                 )
+                if (pointer_fields[0] is None) != (pointer_fields[1] is None):
+                    raise ValueError(
+                        "checkpoint_pointer_path and checkpoint_pointer_value "
+                        "must be provided together"
+                    )
+                finalize_fn = None
+                if meta.checkpoint_pointer_path is not None:
+                    from areal.utils.checkpoint_pointer import (
+                        LATEST_FILENAME,
+                        publish_latest,
+                    )
+
+                    if (
+                        os.path.basename(meta.checkpoint_pointer_path)
+                        != LATEST_FILENAME
+                    ):
+                        raise ValueError(
+                            "checkpoint_pointer_path must name the recovery "
+                            f"pointer {LATEST_FILENAME!r}"
+                        )
+                    finalize_fn = functools.partial(
+                        publish_latest,
+                        os.path.dirname(meta.checkpoint_pointer_path),
+                        meta.checkpoint_pointer_value,
+                    )
+                save_kwargs: dict[str, Any] = {"with_optimizer": meta.with_optim}
+                if finalize_fn is not None:
+                    save_kwargs["finalize_fn"] = finalize_fn
+                self.checkpointer.save_checkpoint(meta.path, **save_kwargs)
             else:
                 raise ValueError(f"Unknown weight format {meta.weight_format}. ")
 

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1163,6 +1163,8 @@ class MegatronEngine(TrainEngine):
                 if finalize_fn is not None:
                     save_kwargs["finalize_fn"] = finalize_fn
                 self.checkpointer.save_checkpoint(meta.path, **save_kwargs)
+                if meta.wait_for_async_save:
+                    self.checkpointer.wait_async_saves()
             else:
                 raise ValueError(f"Unknown weight format {meta.weight_format}. ")
 

--- a/areal/engine/megatron_utils/checkpointer.py
+++ b/areal/engine/megatron_utils/checkpointer.py
@@ -132,7 +132,7 @@ def _release_retained_payload(tensor_lists: list[list]) -> None:
         raise RuntimeError("Failed to release MCore's retained async-save payload")
 
 
-def _run_rank0_finalize(rank: int, finalize_fn: Callable[[], None]) -> None:
+def _run_checkpoint_publication(rank: int, finalize_fn: Callable[[], None]) -> None:
     """Run a filesystem publication on rank 0 and propagate any failure."""
     status: list[tuple[str, str] | None] = [None]
     if rank == 0:
@@ -568,7 +568,7 @@ class MegatronCheckpointManager:
             tensor_lists = _inspect_retained_payload(async_save_request)
             if finalize_fn is not None:
                 async_save_request.add_finalize_fn(
-                    partial(_run_rank0_finalize, self.rank, finalize_fn)
+                    partial(_run_checkpoint_publication, self.rank, finalize_fn)
                 )
             call_idx = self._async_queue.schedule_async_request(async_save_request)
             _release_retained_payload(tensor_lists)
@@ -598,7 +598,7 @@ class MegatronCheckpointManager:
             )
             torch.distributed.barrier()
             if finalize_fn is not None:
-                _run_rank0_finalize(self.rank, finalize_fn)
+                _run_checkpoint_publication(self.rank, finalize_fn)
 
     def _reap_finished_async_saves(self) -> None:
         """Non-blocking finalize of any background save processes that have finished.

--- a/areal/engine/megatron_utils/checkpointer.py
+++ b/areal/engine/megatron_utils/checkpointer.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import os
 import random
+from collections.abc import Callable
+from functools import partial
 from importlib import metadata
 
 import numpy as np
@@ -128,6 +130,24 @@ def _release_retained_payload(tensor_lists: list[list]) -> None:
         tensor_data.clear()
     if any(tensor_data for tensor_data in tensor_lists):
         raise RuntimeError("Failed to release MCore's retained async-save payload")
+
+
+def _run_rank0_finalize(rank: int, finalize_fn: Callable[[], None]) -> None:
+    """Run a filesystem publication on rank 0 and propagate any failure."""
+    status: list[tuple[str, str] | None] = [None]
+    if rank == 0:
+        try:
+            finalize_fn()
+        except Exception as e:
+            status[0] = (type(e).__name__, str(e))
+
+    if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+        torch.distributed.broadcast_object_list(status, src=0)
+    if status[0] is not None:
+        error_type, message = status[0]
+        raise RuntimeError(
+            f"Checkpoint publication failed on rank 0: {error_type}: {message}"
+        )
 
 
 def save_dist_checkpointing(
@@ -515,6 +535,7 @@ class MegatronCheckpointManager:
         with_model: bool = True,
         with_optimizer=True,
         with_rng: bool = True,
+        finalize_fn: Callable[[], None] | None = None,
     ):
         dist_checkpoint_path = local_path
 
@@ -545,6 +566,10 @@ class MegatronCheckpointManager:
             )
             assert self._async_queue is not None
             tensor_lists = _inspect_retained_payload(async_save_request)
+            if finalize_fn is not None:
+                async_save_request.add_finalize_fn(
+                    partial(_run_rank0_finalize, self.rank, finalize_fn)
+                )
             call_idx = self._async_queue.schedule_async_request(async_save_request)
             _release_retained_payload(tensor_lists)
             # By the time schedule_async_request returns, AsyncCallsQueue has
@@ -572,6 +597,8 @@ class MegatronCheckpointManager:
                 "Async save request should be None when not using async save."
             )
             torch.distributed.barrier()
+            if finalize_fn is not None:
+                _run_rank0_finalize(self.rank, finalize_fn)
 
     def _reap_finished_async_saves(self) -> None:
         """Non-blocking finalize of any background save processes that have finished.

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -511,7 +511,7 @@ class PPOTrainer:
 
         # Set up checkpointing for recover
         self.recover_info = self.recover_handler.load(
-            self.actor,
+            self._recover_engines(),
             self.saver,
             self.evaluator,
             self.stats_logger,
@@ -1615,9 +1615,6 @@ class PPOTrainer:
 
     def _save_recover_checkpoint(self, epoch: int, epoch_step: int, global_step: int):
         # Save recoverable checkpoints
-        to_save: dict = dict(default=self.actor)
-        if self.critic is not None:
-            to_save["critic"] = self.critic
         step_info = StepInfo(
             global_step=global_step,
             epoch=epoch,
@@ -1625,7 +1622,7 @@ class PPOTrainer:
             steps_per_epoch=len(self.train_dataloader),
         )
         self.recover_handler.dump(
-            to_save,
+            self._recover_engines(),
             step_info,
             self.saver,
             self.evaluator,
@@ -1638,6 +1635,12 @@ class PPOTrainer:
         if not is_single_controller():
             dist.barrier(group=self.actor.cpu_group)
             current_platform.synchronize()
+
+    def _recover_engines(self) -> dict[str, Any]:
+        engines = {"default": self.actor}
+        if self.critic is not None:
+            engines["critic"] = self.critic
+        return engines
 
     def _evaluate_fn(
         self,

--- a/areal/utils/checkpoint_pointer.py
+++ b/areal/utils/checkpoint_pointer.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Crash-safe publication of immutable recovery checkpoints."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+
+from areal.utils.logging import getLogger
+
+logger = getLogger("CheckpointPointer")
+
+FORMAT_VERSION = 1
+GENERATIONS_DIRNAME = "checkpoint_generations"
+GENERATION_PREFIX = "generation_step"
+GENERATION_STEP_WIDTH = 8
+MANIFEST_DIRNAME = "manifest"
+PAYLOADS_DIRNAME = "payloads"
+LATEST_FILENAME = "LATEST"
+LEGACY_MANIFEST_DIRNAME = "recover_info"
+LEGACY_PAYLOAD_DIRNAME = "recover_checkpoint"
+
+
+class CheckpointConsistencyError(RuntimeError):
+    """Checkpoint artifacts exist, but do not identify a usable snapshot."""
+
+
+@dataclass(frozen=True)
+class PointerRecord:
+    format_version: int
+    generation: str
+    global_step: int
+    engines: list[str]
+
+    def to_json(self) -> str:
+        return json.dumps(dataclasses.asdict(self), indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> PointerRecord:
+        payload = json.loads(text)
+        record = cls(
+            format_version=payload["format_version"],
+            generation=payload["generation"],
+            global_step=payload["global_step"],
+            engines=payload["engines"],
+        )
+        record.validate()
+        return record
+
+    def validate(self) -> None:
+        if not isinstance(self.format_version, int) or isinstance(
+            self.format_version, bool
+        ):
+            raise ValueError("format_version must be an integer")
+        if self.format_version != FORMAT_VERSION:
+            raise ValueError(f"unsupported format_version {self.format_version}")
+        if not isinstance(self.global_step, int) or isinstance(self.global_step, bool):
+            raise ValueError("global_step must be an integer")
+        if not isinstance(self.generation, str):
+            raise ValueError("generation must be a string")
+        if self.generation != generation_dirname(self.global_step):
+            raise ValueError(
+                f"generation {self.generation!r} does not match "
+                f"global_step {self.global_step}"
+            )
+        if not isinstance(self.engines, list) or not self.engines:
+            raise ValueError("engines must be a non-empty list of strings")
+        if any(not isinstance(name, str) for name in self.engines):
+            raise ValueError("engines must be a non-empty list of strings")
+        if any(
+            not name or name in (".", "..") or os.path.basename(name) != name
+            for name in self.engines
+        ):
+            raise ValueError("engine names must be single path components")
+        if len(set(self.engines)) != len(self.engines):
+            raise ValueError("engines contains duplicate names")
+
+
+@dataclass(frozen=True)
+class ResumeSource:
+    manifest: str
+    payloads: dict[str, str]
+    label: str
+    transactional: bool
+
+
+def generation_dirname(global_step: int) -> str:
+    if global_step < 0:
+        raise ValueError("global_step must be non-negative")
+    return f"{GENERATION_PREFIX}{global_step:0{GENERATION_STEP_WIDTH}d}"
+
+
+def generations_root(save_root: str) -> str:
+    return os.path.join(save_root, GENERATIONS_DIRNAME)
+
+
+def generation_dir(save_root: str, global_step: int) -> str:
+    return os.path.join(generations_root(save_root), generation_dirname(global_step))
+
+
+def manifest_dir(generation: str) -> str:
+    return os.path.join(generation, MANIFEST_DIRNAME)
+
+
+def payload_dir(generation: str, engine_name: str) -> str:
+    return os.path.join(generation, PAYLOADS_DIRNAME, engine_name)
+
+
+def latest_path(save_root: str) -> str:
+    return os.path.join(save_root, LATEST_FILENAME)
+
+
+def make_record(global_step: int, engine_names: list[str]) -> PointerRecord:
+    record = PointerRecord(
+        format_version=FORMAT_VERSION,
+        generation=generation_dirname(global_step),
+        global_step=global_step,
+        engines=list(engine_names),
+    )
+    record.validate()
+    return record
+
+
+def read_latest(save_root: str) -> PointerRecord | None:
+    path = latest_path(save_root)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return PointerRecord.from_json(f.read())
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+        raise CheckpointConsistencyError(
+            f"Invalid recovery checkpoint pointer at {path}: {e}"
+        ) from e
+
+
+def _source_from_record(
+    save_root: str,
+    record: PointerRecord,
+    engine_names: list[str] | None,
+    *,
+    label: str,
+) -> ResumeSource:
+    names = record.engines if engine_names is None else engine_names
+    if set(names) != set(record.engines):
+        raise CheckpointConsistencyError(
+            f"Checkpoint {record.generation} contains engines "
+            f"{sorted(record.engines)}, but this run requires {sorted(names)}"
+        )
+    generation = os.path.join(generations_root(save_root), record.generation)
+    manifest = manifest_dir(generation)
+    payloads = {name: payload_dir(generation, name) for name in names}
+    missing = [
+        path for path in [manifest, *payloads.values()] if not os.path.isdir(path)
+    ]
+    if missing:
+        raise CheckpointConsistencyError(
+            f"Checkpoint pointer {record.generation} references missing paths: {missing}"
+        )
+    return ResumeSource(
+        manifest=manifest,
+        payloads=payloads,
+        label=label,
+        transactional=True,
+    )
+
+
+def _legacy_source(
+    save_root: str, engine_names: list[str] | None
+) -> ResumeSource | None:
+    manifest = os.path.join(save_root, LEGACY_MANIFEST_DIRNAME)
+    if not os.path.isdir(manifest):
+        return None
+    if engine_names is None:
+        engine_names = sorted(
+            name
+            for name in os.listdir(save_root)
+            if os.path.isdir(os.path.join(save_root, name, LEGACY_PAYLOAD_DIRNAME))
+        )
+    payloads = {
+        name: os.path.join(save_root, name, LEGACY_PAYLOAD_DIRNAME)
+        for name in engine_names
+    }
+    if not payloads or any(not os.path.isdir(path) for path in payloads.values()):
+        return None
+    return ResumeSource(
+        manifest=manifest,
+        payloads=payloads,
+        label=f"legacy checkpoint under {save_root}",
+        transactional=False,
+    )
+
+
+def resolve_checkpoint(
+    save_root: str, engine_names: list[str] | None
+) -> ResumeSource | None:
+    record = read_latest(save_root)
+    if record is not None:
+        return _source_from_record(
+            save_root,
+            record,
+            engine_names,
+            label=f"checkpoint pointer {latest_path(save_root)}",
+        )
+
+    return _legacy_source(save_root, engine_names)
+
+
+def prepare_generation(
+    save_root: str, global_step: int, engine_names: list[str]
+) -> tuple[str, PointerRecord]:
+    record = make_record(global_step, engine_names)
+    current = read_latest(save_root)
+    if current is not None and global_step <= current.global_step:
+        raise CheckpointConsistencyError(
+            f"Refusing to save step {global_step}: LATEST already points to "
+            f"step {current.global_step}"
+        )
+
+    generation = generation_dir(save_root, global_step)
+    if os.path.exists(generation):
+        shutil.rmtree(generation)
+    os.makedirs(manifest_dir(generation))
+    for name in engine_names:
+        os.makedirs(payload_dir(generation, name))
+    return generation, record
+
+
+def _fsync_directory(path: str) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def publish_latest(save_root: str, record_json: str) -> None:
+    """Atomically publish a finalized generation, then retire its predecessor."""
+    record = PointerRecord.from_json(record_json)
+    _source_from_record(
+        save_root,
+        record,
+        record.engines,
+        label=f"generation {record.generation}",
+    )
+    previous = read_latest(save_root)
+    if previous is not None:
+        if previous.global_step > record.global_step:
+            raise CheckpointConsistencyError(
+                f"Refusing to move LATEST backwards from step "
+                f"{previous.global_step} to {record.global_step}"
+            )
+        if previous.global_step == record.global_step:
+            if previous == record:
+                return
+            raise CheckpointConsistencyError(
+                f"Step {record.global_step} has conflicting checkpoint pointers"
+            )
+
+    os.makedirs(save_root, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=".LATEST.", dir=save_root, text=True)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(record_json)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, latest_path(save_root))
+        _fsync_directory(save_root)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    if previous is None or previous.generation == record.generation:
+        return
+    previous_dir = os.path.join(generations_root(save_root), previous.generation)
+    try:
+        shutil.rmtree(previous_dir)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.warning(
+            "Published checkpoint step %s but could not remove the previous "
+            "generation %s: %s",
+            record.global_step,
+            previous_dir,
+            e,
+        )

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -24,8 +24,7 @@ from areal.api import (
 )
 from areal.api.cli_args import RecoverConfig
 from areal.infra import TrainController
-from areal.utils import checkpoint_pointer as cp
-from areal.utils import logging, timeutil
+from areal.utils import checkpoint_pointer, logging, timeutil
 from areal.utils.environ import is_single_controller
 from areal.utils.evaluator import Evaluator
 from areal.utils.saver import Saver
@@ -325,8 +324,8 @@ class RecoverHandler:
         )
 
         if not self._supports_checkpoint_pointer():
-            if cp.read_latest(save_root) is not None:
-                raise cp.CheckpointConsistencyError(
+            if checkpoint_pointer.read_latest(save_root) is not None:
+                raise checkpoint_pointer.CheckpointConsistencyError(
                     "Cannot write a legacy recovery checkpoint while LATEST "
                     "selects a transactional checkpoint generation"
                 )
@@ -361,11 +360,11 @@ class RecoverHandler:
         ]
         publisher_name = async_engines[-1] if async_engines else None
 
-        generation, pointer_record = cp.prepare_generation(
+        generation, pointer_record = checkpoint_pointer.prepare_generation(
             save_root, step_info.global_step, engine_names
         )
 
-        recover_info.dump(cp.manifest_dir(generation))
+        recover_info.dump(checkpoint_pointer.manifest_dir(generation))
 
         pointer_value = pointer_record.to_json()
         # Finish every other async payload before scheduling the publisher. Its
@@ -379,13 +378,15 @@ class RecoverHandler:
             publishes_generation = name == publisher_name
             self._save_checkpoint(
                 engine_,
-                path=cp.payload_dir(generation, name),
+                path=checkpoint_pointer.payload_dir(generation, name),
                 name=name,
                 tokenizer=tokenizer,
                 processor=processor,
                 base_model_path=base_model_path,
                 checkpoint_pointer_path=(
-                    cp.latest_path(save_root) if publishes_generation else None
+                    checkpoint_pointer.latest_path(save_root)
+                    if publishes_generation
+                    else None
                 ),
                 checkpoint_pointer_value=(
                     pointer_value if publishes_generation else None
@@ -403,7 +404,7 @@ class RecoverHandler:
                 publisher_name,
             )
         else:
-            cp.publish_latest(save_root, pointer_value)
+            checkpoint_pointer.publish_latest(save_root, pointer_value)
             logger.info(
                 "Published recovery checkpoint generation %s at step %s",
                 generation,
@@ -441,7 +442,9 @@ class RecoverHandler:
             self.config.trial_name,
             self.config.fileroot,
         )
-        source = cp.resolve_checkpoint(save_root, list(normalized_engine))
+        source = checkpoint_pointer.resolve_checkpoint(
+            save_root, list(normalized_engine)
+        )
         if source is None:
             logger.warning(
                 f"Resume info not found under {save_root}. "
@@ -518,7 +521,7 @@ class RecoverHandler:
             return recover_info
         except (FileNotFoundError, InValidRecoverInfo) as e:
             if source.transactional:
-                raise cp.CheckpointConsistencyError(
+                raise checkpoint_pointer.CheckpointConsistencyError(
                     f"Published checkpoint {source.label} is not loadable: {e}"
                 ) from e
             logger.warning(
@@ -584,7 +587,7 @@ def check_if_auto_recover(config: RecoverConfig) -> bool:
         config.experiment_name, config.trial_name, config.fileroot
     )
     logger.info(f"Searching for recovery checkpoint under {save_root}.")
-    source = cp.resolve_checkpoint(save_root, None)
+    source = checkpoint_pointer.resolve_checkpoint(save_root, None)
     if source is None:
         logger.warning(f"Recover info not found under: {save_root}")
         return False
@@ -592,7 +595,7 @@ def check_if_auto_recover(config: RecoverConfig) -> bool:
         info = RecoverInfo.load(source.manifest)
     except Exception as e:
         if source.transactional:
-            raise cp.CheckpointConsistencyError(
+            raise checkpoint_pointer.CheckpointConsistencyError(
                 f"Published checkpoint {source.label} is not loadable: {e}"
             ) from e
         logger.warning(f"Failed to load recover info from {source.manifest}: {e}")

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -359,13 +359,7 @@ class RecoverHandler:
             for name, engine_ in normalized_engine.items()
             if self._uses_async_checkpoint(engine_)
         ]
-        # TODO(agent): coordinate per-engine finalize callbacks before allowing
-        # an asynchronous generation containing both actor and critic payloads.
-        if async_engines and len(normalized_engine) != 1:
-            raise NotImplementedError(
-                "Crash-safe asynchronous recovery currently supports one train "
-                "engine. Disable Megatron async_save when saving multiple engines."
-            )
+        publisher_name = async_engines[-1] if async_engines else None
 
         generation, pointer_record = cp.prepare_generation(
             save_root, step_info.global_step, engine_names
@@ -374,7 +368,15 @@ class RecoverHandler:
         recover_info.dump(cp.manifest_dir(generation))
 
         pointer_value = pointer_record.to_json()
-        for name, engine_ in normalized_engine.items():
+        # Finish every other async payload before scheduling the publisher. Its
+        # finalize callback can then expose the generation without waiting for
+        # another engine, while preserving one background save for overlap.
+        save_order = [name for name in engine_names if name != publisher_name]
+        if publisher_name is not None:
+            save_order.append(publisher_name)
+        for name in save_order:
+            engine_ = normalized_engine[name]
+            publishes_generation = name == publisher_name
             self._save_checkpoint(
                 engine_,
                 path=cp.payload_dir(generation, name),
@@ -383,18 +385,22 @@ class RecoverHandler:
                 processor=processor,
                 base_model_path=base_model_path,
                 checkpoint_pointer_path=(
-                    cp.latest_path(save_root) if name in async_engines else None
+                    cp.latest_path(save_root) if publishes_generation else None
                 ),
                 checkpoint_pointer_value=(
-                    pointer_value if name in async_engines else None
+                    pointer_value if publishes_generation else None
+                ),
+                wait_for_async_save=(
+                    name in async_engines and not publishes_generation
                 ),
             )
 
-        if async_engines:
+        if publisher_name is not None:
             logger.info(
-                "Checkpoint generation %s will be published after Megatron "
-                "async finalize completes",
+                "Checkpoint generation %s will be published after engine %s "
+                "finishes Megatron async finalize",
                 generation,
+                publisher_name,
             )
         else:
             cp.publish_latest(save_root, pointer_value)
@@ -530,6 +536,7 @@ class RecoverHandler:
         base_model_path: str | None = None,
         checkpoint_pointer_path: str | None = None,
         checkpoint_pointer_value: str | None = None,
+        wait_for_async_save: bool = False,
     ):
         weight_format = "dcp"
         with_optim = not self.config.no_save_optim
@@ -542,6 +549,7 @@ class RecoverHandler:
             base_model_path=base_model_path,
             checkpoint_pointer_path=checkpoint_pointer_path,
             checkpoint_pointer_value=checkpoint_pointer_value,
+            wait_for_async_save=wait_for_async_save,
         )
         engine.save(meta)
         logger.info(f"Saved recover checkpoint to {path} (with_optim={with_optim})")

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -24,7 +24,9 @@ from areal.api import (
 )
 from areal.api.cli_args import RecoverConfig
 from areal.infra import TrainController
+from areal.utils import checkpoint_pointer as cp
 from areal.utils import logging, timeutil
+from areal.utils.environ import is_single_controller
 from areal.utils.evaluator import Evaluator
 from areal.utils.saver import Saver
 
@@ -219,6 +221,11 @@ class RecoverHandler:
         return {"default": engine}
 
     @staticmethod
+    def _supports_checkpoint_pointer() -> bool:
+        multi_rank = dist.is_initialized() and dist.get_world_size() > 1
+        return is_single_controller() and not multi_rank
+
+    @staticmethod
     def _should_run_awex_colocate_transfer(
         inference_engine: InferenceEngine | None,
         weight_update_meta: WeightUpdateMeta | None,
@@ -263,6 +270,19 @@ class RecoverHandler:
                 "configuration without actor-rollout colocation."
             )
 
+    @staticmethod
+    def _uses_async_checkpoint(
+        engine: TrainEngine | TrainController,
+    ) -> bool:
+        config = getattr(engine, "config", None)
+        backend = getattr(config, "backend", "")
+        megatron_config = getattr(config, "megatron", None)
+        return (
+            isinstance(backend, str)
+            and backend.split(":", 1)[0] == "megatron"
+            and bool(getattr(megatron_config, "async_save", False))
+        )
+
     def dump(
         self,
         engine: TrainEngine
@@ -289,15 +309,6 @@ class RecoverHandler:
         normalized_engine: dict[str, TrainEngine | TrainController] = (
             self._normalize_recover_engines(engine)
         )
-        for name, engine_ in normalized_engine.items():
-            self._save_checkpoint(
-                engine_,
-                name=name,
-                tokenizer=tokenizer,
-                processor=processor,
-                base_model_path=base_model_path,
-            )
-
         self.last_step_info = step_info
         recover_info = RecoverInfo(
             last_step_info=self.last_step_info,
@@ -307,13 +318,91 @@ class RecoverHandler:
             dataloader_info=dataloader.state_dict(),
             checkpoint_info=self.freq_ctl.state_dict(),
         )
-
-        recover_info_path = self.recover_info_path(
+        save_root = Saver.get_save_root(
             self.config.experiment_name,
             self.config.trial_name,
             self.config.fileroot,
         )
-        recover_info.dump(recover_info_path)
+
+        if not self._supports_checkpoint_pointer():
+            if cp.read_latest(save_root) is not None:
+                raise cp.CheckpointConsistencyError(
+                    "Cannot write a legacy recovery checkpoint while LATEST "
+                    "selects a transactional checkpoint generation"
+                )
+            for name, engine_ in normalized_engine.items():
+                self._save_checkpoint(
+                    engine_,
+                    path=Saver.get_recover_checkpoint_path(
+                        self.config.experiment_name,
+                        self.config.trial_name,
+                        self.config.fileroot,
+                        name=name,
+                    ),
+                    name=name,
+                    tokenizer=tokenizer,
+                    processor=processor,
+                    base_model_path=base_model_path,
+                )
+            recover_info.dump(
+                self.recover_info_path(
+                    self.config.experiment_name,
+                    self.config.trial_name,
+                    self.config.fileroot,
+                )
+            )
+            return
+
+        engine_names = list(normalized_engine)
+        async_engines = [
+            name
+            for name, engine_ in normalized_engine.items()
+            if self._uses_async_checkpoint(engine_)
+        ]
+        # TODO(agent): coordinate per-engine finalize callbacks before allowing
+        # an asynchronous generation containing both actor and critic payloads.
+        if async_engines and len(normalized_engine) != 1:
+            raise NotImplementedError(
+                "Crash-safe asynchronous recovery currently supports one train "
+                "engine. Disable Megatron async_save when saving multiple engines."
+            )
+
+        generation, pointer_record = cp.prepare_generation(
+            save_root, step_info.global_step, engine_names
+        )
+
+        recover_info.dump(cp.manifest_dir(generation))
+
+        pointer_value = pointer_record.to_json()
+        for name, engine_ in normalized_engine.items():
+            self._save_checkpoint(
+                engine_,
+                path=cp.payload_dir(generation, name),
+                name=name,
+                tokenizer=tokenizer,
+                processor=processor,
+                base_model_path=base_model_path,
+                checkpoint_pointer_path=(
+                    cp.latest_path(save_root) if name in async_engines else None
+                ),
+                checkpoint_pointer_value=(
+                    pointer_value if name in async_engines else None
+                ),
+            )
+
+        if async_engines:
+            logger.info(
+                "Checkpoint generation %s will be published after Megatron "
+                "async finalize completes",
+                generation,
+            )
+        else:
+            cp.publish_latest(save_root, pointer_value)
+            logger.info(
+                "Published recovery checkpoint generation %s at step %s",
+                generation,
+                step_info.global_step,
+            )
 
     def load(
         self,
@@ -341,15 +430,25 @@ class RecoverHandler:
             self._normalize_recover_engines(engine)
         )
 
-        recover_info_path = self.recover_info_path(
+        save_root = Saver.get_save_root(
             self.config.experiment_name,
             self.config.trial_name,
             self.config.fileroot,
         )
-        logger.info(f"Loading recover info from {recover_info_path}")
+        source = cp.resolve_checkpoint(save_root, list(normalized_engine))
+        if source is None:
+            logger.warning(
+                f"Resume info not found under {save_root}. "
+                f"This should not be a resumed experiment!"
+            )
+            return None
+        logger.info(f"Loading recover info from {source.manifest}")
         try:
-            recover_info: RecoverInfo = RecoverInfo.load(recover_info_path)
-            logger.info(f"Recovering from {recover_info.last_step_info.next()}.")
+            recover_info: RecoverInfo = RecoverInfo.load(source.manifest)
+            logger.info(
+                f"Recovering from {recover_info.last_step_info.next()} using "
+                f"{source.label}."
+            )
             saver.load_state_dict(recover_info.saver_info)
             self.freq_ctl.load_state_dict(recover_info.checkpoint_info)
             evaluator.load_state_dict(recover_info.evaluator_info)
@@ -369,7 +468,9 @@ class RecoverHandler:
 
             if not is_awex_colocate:
                 for name, engine_ in normalized_engine.items():
-                    self._load_checkpoint(engine_, name=name)
+                    self._load_checkpoint(
+                        engine_, path=source.payloads[name], name=name
+                    )
 
             if inference_engine is not None:
                 assert weight_update_meta is not None
@@ -398,7 +499,9 @@ class RecoverHandler:
                         # first would stack DCP weights/optimizer on top of the
                         # still-resident sglang allocation and risk OOM.
                         for name, engine_ in normalized_engine.items():
-                            self._load_checkpoint(engine_, name=name)
+                            self._load_checkpoint(
+                                engine_, path=source.payloads[name], name=name
+                            )
                     update_engine.update_weights(versioned_meta)
                 finally:
                     # Always resume: leaving rollout paused after a failed
@@ -407,26 +510,27 @@ class RecoverHandler:
                 update_engine.set_version(recovery_version)
                 inference_engine.set_version(recovery_version)
             return recover_info
-        except (FileNotFoundError, InValidRecoverInfo):
+        except (FileNotFoundError, InValidRecoverInfo) as e:
+            if source.transactional:
+                raise cp.CheckpointConsistencyError(
+                    f"Published checkpoint {source.label} is not loadable: {e}"
+                ) from e
             logger.warning(
-                f"Resume info not found at {recover_info_path}. "
+                f"Resume info not found at {source.manifest}. "
                 f"This should not be a resumed experiment!"
             )
 
     def _save_checkpoint(
         self,
         engine: TrainEngine,
+        path: str,
         name: str = "default",
         tokenizer: PreTrainedTokenizerFast | None = None,
         processor: AutoProcessor | None = None,
         base_model_path: str | None = None,
+        checkpoint_pointer_path: str | None = None,
+        checkpoint_pointer_value: str | None = None,
     ):
-        path = Saver.get_recover_checkpoint_path(
-            self.config.experiment_name,
-            self.config.trial_name,
-            self.config.fileroot,
-            name=name,
-        )
         weight_format = "dcp"
         with_optim = not self.config.no_save_optim
         meta = SaveLoadMeta(
@@ -436,6 +540,8 @@ class RecoverHandler:
             tokenizer=tokenizer,
             processor=processor,
             base_model_path=base_model_path,
+            checkpoint_pointer_path=checkpoint_pointer_path,
+            checkpoint_pointer_value=checkpoint_pointer_value,
         )
         engine.save(meta)
         logger.info(f"Saved recover checkpoint to {path} (with_optim={with_optim})")
@@ -443,16 +549,11 @@ class RecoverHandler:
     def _load_checkpoint(
         self,
         engine: TrainEngine | TrainController,
+        path: str,
         name: str = "default",
         tokenizer: PreTrainedTokenizerFast | None = None,
         base_model_path: str | None = None,
     ):
-        path = Saver.get_recover_checkpoint_path(
-            self.config.experiment_name,
-            self.config.trial_name,
-            self.config.fileroot,
-            name=name,
-        )
         if not os.path.exists(path):
             raise FileNotFoundError(f"Checkpoint path {path} does not exist.")
         weight_format = "dcp"
@@ -471,41 +572,30 @@ class RecoverHandler:
 def check_if_auto_recover(config: RecoverConfig) -> bool:
     # This method is called by check_if_recover to check if the experiment should
     # recover from a previous run when recovery is enabled ("on" or "auto" mode).
-    experiment_name = config.experiment_name
-    trial_name = config.trial_name
-    fileroot = config.fileroot
-    recover_info_path = RecoverHandler.recover_info_path(
-        experiment_name, trial_name, fileroot
+    save_root = Saver.get_save_root(
+        config.experiment_name, config.trial_name, config.fileroot
     )
-    logger.info(f"Searching for recover info file in {recover_info_path}.")
-    if os.path.exists(str(recover_info_path)):
-        try:
-            info = RecoverInfo.load(recover_info_path)
-        except Exception as e:
-            logger.warning(f"Failed to load recover info from {recover_info_path}: {e}")
-            return False
-        if info.last_step_info.epoch < 0:
-            msg = (
-                f"Recover checkpoint is not valid. "
-                f"Expected last_step_info.epoch >= 0, "
-                f"but found {info.last_step_info.epoch}"
-            )
-            logger.warning(msg)
-            return False
-
-        save_root = Saver.get_save_root(experiment_name, trial_name, fileroot)
-        for name in os.listdir(save_root):
-            if not os.path.isdir(os.path.join(save_root, name)):
-                continue
-            path = Saver.get_recover_checkpoint_path(
-                experiment_name, trial_name, fileroot, name=name
-            )
-            if not os.path.exists(path):
-                logger.warning(f"Recover checkpoint for model {name} does not exist.")
-                return False
-        return True
-    logger.warning(f"Recover info not found at: {recover_info_path}")
-    return False
+    logger.info(f"Searching for recovery checkpoint under {save_root}.")
+    source = cp.resolve_checkpoint(save_root, None)
+    if source is None:
+        logger.warning(f"Recover info not found under: {save_root}")
+        return False
+    try:
+        info = RecoverInfo.load(source.manifest)
+    except Exception as e:
+        if source.transactional:
+            raise cp.CheckpointConsistencyError(
+                f"Published checkpoint {source.label} is not loadable: {e}"
+            ) from e
+        logger.warning(f"Failed to load recover info from {source.manifest}: {e}")
+        return False
+    if info.last_step_info.epoch < 0:
+        logger.warning(
+            "Recover checkpoint is not valid. Expected last_step_info.epoch "
+            f">= 0, but found {info.last_step_info.epoch}"
+        )
+        return False
+    return True
 
 
 def check_if_recover(config: RecoverConfig, _run_id: int) -> bool:

--- a/docs/en/reference/checkpointing.md
+++ b/docs/en/reference/checkpointing.md
@@ -36,7 +36,9 @@ Used by `RecoverHandler` for fault tolerance:
 - Includes model weights, optimizer state, RNG state, etc
 - Backend-specific: checkpoints are only compatible with the same parallelism
   configuration
-- Overwrites previous checkpoint to save disk space
+- In single-controller mode, writes an immutable generation and atomically publishes it
+  through a `LATEST` pointer
+- Retains the legacy overwrite layout in SPMD mode
 
 ## Architecture
 
@@ -186,25 +188,28 @@ RecoverHandler saves complete training state:
 
 ### Output Location
 
-Recovery checkpoints are saved to:
+In single-controller mode, recovery checkpoints are saved as immutable generations:
 
 ```
 {fileroot}/checkpoints/{user}/{experiment_name}/{trial_name}/
-├── default/
-│   └── recover_checkpoint/     # Model + optimizer (DCP format)
-│       ├── __0_0.distcp
-│       ├── __1_0.distcp
-│       └── ...
-├── critic/                     # If using critic
-│   └── recover_checkpoint/
-└── recover_info/               # Metadata
-    ├── step_info.json
-    ├── saver_info.json
-    ├── evaluator_info.json
-    ├── stats_logger_info.json
-    ├── checkpoint_info.json
-    └── dataloader_info.pkl
+├── LATEST                      # Atomic JSON pointer to one complete generation
+└── checkpoint_generations/
+    └── generation_step00000123/
+        ├── manifest/           # Dataloader and training progress metadata
+        └── payloads/
+            ├── default/        # Model + optimizer (DCP format)
+            └── critic/         # Present when a critic is checkpointed
 ```
+
+The pointer is updated only after every synchronous payload save returns. For Megatron
+asynchronous saves, publication is appended to MCore's finalize callbacks, after
+background I/O finishes. A crash may leave an unpublished generation on disk, but
+recovery continues to use the generation selected by `LATEST`. The previous published
+generation is removed after the pointer switches successfully.
+
+SPMD trainers keep the pre-pointer `recover_info/` and `<engine>/recover_checkpoint/`
+layout for compatibility. Recovery can read both layouts. Asynchronous publication of a
+checkpoint containing multiple train engines is not supported yet.
 
 ### Recovery Process
 
@@ -230,12 +235,16 @@ When training resumes:
 
 - **Saver**: Each save creates a new directory. High frequency consumes significant
   space.
-- **RecoverHandler**: Overwrites previous checkpoint. Only one copy exists at a time.
+- **RecoverHandler**: Normally keeps one published generation plus any in-progress or
+  crash-abandoned generation. SPMD mode continues to overwrite the legacy paths.
 
 ### Recovery Tips
 
-1. **Verify checkpoint validity**: Check `recover_info/step_info.json` for the last
-   saved step
+1. **Verify checkpoint validity**: Read `LATEST`, then inspect the selected generation's
+   `manifest/step_info.json`
 1. **Same config required**: DCP checkpoints require identical parallelism
    configuration, experiment name, and trial name
-1. **Clean restart**: Delete `recover_info/` directory to start fresh
+1. **One writer per trial**: Do not run concurrent checkpoint writers against the same
+   experiment and trial directory
+1. **Clean restart**: Delete both `LATEST` and `checkpoint_generations/`. For a legacy
+   SPMD checkpoint, delete `recover_info/` and each engine's `recover_checkpoint/`

--- a/docs/en/reference/checkpointing.md
+++ b/docs/en/reference/checkpointing.md
@@ -201,15 +201,16 @@ In single-controller mode, recovery checkpoints are saved as immutable generatio
             └── critic/         # Present when a critic is checkpointed
 ```
 
-The pointer is updated only after every synchronous payload save returns. For Megatron
-asynchronous saves, publication is appended to MCore's finalize callbacks, after
-background I/O finishes. A crash may leave an unpublished generation on disk, but
-recovery continues to use the generation selected by `LATEST`. The previous published
-generation is removed after the pointer switches successfully.
+The pointer is updated only after every payload is durable. When a generation contains
+multiple train engines, `RecoverHandler` drains all but one asynchronous save before
+scheduling the final asynchronous engine. Publication is appended only to that engine's
+MCore finalize callback, so one background save can still overlap training without
+exposing a partially written actor/critic generation. A crash may leave an unpublished
+generation on disk, but recovery continues to use the generation selected by `LATEST`.
+The previous published generation is removed after the pointer switches successfully.
 
 SPMD trainers keep the pre-pointer `recover_info/` and `<engine>/recover_checkpoint/`
-layout for compatibility. Recovery can read both layouts. Asynchronous publication of a
-checkpoint containing multiple train engines is not supported yet.
+layout for compatibility. Recovery can read both layouts.
 
 ### Recovery Process
 

--- a/docs/zh/reference/checkpointing.md
+++ b/docs/zh/reference/checkpointing.md
@@ -32,7 +32,8 @@ AReaL 提供两种互补的检查点机制：
 - 跨所有 rank 分片以实现高效的并行 I/O
 - 包含模型权重、优化器状态、RNG 状态等
 - 后端特定：检查点仅与相同并行配置兼容
-- 覆盖之前的检查点以节省磁盘空间
+- 在 single-controller 模式下写入不可变 generation，并通过 `LATEST` 指针原子发布
+- SPMD 模式继续使用原有的覆盖写入布局
 
 ## 架构
 
@@ -178,25 +179,25 @@ RecoverHandler 保存完整训练状态：
 
 ### 输出位置
 
-恢复检查点保存到：
+在 single-controller 模式下，恢复检查点保存为不可变 generation：
 
 ```
 {fileroot}/checkpoints/{user}/{experiment_name}/{trial_name}/
-├── default/
-│   └── recover_checkpoint/     # 模型 + 优化器（DCP 格式）
-│       ├── __0_0.distcp
-│       ├── __1_0.distcp
-│       └── ...
-├── critic/                     # 如果使用 critic
-│   └── recover_checkpoint/
-└── recover_info/               # 元数据
-    ├── step_info.json
-    ├── saver_info.json
-    ├── evaluator_info.json
-    ├── stats_logger_info.json
-    ├── checkpoint_info.json
-    └── dataloader_info.pkl
+├── LATEST                      # 原子 JSON 指针，指向一个完整 generation
+└── checkpoint_generations/
+    └── generation_step00000123/
+        ├── manifest/           # Dataloader 和训练进度元数据
+        └── payloads/
+            ├── default/        # 模型 + 优化器（DCP 格式）
+            └── critic/         # 保存 critic 时存在
 ```
+
+所有同步 payload 保存返回后才更新指针。对于 Megatron 异步保存，发布操作会追加到 MCore 的 finalize callback，在后台 I/O
+完成后执行。进程崩溃可能在磁盘上留下未发布的 generation，但恢复仍使用 `LATEST` 选中的 generation。指针成功切换后才删除上一个已发布
+generation。
+
+为保持兼容性，SPMD trainer 继续使用原有的 `recover_info/` 和 `<engine>/recover_checkpoint/`
+布局。恢复逻辑可以读取两种布局。目前尚不支持对包含多个 训练引擎的检查点进行异步发布。
 
 ### 恢复过程
 
@@ -221,10 +222,12 @@ RecoverHandler 保存完整训练状态：
 ### 磁盘空间注意事项
 
 - **Saver**：每次保存创建新目录。高频率会消耗大量空间。
-- **RecoverHandler**：覆盖之前的检查点。同时只存在一份副本。
+- **RecoverHandler**：通常保留一个已发布 generation，以及可能存在的正在写入或崩溃遗留 generation。SPMD 模式继续覆盖原有路径。
 
 ### 恢复技巧
 
-1. **验证检查点有效性**：检查 `recover_info/step_info.json` 获取最后保存的步数
+1. **验证检查点有效性**：读取 `LATEST`，再检查其选中 generation 的 `manifest/step_info.json`
 1. **需要相同配置**：DCP 检查点需要相同的并行配置、实验名称和试次名称
-1. **干净重启**：删除 `recover_info/` 目录以全新开始
+1. **每个 trial 仅一个 writer**：不要让多个检查点 writer 并发写入同一实验和 trial 目录
+1. **干净重启**：同时删除 `LATEST` 和 `checkpoint_generations/`。对于旧版 SPMD 检查点， 删除 `recover_info/`
+   和每个引擎的 `recover_checkpoint/`

--- a/docs/zh/reference/checkpointing.md
+++ b/docs/zh/reference/checkpointing.md
@@ -192,12 +192,13 @@ RecoverHandler 保存完整训练状态：
             └── critic/         # 保存 critic 时存在
 ```
 
-所有同步 payload 保存返回后才更新指针。对于 Megatron 异步保存，发布操作会追加到 MCore 的 finalize callback，在后台 I/O
-完成后执行。进程崩溃可能在磁盘上留下未发布的 generation，但恢复仍使用 `LATEST` 选中的 generation。指针成功切换后才删除上一个已发布
-generation。
+只有所有 payload 都持久化后才更新指针。当一个 generation 包含多个训练引擎时，`RecoverHandler`
+会先等待除最后一个异步引擎以外的所有保存完成，再调度最后一个异步引擎。发布操作只追加到该引擎的 MCore finalize
+callback，因此仍可让一次后台保存与训练重叠，同时不会暴露只写完 actor 或 critic 的 generation。 进程崩溃可能在磁盘上留下未发布的
+generation，但恢复仍使用 `LATEST` 选中的 generation。指针成功切换后才删除上一个已发布 generation。
 
 为保持兼容性，SPMD trainer 继续使用原有的 `recover_info/` 和 `<engine>/recover_checkpoint/`
-布局。恢复逻辑可以读取两种布局。目前尚不支持对包含多个 训练引擎的检查点进行异步发布。
+布局。恢复逻辑可以读取两种布局。
 
 ### 恢复过程
 

--- a/tests/test_checkpoint_pointer.py
+++ b/tests/test_checkpoint_pointer.py
@@ -2,95 +2,114 @@ import os
 
 import pytest
 
-from areal.utils import checkpoint_pointer as cp
+from areal.utils import checkpoint_pointer
 
 
 def make_generation(root: str, step: int, engines=("default",)) -> str:
-    generation = cp.generation_dir(root, step)
-    os.makedirs(cp.manifest_dir(generation))
+    generation = checkpoint_pointer.generation_dir(root, step)
+    os.makedirs(checkpoint_pointer.manifest_dir(generation))
     for name in engines:
-        os.makedirs(cp.payload_dir(generation, name))
+        os.makedirs(checkpoint_pointer.payload_dir(generation, name))
     return generation
 
 
 def test_publish_latest_atomically_selects_generation(tmp_path):
     root = str(tmp_path)
     make_generation(root, 4)
-    record = cp.make_record(4, ["default"])
+    record = checkpoint_pointer.make_record(4, ["default"])
 
-    cp.publish_latest(root, record.to_json())
+    checkpoint_pointer.publish_latest(root, record.to_json())
 
-    assert cp.read_latest(root) == record
-    source = cp.resolve_checkpoint(root, ["default"])
-    assert source.manifest == cp.manifest_dir(cp.generation_dir(root, 4))
+    assert checkpoint_pointer.read_latest(root) == record
+    source = checkpoint_pointer.resolve_checkpoint(root, ["default"])
+    assert source.manifest == checkpoint_pointer.manifest_dir(
+        checkpoint_pointer.generation_dir(root, 4)
+    )
     assert source.transactional is True
 
 
 def test_publish_latest_removes_previous_generation_after_switch(tmp_path):
     root = str(tmp_path)
     old_generation = make_generation(root, 4)
-    cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+    checkpoint_pointer.publish_latest(
+        root, checkpoint_pointer.make_record(4, ["default"]).to_json()
+    )
     new_generation = make_generation(root, 7)
 
-    cp.publish_latest(root, cp.make_record(7, ["default"]).to_json())
+    checkpoint_pointer.publish_latest(
+        root, checkpoint_pointer.make_record(7, ["default"]).to_json()
+    )
 
     assert not os.path.exists(old_generation)
     assert os.path.isdir(new_generation)
-    assert cp.read_latest(root).global_step == 7
+    assert checkpoint_pointer.read_latest(root).global_step == 7
 
 
 def test_partial_newer_generation_does_not_change_recovery_source(tmp_path):
     root = str(tmp_path)
     make_generation(root, 4)
-    cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+    checkpoint_pointer.publish_latest(
+        root, checkpoint_pointer.make_record(4, ["default"]).to_json()
+    )
     make_generation(root, 7)
 
-    source = cp.resolve_checkpoint(root, ["default"])
+    source = checkpoint_pointer.resolve_checkpoint(root, ["default"])
 
-    assert source.payloads["default"] == cp.payload_dir(
-        cp.generation_dir(root, 4), "default"
+    assert source.payloads["default"] == checkpoint_pointer.payload_dir(
+        checkpoint_pointer.generation_dir(root, 4), "default"
     )
 
 
 def test_resolve_checkpoint_rejects_engine_set_mismatch(tmp_path):
     root = str(tmp_path)
     make_generation(root, 4, engines=("actor", "critic"))
-    cp.publish_latest(root, cp.make_record(4, ["actor", "critic"]).to_json())
+    checkpoint_pointer.publish_latest(
+        root,
+        checkpoint_pointer.make_record(4, ["actor", "critic"]).to_json(),
+    )
 
-    with pytest.raises(cp.CheckpointConsistencyError, match="requires"):
-        cp.resolve_checkpoint(root, ["actor"])
+    with pytest.raises(checkpoint_pointer.CheckpointConsistencyError, match="requires"):
+        checkpoint_pointer.resolve_checkpoint(root, ["actor"])
 
 
 def test_publish_latest_rejects_missing_payload_directory(tmp_path):
     root = str(tmp_path)
-    generation = cp.generation_dir(root, 4)
-    os.makedirs(cp.manifest_dir(generation))
+    generation = checkpoint_pointer.generation_dir(root, 4)
+    os.makedirs(checkpoint_pointer.manifest_dir(generation))
 
-    with pytest.raises(cp.CheckpointConsistencyError, match="missing paths"):
-        cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+    with pytest.raises(
+        checkpoint_pointer.CheckpointConsistencyError, match="missing paths"
+    ):
+        checkpoint_pointer.publish_latest(
+            root, checkpoint_pointer.make_record(4, ["default"]).to_json()
+        )
 
-    assert not os.path.exists(cp.latest_path(root))
+    assert not os.path.exists(checkpoint_pointer.latest_path(root))
 
 
 def test_invalid_latest_does_not_fall_back_to_legacy_checkpoint(tmp_path):
     root = str(tmp_path)
-    os.makedirs(os.path.join(root, cp.LEGACY_MANIFEST_DIRNAME))
-    os.makedirs(os.path.join(root, "default", cp.LEGACY_PAYLOAD_DIRNAME))
-    with open(cp.latest_path(root), "w") as f:
+    os.makedirs(os.path.join(root, checkpoint_pointer.LEGACY_MANIFEST_DIRNAME))
+    os.makedirs(
+        os.path.join(root, "default", checkpoint_pointer.LEGACY_PAYLOAD_DIRNAME)
+    )
+    with open(checkpoint_pointer.latest_path(root), "w") as f:
         f.write("not json")
 
-    with pytest.raises(cp.CheckpointConsistencyError, match="Invalid recovery"):
-        cp.resolve_checkpoint(root, ["default"])
+    with pytest.raises(
+        checkpoint_pointer.CheckpointConsistencyError, match="Invalid recovery"
+    ):
+        checkpoint_pointer.resolve_checkpoint(root, ["default"])
 
 
 def test_resolve_checkpoint_accepts_pre_pointer_layout(tmp_path):
     root = str(tmp_path)
-    manifest = os.path.join(root, cp.LEGACY_MANIFEST_DIRNAME)
-    payload = os.path.join(root, "default", cp.LEGACY_PAYLOAD_DIRNAME)
+    manifest = os.path.join(root, checkpoint_pointer.LEGACY_MANIFEST_DIRNAME)
+    payload = os.path.join(root, "default", checkpoint_pointer.LEGACY_PAYLOAD_DIRNAME)
     os.makedirs(manifest)
     os.makedirs(payload)
 
-    source = cp.resolve_checkpoint(root, ["default"])
+    source = checkpoint_pointer.resolve_checkpoint(root, ["default"])
 
     assert source.manifest == manifest
     assert source.payloads == {"default": payload}
@@ -103,7 +122,7 @@ def test_prepare_generation_replaces_only_unpublished_same_step(tmp_path):
     stale_file = os.path.join(stale, "partial")
     open(stale_file, "w").close()
 
-    generation, record = cp.prepare_generation(root, 7, ["default"])
+    generation, record = checkpoint_pointer.prepare_generation(root, 7, ["default"])
 
     assert generation == stale
     assert record.global_step == 7
@@ -113,19 +132,29 @@ def test_prepare_generation_replaces_only_unpublished_same_step(tmp_path):
 def test_prepare_generation_refuses_to_overwrite_published_step(tmp_path):
     root = str(tmp_path)
     make_generation(root, 7)
-    cp.publish_latest(root, cp.make_record(7, ["default"]).to_json())
+    checkpoint_pointer.publish_latest(
+        root, checkpoint_pointer.make_record(7, ["default"]).to_json()
+    )
 
-    with pytest.raises(cp.CheckpointConsistencyError, match="already points"):
-        cp.prepare_generation(root, 7, ["default"])
+    with pytest.raises(
+        checkpoint_pointer.CheckpointConsistencyError, match="already points"
+    ):
+        checkpoint_pointer.prepare_generation(root, 7, ["default"])
 
 
 def test_publish_latest_refuses_to_move_pointer_backwards(tmp_path):
     root = str(tmp_path)
     make_generation(root, 4)
     make_generation(root, 7)
-    cp.publish_latest(root, cp.make_record(7, ["default"]).to_json())
+    checkpoint_pointer.publish_latest(
+        root, checkpoint_pointer.make_record(7, ["default"]).to_json()
+    )
 
-    with pytest.raises(cp.CheckpointConsistencyError, match="backwards"):
-        cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+    with pytest.raises(
+        checkpoint_pointer.CheckpointConsistencyError, match="backwards"
+    ):
+        checkpoint_pointer.publish_latest(
+            root, checkpoint_pointer.make_record(4, ["default"]).to_json()
+        )
 
-    assert cp.read_latest(root).global_step == 7
+    assert checkpoint_pointer.read_latest(root).global_step == 7

--- a/tests/test_checkpoint_pointer.py
+++ b/tests/test_checkpoint_pointer.py
@@ -1,0 +1,131 @@
+import os
+
+import pytest
+
+from areal.utils import checkpoint_pointer as cp
+
+
+def make_generation(root: str, step: int, engines=("default",)) -> str:
+    generation = cp.generation_dir(root, step)
+    os.makedirs(cp.manifest_dir(generation))
+    for name in engines:
+        os.makedirs(cp.payload_dir(generation, name))
+    return generation
+
+
+def test_publish_latest_atomically_selects_generation(tmp_path):
+    root = str(tmp_path)
+    make_generation(root, 4)
+    record = cp.make_record(4, ["default"])
+
+    cp.publish_latest(root, record.to_json())
+
+    assert cp.read_latest(root) == record
+    source = cp.resolve_checkpoint(root, ["default"])
+    assert source.manifest == cp.manifest_dir(cp.generation_dir(root, 4))
+    assert source.transactional is True
+
+
+def test_publish_latest_removes_previous_generation_after_switch(tmp_path):
+    root = str(tmp_path)
+    old_generation = make_generation(root, 4)
+    cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+    new_generation = make_generation(root, 7)
+
+    cp.publish_latest(root, cp.make_record(7, ["default"]).to_json())
+
+    assert not os.path.exists(old_generation)
+    assert os.path.isdir(new_generation)
+    assert cp.read_latest(root).global_step == 7
+
+
+def test_partial_newer_generation_does_not_change_recovery_source(tmp_path):
+    root = str(tmp_path)
+    make_generation(root, 4)
+    cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+    make_generation(root, 7)
+
+    source = cp.resolve_checkpoint(root, ["default"])
+
+    assert source.payloads["default"] == cp.payload_dir(
+        cp.generation_dir(root, 4), "default"
+    )
+
+
+def test_resolve_checkpoint_rejects_engine_set_mismatch(tmp_path):
+    root = str(tmp_path)
+    make_generation(root, 4, engines=("actor", "critic"))
+    cp.publish_latest(root, cp.make_record(4, ["actor", "critic"]).to_json())
+
+    with pytest.raises(cp.CheckpointConsistencyError, match="requires"):
+        cp.resolve_checkpoint(root, ["actor"])
+
+
+def test_publish_latest_rejects_missing_payload_directory(tmp_path):
+    root = str(tmp_path)
+    generation = cp.generation_dir(root, 4)
+    os.makedirs(cp.manifest_dir(generation))
+
+    with pytest.raises(cp.CheckpointConsistencyError, match="missing paths"):
+        cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+
+    assert not os.path.exists(cp.latest_path(root))
+
+
+def test_invalid_latest_does_not_fall_back_to_legacy_checkpoint(tmp_path):
+    root = str(tmp_path)
+    os.makedirs(os.path.join(root, cp.LEGACY_MANIFEST_DIRNAME))
+    os.makedirs(os.path.join(root, "default", cp.LEGACY_PAYLOAD_DIRNAME))
+    with open(cp.latest_path(root), "w") as f:
+        f.write("not json")
+
+    with pytest.raises(cp.CheckpointConsistencyError, match="Invalid recovery"):
+        cp.resolve_checkpoint(root, ["default"])
+
+
+def test_resolve_checkpoint_accepts_pre_pointer_layout(tmp_path):
+    root = str(tmp_path)
+    manifest = os.path.join(root, cp.LEGACY_MANIFEST_DIRNAME)
+    payload = os.path.join(root, "default", cp.LEGACY_PAYLOAD_DIRNAME)
+    os.makedirs(manifest)
+    os.makedirs(payload)
+
+    source = cp.resolve_checkpoint(root, ["default"])
+
+    assert source.manifest == manifest
+    assert source.payloads == {"default": payload}
+    assert source.transactional is False
+
+
+def test_prepare_generation_replaces_only_unpublished_same_step(tmp_path):
+    root = str(tmp_path)
+    stale = make_generation(root, 7)
+    stale_file = os.path.join(stale, "partial")
+    open(stale_file, "w").close()
+
+    generation, record = cp.prepare_generation(root, 7, ["default"])
+
+    assert generation == stale
+    assert record.global_step == 7
+    assert not os.path.exists(stale_file)
+
+
+def test_prepare_generation_refuses_to_overwrite_published_step(tmp_path):
+    root = str(tmp_path)
+    make_generation(root, 7)
+    cp.publish_latest(root, cp.make_record(7, ["default"]).to_json())
+
+    with pytest.raises(cp.CheckpointConsistencyError, match="already points"):
+        cp.prepare_generation(root, 7, ["default"])
+
+
+def test_publish_latest_refuses_to_move_pointer_backwards(tmp_path):
+    root = str(tmp_path)
+    make_generation(root, 4)
+    make_generation(root, 7)
+    cp.publish_latest(root, cp.make_record(7, ["default"]).to_json())
+
+    with pytest.raises(cp.CheckpointConsistencyError, match="backwards"):
+        cp.publish_latest(root, cp.make_record(4, ["default"]).to_json())
+
+    assert cp.read_latest(root).global_step == 7

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -199,7 +199,7 @@ def test_publication_failure_is_broadcast_before_all_ranks_raise(
         patch("torch.distributed.broadcast_object_list") as broadcast,
         pytest.raises(RuntimeError, match="disk unavailable"),
     ):
-        mod._run_rank0_finalize(0, publish)
+        mod._run_checkpoint_publication(0, publish)
 
     status = broadcast.call_args.args[0]
     assert status == [("OSError", "disk unavailable")]
@@ -224,7 +224,7 @@ def test_nonzero_rank_raises_publication_failure_received_from_rank0(
         ),
         pytest.raises(RuntimeError, match="disk unavailable"),
     ):
-        mod._run_rank0_finalize(1, publish)
+        mod._run_checkpoint_publication(1, publish)
 
     publish.assert_not_called()
 

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -7,6 +7,7 @@ that the manager correctly:
 - skips queue creation when async_save is False
 - routes the AsyncRequest to AsyncCallsQueue.schedule_async_request when True
 - finalizes completed saves non-blockingly on each new save call
+- appends recovery publication after MCore's existing finalize callbacks
 - blocks on load_checkpoint / close
 - treats close as idempotent
 - emits the async-only metric (queue_depth on schedule)
@@ -160,6 +161,71 @@ def test_save_schedules_async_request(patched_checkpointer, tmp_path):
     inspect_fn.assert_called_once_with(fake_request)
     queue.schedule_async_request.assert_called_once_with(fake_request)
     release_fn.assert_called_once_with(tensor_lists)
+
+
+def test_async_save_publishes_only_from_finalize(patched_checkpointer, tmp_path):
+    mod, manager, queue = patched_checkpointer
+    fake_request = MagicMock()
+    publish = MagicMock()
+
+    with (
+        patch.object(manager, "generate_state_dict", return_value={"model": {}}),
+        patch.object(mod, "save_dist_checkpointing", return_value=fake_request),
+        patch("torch.cuda.empty_cache"),
+        patch("torch.distributed.barrier"),
+    ):
+        manager.save_checkpoint(str(tmp_path / "step0"), finalize_fn=publish)
+
+    publish.assert_not_called()
+    fake_request.add_finalize_fn.assert_called_once()
+    queue.schedule_async_request.assert_called_once_with(fake_request)
+
+    appended_finalize = fake_request.add_finalize_fn.call_args.args[0]
+    appended_finalize()
+
+    publish.assert_called_once_with()
+
+
+def test_publication_failure_is_broadcast_before_all_ranks_raise(
+    patched_checkpointer,
+):
+    mod, _, _ = patched_checkpointer
+    publish = MagicMock(side_effect=OSError("disk unavailable"))
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.broadcast_object_list") as broadcast,
+        pytest.raises(RuntimeError, match="disk unavailable"),
+    ):
+        mod._run_rank0_finalize(0, publish)
+
+    status = broadcast.call_args.args[0]
+    assert status == [("OSError", "disk unavailable")]
+
+
+def test_nonzero_rank_raises_publication_failure_received_from_rank0(
+    patched_checkpointer,
+):
+    mod, _, _ = patched_checkpointer
+    publish = MagicMock()
+
+    def broadcast_rank0_failure(status, src):
+        assert src == 0
+        status[0] = ("OSError", "disk unavailable")
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch(
+            "torch.distributed.broadcast_object_list",
+            side_effect=broadcast_rank0_failure,
+        ),
+        pytest.raises(RuntimeError, match="disk unavailable"),
+    ):
+        mod._run_rank0_finalize(1, publish)
+
+    publish.assert_not_called()
 
 
 def test_save_reaps_before_scheduling_next(patched_checkpointer, tmp_path):

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -171,6 +171,7 @@ def test_async_save_publishes_only_from_finalize(patched_checkpointer, tmp_path)
     with (
         patch.object(manager, "generate_state_dict", return_value={"model": {}}),
         patch.object(mod, "save_dist_checkpointing", return_value=fake_request),
+        patch.object(mod, "_inspect_retained_payload", return_value=[]),
         patch("torch.cuda.empty_cache"),
         patch("torch.distributed.barrier"),
     ):

--- a/tests/test_megatron_engine.py
+++ b/tests/test_megatron_engine.py
@@ -1,10 +1,11 @@
 import json
 import os
 import time
+from contextlib import nullcontext
 from importlib.metadata import version as get_version
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 import torch
@@ -202,6 +203,61 @@ def test_bailing_v3_bridge_rejects_mtp_construction(monkeypatch):
 
     with pytest.raises(ValueError, match="does not support enable_mtp"):
         engine._build_hf_mcore_bridge()
+
+
+def test_dcp_save_waits_for_async_save_when_requested(tmp_path):
+    engine = MegatronEngine.__new__(MegatronEngine)
+    engine._weight_residency = None
+    engine._offload_aware_context = MagicMock(return_value=nullcontext())
+    engine.checkpointer = MagicMock()
+    meta = SaveLoadMeta(
+        path=str(tmp_path / "checkpoint"),
+        weight_format="dcp",
+        with_optim=True,
+        wait_for_async_save=True,
+    )
+
+    engine.save(meta)
+
+    assert engine.checkpointer.method_calls == [
+        call.save_checkpoint(meta.path, with_optimizer=True),
+        call.wait_async_saves(),
+    ]
+
+
+def test_dcp_save_does_not_wait_after_schedule_failure(tmp_path):
+    engine = MegatronEngine.__new__(MegatronEngine)
+    engine._weight_residency = None
+    engine._offload_aware_context = MagicMock(return_value=nullcontext())
+    engine.checkpointer = MagicMock()
+    engine.checkpointer.save_checkpoint.side_effect = RuntimeError("save failed")
+    meta = SaveLoadMeta(
+        path=str(tmp_path / "checkpoint"),
+        weight_format="dcp",
+        with_optim=True,
+        wait_for_async_save=True,
+    )
+
+    with pytest.raises(RuntimeError, match="save failed"):
+        engine.save(meta)
+
+    engine.checkpointer.wait_async_saves.assert_not_called()
+
+
+def test_dcp_save_does_not_wait_when_not_requested(tmp_path):
+    engine = MegatronEngine.__new__(MegatronEngine)
+    engine._weight_residency = None
+    engine._offload_aware_context = MagicMock(return_value=nullcontext())
+    engine.checkpointer = MagicMock()
+    meta = SaveLoadMeta(
+        path=str(tmp_path / "checkpoint"),
+        weight_format="dcp",
+        with_optim=True,
+    )
+
+    engine.save(meta)
+
+    engine.checkpointer.wait_async_saves.assert_not_called()
 
 
 # Cannot use a "module" scope since process groups can only be initialized once.

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -10,7 +10,7 @@ import pytest
 
 from areal.api.cli_args import RecoverConfig
 from areal.api.io_struct import FinetuneSpec, StepInfo
-from areal.utils import checkpoint_pointer as cp
+from areal.utils import checkpoint_pointer
 from areal.utils.recover import (
     RecoverHandler,
     check_if_auto_recover,
@@ -278,9 +278,11 @@ class TestRecoverHandler:
         )
 
         save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
-        assert cp.read_latest(save_root).global_step == 3
+        assert checkpoint_pointer.read_latest(save_root).global_step == 3
         meta = engine.save.call_args.args[0]
-        assert meta.path == cp.payload_dir(cp.generation_dir(save_root, 3), "default")
+        assert meta.path == checkpoint_pointer.payload_dir(
+            checkpoint_pointer.generation_dir(save_root, 3), "default"
+        )
         assert meta.checkpoint_pointer_path is None
 
     def test_dump_async_megatron_defers_pointer_to_finalize(self, tmp_path):
@@ -300,13 +302,13 @@ class TestRecoverHandler:
         )
 
         save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
-        assert cp.read_latest(save_root) is None
+        assert checkpoint_pointer.read_latest(save_root) is None
         meta = engine.save.call_args.args[0]
         assert meta.wait_for_async_save is False
-        assert meta.checkpoint_pointer_path == cp.latest_path(save_root)
+        assert meta.checkpoint_pointer_path == checkpoint_pointer.latest_path(save_root)
 
-        cp.publish_latest(save_root, meta.checkpoint_pointer_value)
-        assert cp.read_latest(save_root).global_step == 3
+        checkpoint_pointer.publish_latest(save_root, meta.checkpoint_pointer_value)
+        assert checkpoint_pointer.read_latest(save_root).global_step == 3
 
     def test_dump_multiple_async_engines_waits_before_deferred_publication(
         self, tmp_path
@@ -334,7 +336,7 @@ class TestRecoverHandler:
         )
 
         save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
-        assert cp.read_latest(save_root) is None
+        assert checkpoint_pointer.read_latest(save_root) is None
         assert save_order == ["default", "critic"]
 
         actor_meta = actor.save.call_args.args[0]
@@ -343,10 +345,14 @@ class TestRecoverHandler:
 
         critic_meta = critic.save.call_args.args[0]
         assert critic_meta.wait_for_async_save is False
-        assert critic_meta.checkpoint_pointer_path == cp.latest_path(save_root)
+        assert critic_meta.checkpoint_pointer_path == checkpoint_pointer.latest_path(
+            save_root
+        )
 
-        cp.publish_latest(save_root, critic_meta.checkpoint_pointer_value)
-        assert cp.read_latest(save_root).global_step == 3
+        checkpoint_pointer.publish_latest(
+            save_root, critic_meta.checkpoint_pointer_value
+        )
+        assert checkpoint_pointer.read_latest(save_root).global_step == 3
 
     def test_dump_mixed_engines_saves_async_publisher_last(self, tmp_path):
         handler = self._make_handler(str(tmp_path), "on")
@@ -374,10 +380,10 @@ class TestRecoverHandler:
         save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
         assert save_order == ["critic", "default"]
         assert critic.save.call_args.args[0].checkpoint_pointer_path is None
-        assert actor.save.call_args.args[0].checkpoint_pointer_path == cp.latest_path(
-            save_root
-        )
-        assert cp.read_latest(save_root) is None
+        assert actor.save.call_args.args[
+            0
+        ].checkpoint_pointer_path == checkpoint_pointer.latest_path(save_root)
+        assert checkpoint_pointer.read_latest(save_root) is None
 
     def test_dump_multiple_engines_keeps_latest_when_publisher_save_fails(
         self, tmp_path
@@ -396,8 +402,10 @@ class TestRecoverHandler:
             backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
         )
         save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
-        _, previous = cp.prepare_generation(save_root, 2, ["default", "critic"])
-        cp.publish_latest(save_root, previous.to_json())
+        _, previous = checkpoint_pointer.prepare_generation(
+            save_root, 2, ["default", "critic"]
+        )
+        checkpoint_pointer.publish_latest(save_root, previous.to_json())
 
         with pytest.raises(RuntimeError, match="critic save failed"):
             handler.dump(
@@ -407,7 +415,7 @@ class TestRecoverHandler:
             )
 
         assert actor.save.call_args.args[0].wait_for_async_save is True
-        assert cp.read_latest(save_root).global_step == 2
+        assert checkpoint_pointer.read_latest(save_root).global_step == 2
 
     def test_dump_spmd_mode_preserves_legacy_layout(self, tmp_path, monkeypatch):
         handler = self._make_handler(str(tmp_path), "on")
@@ -431,8 +439,10 @@ class TestRecoverHandler:
         assert meta.path == Saver.get_recover_checkpoint_path(
             "test_exp", "test_trial", str(tmp_path), name="default"
         )
-        assert os.path.isdir(os.path.join(save_root, cp.LEGACY_MANIFEST_DIRNAME))
-        assert cp.read_latest(save_root) is None
+        assert os.path.isdir(
+            os.path.join(save_root, checkpoint_pointer.LEGACY_MANIFEST_DIRNAME)
+        )
+        assert checkpoint_pointer.read_latest(save_root) is None
 
     @pytest.mark.parametrize("mode", ["on", "auto"])
     def test_load_rejects_gateway_train_controller(self, mode):

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -526,6 +526,29 @@ class TestRecoverHandler:
             assert meta.with_optim is (not no_load_optim)
 
 
+class TestPPORecoverEngines:
+    def test_actor_only_returns_default_engine(self):
+        from areal.trainer.rl_trainer import PPOTrainer
+
+        trainer = PPOTrainer.__new__(PPOTrainer)
+        trainer.actor = Mock()
+        trainer.critic = None
+
+        assert trainer._recover_engines() == {"default": trainer.actor}
+
+    def test_critic_is_included_with_stable_name(self):
+        from areal.trainer.rl_trainer import PPOTrainer
+
+        trainer = PPOTrainer.__new__(PPOTrainer)
+        trainer.actor = Mock()
+        trainer.critic = Mock()
+
+        assert trainer._recover_engines() == {
+            "default": trainer.actor,
+            "critic": trainer.critic,
+        }
+
+
 class TestAwexColocateGate:
     """The AWEX pre-transfer sequence must run only for colocated rollouts."""
 

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -302,33 +302,112 @@ class TestRecoverHandler:
         save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
         assert cp.read_latest(save_root) is None
         meta = engine.save.call_args.args[0]
+        assert meta.wait_for_async_save is False
         assert meta.checkpoint_pointer_path == cp.latest_path(save_root)
 
         cp.publish_latest(save_root, meta.checkpoint_pointer_value)
         assert cp.read_latest(save_root).global_step == 3
 
-    def test_dump_multiple_engines_rejects_async_publication(self, tmp_path):
+    def test_dump_multiple_async_engines_waits_before_deferred_publication(
+        self, tmp_path
+    ):
         handler = self._make_handler(str(tmp_path), "on")
         handler.freq_ctl = Mock()
         handler.freq_ctl.check.return_value = True
+        handler.freq_ctl.state_dict.return_value = {}
+        save_order = []
+        actor = Mock()
+        actor.save.side_effect = lambda _meta: save_order.append("default")
+        actor.config = SimpleNamespace(
+            backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
+        )
+        critic = Mock()
+        critic.save.side_effect = lambda _meta: save_order.append("critic")
+        critic.config = SimpleNamespace(
+            backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
+        )
+
+        handler.dump(
+            {"default": actor, "critic": critic},
+            self._step_info(handler),
+            *self._dump_dependencies(),
+        )
+
+        save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
+        assert cp.read_latest(save_root) is None
+        assert save_order == ["default", "critic"]
+
+        actor_meta = actor.save.call_args.args[0]
+        assert actor_meta.wait_for_async_save is True
+        assert actor_meta.checkpoint_pointer_path is None
+
+        critic_meta = critic.save.call_args.args[0]
+        assert critic_meta.wait_for_async_save is False
+        assert critic_meta.checkpoint_pointer_path == cp.latest_path(save_root)
+
+        cp.publish_latest(save_root, critic_meta.checkpoint_pointer_value)
+        assert cp.read_latest(save_root).global_step == 3
+
+    def test_dump_mixed_engines_saves_async_publisher_last(self, tmp_path):
+        handler = self._make_handler(str(tmp_path), "on")
+        handler.freq_ctl = Mock()
+        handler.freq_ctl.check.return_value = True
+        handler.freq_ctl.state_dict.return_value = {}
+        save_order = []
+        actor = Mock()
+        actor.save.side_effect = lambda _meta: save_order.append("default")
+        actor.config = SimpleNamespace(
+            backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
+        )
+        critic = Mock()
+        critic.save.side_effect = lambda _meta: save_order.append("critic")
+        critic.config = SimpleNamespace(
+            backend="fsdp:d1", megatron=SimpleNamespace(async_save=False)
+        )
+
+        handler.dump(
+            {"default": actor, "critic": critic},
+            self._step_info(handler),
+            *self._dump_dependencies(),
+        )
+
+        save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
+        assert save_order == ["critic", "default"]
+        assert critic.save.call_args.args[0].checkpoint_pointer_path is None
+        assert actor.save.call_args.args[0].checkpoint_pointer_path == cp.latest_path(
+            save_root
+        )
+        assert cp.read_latest(save_root) is None
+
+    def test_dump_multiple_engines_keeps_latest_when_publisher_save_fails(
+        self, tmp_path
+    ):
+        handler = self._make_handler(str(tmp_path), "on")
+        handler.freq_ctl = Mock()
+        handler.freq_ctl.check.return_value = True
+        handler.freq_ctl.state_dict.return_value = {}
         actor = Mock()
         actor.config = SimpleNamespace(
             backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
         )
         critic = Mock()
+        critic.save.side_effect = RuntimeError("critic save failed")
         critic.config = SimpleNamespace(
             backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
         )
+        save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
+        _, previous = cp.prepare_generation(save_root, 2, ["default", "critic"])
+        cp.publish_latest(save_root, previous.to_json())
 
-        with pytest.raises(NotImplementedError, match="one train engine"):
+        with pytest.raises(RuntimeError, match="critic save failed"):
             handler.dump(
                 {"default": actor, "critic": critic},
                 self._step_info(handler),
                 *self._dump_dependencies(),
             )
 
-        actor.save.assert_not_called()
-        critic.save.assert_not_called()
+        assert actor.save.call_args.args[0].wait_for_async_save is True
+        assert cp.read_latest(save_root).global_step == 2
 
     def test_dump_spmd_mode_preserves_legacy_layout(self, tmp_path, monkeypatch):
         handler = self._make_handler(str(tmp_path), "on")
@@ -408,6 +487,18 @@ class TestRecoverHandler:
 
             meta = engine.save.call_args[0][0]
             assert meta.with_optim is (not no_save_optim)
+
+    def test_save_checkpoint_passes_wait_for_async_save(self, tmp_path):
+        handler = self._make_handler(str(tmp_path), "auto")
+        engine = Mock()
+
+        handler._save_checkpoint(
+            engine,
+            path=str(tmp_path / "checkpoint"),
+            wait_for_async_save=True,
+        )
+
+        assert engine.save.call_args.args[0].wait_for_async_save is True
 
     @pytest.mark.parametrize("no_load_optim", [False, True])
     def test_load_checkpoint_passes_with_optim_from_config(self, no_load_optim):

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -3,12 +3,14 @@
 import dataclasses
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
 from areal.api.cli_args import RecoverConfig
 from areal.api.io_struct import FinetuneSpec, StepInfo
+from areal.utils import checkpoint_pointer as cp
 from areal.utils.recover import (
     RecoverHandler,
     check_if_auto_recover,
@@ -237,6 +239,122 @@ class TestRecoverHandler:
     def _make_gateway_controller() -> GatewayTrainController:
         return GatewayTrainController.__new__(GatewayTrainController)
 
+    @staticmethod
+    def _dump_dependencies():
+        saver = Mock()
+        saver.state_dict.return_value = {}
+        evaluator = Mock()
+        evaluator.state_dict.return_value = {}
+        stats_logger = Mock()
+        stats_logger.state_dict.return_value = {}
+        dataloader = Mock()
+        dataloader.state_dict.return_value = {}
+        dataloader.sampler = None
+        return saver, evaluator, stats_logger, dataloader
+
+    @staticmethod
+    def _step_info(handler: RecoverHandler, global_step: int = 3) -> StepInfo:
+        return StepInfo(
+            epoch=0,
+            epoch_step=global_step,
+            global_step=global_step,
+            steps_per_epoch=handler.ft_spec.steps_per_epoch,
+        )
+
+    def test_dump_sync_engine_publishes_generation(self, tmp_path):
+        handler = self._make_handler(str(tmp_path), "on")
+        handler.freq_ctl = Mock()
+        handler.freq_ctl.check.return_value = True
+        handler.freq_ctl.state_dict.return_value = {}
+        engine = Mock()
+        engine.config = SimpleNamespace(
+            backend="fsdp:d1", megatron=SimpleNamespace(async_save=False)
+        )
+
+        handler.dump(
+            engine,
+            self._step_info(handler),
+            *self._dump_dependencies(),
+        )
+
+        save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
+        assert cp.read_latest(save_root).global_step == 3
+        meta = engine.save.call_args.args[0]
+        assert meta.path == cp.payload_dir(cp.generation_dir(save_root, 3), "default")
+        assert meta.checkpoint_pointer_path is None
+
+    def test_dump_async_megatron_defers_pointer_to_finalize(self, tmp_path):
+        handler = self._make_handler(str(tmp_path), "on")
+        handler.freq_ctl = Mock()
+        handler.freq_ctl.check.return_value = True
+        handler.freq_ctl.state_dict.return_value = {}
+        engine = Mock()
+        engine.config = SimpleNamespace(
+            backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
+        )
+
+        handler.dump(
+            engine,
+            self._step_info(handler),
+            *self._dump_dependencies(),
+        )
+
+        save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
+        assert cp.read_latest(save_root) is None
+        meta = engine.save.call_args.args[0]
+        assert meta.checkpoint_pointer_path == cp.latest_path(save_root)
+
+        cp.publish_latest(save_root, meta.checkpoint_pointer_value)
+        assert cp.read_latest(save_root).global_step == 3
+
+    def test_dump_multiple_engines_rejects_async_publication(self, tmp_path):
+        handler = self._make_handler(str(tmp_path), "on")
+        handler.freq_ctl = Mock()
+        handler.freq_ctl.check.return_value = True
+        actor = Mock()
+        actor.config = SimpleNamespace(
+            backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
+        )
+        critic = Mock()
+        critic.config = SimpleNamespace(
+            backend="megatron:d1", megatron=SimpleNamespace(async_save=True)
+        )
+
+        with pytest.raises(NotImplementedError, match="one train engine"):
+            handler.dump(
+                {"default": actor, "critic": critic},
+                self._step_info(handler),
+                *self._dump_dependencies(),
+            )
+
+        actor.save.assert_not_called()
+        critic.save.assert_not_called()
+
+    def test_dump_spmd_mode_preserves_legacy_layout(self, tmp_path, monkeypatch):
+        handler = self._make_handler(str(tmp_path), "on")
+        handler.freq_ctl = Mock()
+        handler.freq_ctl.check.return_value = True
+        handler.freq_ctl.state_dict.return_value = {}
+        monkeypatch.setenv("AREAL_SPMD_MODE", "1")
+        engine = Mock()
+        engine.config = SimpleNamespace(
+            backend="fsdp:d1", megatron=SimpleNamespace(async_save=False)
+        )
+
+        handler.dump(
+            engine,
+            self._step_info(handler),
+            *self._dump_dependencies(),
+        )
+
+        save_root = Saver.get_save_root("test_exp", "test_trial", str(tmp_path))
+        meta = engine.save.call_args.args[0]
+        assert meta.path == Saver.get_recover_checkpoint_path(
+            "test_exp", "test_trial", str(tmp_path), name="default"
+        )
+        assert os.path.isdir(os.path.join(save_root, cp.LEGACY_MANIFEST_DIRNAME))
+        assert cp.read_latest(save_root) is None
+
     @pytest.mark.parametrize("mode", ["on", "auto"])
     def test_load_rejects_gateway_train_controller(self, mode):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -286,7 +404,7 @@ class TestRecoverHandler:
             handler = self._make_handler(tmpdir, "auto", no_save_optim=no_save_optim)
             engine = Mock()
 
-            handler._save_checkpoint(engine)
+            handler._save_checkpoint(engine, path=os.path.join(tmpdir, "checkpoint"))
 
             meta = engine.save.call_args[0][0]
             assert meta.with_optim is (not no_save_optim)
@@ -306,7 +424,12 @@ class TestRecoverHandler:
                 exist_ok=True,
             )
 
-            handler._load_checkpoint(engine)
+            handler._load_checkpoint(
+                engine,
+                path=Saver.get_recover_checkpoint_path(
+                    "test_exp", "test_trial", tmpdir, name="default"
+                ),
+            )
 
             meta = engine.load.call_args[0][0]
             assert meta.with_optim is (not no_load_optim)


### PR DESCRIPTION
## Description

Recovery checkpoints were previously written directly into the active recovery
path. If training or a background checkpoint writer terminated during a DCP
save, the next run could try to load a partially written checkpoint.

This PR introduces immutable checkpoint generations and an atomically
published `LATEST` pointer:

- Write each checkpoint into a new immutable generation and keep the previous
  generation active until the new one is complete.
- Publish `LATEST` only after synchronous payloads complete or, for Megatron
  asynchronous saves, from the MCore finalization callback after background I/O
  completes.
- Coordinate multiple engines so non-publishing asynchronous saves finish
  before the final publisher is scheduled. This lets PPO actor and critic
  checkpoints become visible as one generation.
- Use one stable actor/critic engine mapping for both save and load, with actor
  under `default` and critic under `critic`.
- Validate engine sets and generation paths, reject backward/conflicting
  publication, retain legacy checkpoint reads, and preserve the SPMD legacy
  write path.

If a process terminates during checkpoint creation, the incomplete generation
remains unpublished and recovery continues from the previous complete
generation referenced by `LATEST`.

The checkpointing documentation now describes the generation layout,
publication rules, compatibility behavior, and clean-restart procedure.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Focused checkpoint/recovery tests pass in the project image: 77 passed and 2
skipped. Changed-file pre-commit hooks also pass. The all-files checkbox remains
unchecked because the host environment lacks tools required by unrelated
repository-wide hooks.

We also validated the multi-engine path end to end with AReaL v2 PPO using
Qwen3-0.6B on an 8-GPU colocated actor/critic/rollout setup:

- The first phase asynchronously saved actor and critic and published a
  generation containing both `default` and `critic` engines.
- The recovery phase restored actor from `payloads/default` and critic from
  `payloads/critic`, including model, optimizer, learning-rate scheduler, and
  RNG state on all eight ranks.
- Training then completed 10 post-recovery steps with successful weight
  updates and no checkpoint-publication, OOM, or NCCL errors.
- `LATEST` advanced through the last fully finalized generation. A final
  in-flight generation at shutdown was conservatively left unpublished rather
  than exposing a partial actor/critic checkpoint.

An earlier crash-injection experiment also confirmed that interrupting a newer
DCP generation leaves `LATEST` pointing to the previous complete generation,
from which training can recover and continue.

This provides process-crash safety for checkpoint publication. It does not
claim durability against storage or power failures beyond the guarantees of
the underlying filesystem.

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
