### PR TITLE
fix(infra): pause proxy workers during weight updates

### DIFF
--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -1185,10 +1185,14 @@ class RolloutController:
 
     def pause(self):
         self.dispatcher.pause()
+        if self._proxy_started:
+            self._proxy_collective_rpc("pause", http_timeout=60.0)
         self._collective_rpc("pause", http_timeout=60.0)
 
     def resume(self):
         self._collective_rpc("resume", http_timeout=60.0)
+        if self._proxy_started:
+            self._proxy_collective_rpc("resume", http_timeout=60.0)
         self.dispatcher.resume()
 
     def offload(self, tags: list[str] | None = None):

--- a/tests/test_rollout_controller_proxy_pause.py
+++ b/tests/test_rollout_controller_proxy_pause.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from areal.infra.controller.rollout_controller import RolloutController
+
+
+class _RecordingController:
+    def __init__(self, proxy_started: bool):
+        self.calls: list[str] = []
+        self._proxy_started = proxy_started
+
+        class _Dispatcher:
+            def __init__(self, calls: list[str]):
+                self.calls = calls
+
+            def pause(self):
+                self.calls.append("dispatcher.pause")
+
+            def resume(self):
+                self.calls.append("dispatcher.resume")
+
+        self.dispatcher = _Dispatcher(self.calls)
+
+    def _collective_rpc(self, method, *args, **kwargs):
+        self.calls.append(f"workers.{method}")
+
+    def _proxy_collective_rpc(self, method, *args, **kwargs):
+        self.calls.append(f"proxy.{method}")
+
+    pause = RolloutController.pause
+    resume = RolloutController.resume
+
+
+def test_pause_and_resume_include_proxy_workers_in_safe_order():
+    controller = _RecordingController(proxy_started=True)
+
+    controller.pause()
+    controller.resume()
+
+    assert controller.calls == [
+        "dispatcher.pause",
+        "proxy.pause",
+        "workers.pause",
+        "workers.resume",
+        "proxy.resume",
+        "dispatcher.resume",
+    ]
+
+
+def test_pause_and_resume_skip_proxy_rpc_when_not_started():
+    controller = _RecordingController(proxy_started=False)
+
+    controller.pause()
+    controller.resume()
+
+    assert controller.calls == [
+        "dispatcher.pause",
+        "workers.pause",
+        "workers.resume",
+        "dispatcher.resume",
+    ]


### PR DESCRIPTION
## Description

Pause proxy workers during rollout weight updates, before pausing normal rollout workers, and resume them before the dispatcher accepts new work. Proxy workers own separate inference-engine clients against the same servers; leaving them active allowed stale generation requests to be retried while inference was aborting requests, clearing caches, and replacing weights.

This ports the synchronization fix from [HwVanICI/AReaL@29e1d727](https://github.com/HwVanICI/AReaL/commit/29e1d7270bb31746812af832530cf76d42234aeb) to the current `main` controller layout and adds focused ordering coverage for runs with and without proxy workers.

## Related Issue

Related to #1601.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable; no user-facing behavior or configuration changed)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None.

## Additional Context

Validation: `.venv/bin/pytest tests/test_rollout_controller_proxy_pause.py -q` (`2 passed`), Ruff lint and format checks, `git diff --check`, and the full pre-commit stack.

This closes the repeated stale-request resubmission window during updates. A narrower race between the pause check and HTTP request admission, including retries of an already-built payload, remains separate follow-up work.

______________________________________________________________________

**Need help?** Check the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md) or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
