### PR TITLE
feat: support qwen35 awex colocate weight update

### DIFF
--- a/areal/engine/awex/colocate_reader.py
+++ b/areal/engine/awex/colocate_reader.py
@@ -113,8 +113,16 @@ def _ensure_awex_models_registered() -> None:
 
     ``import_model_configs`` is ``lru_cache``-d and ``ModelRegistry`` is built
     once at module load. If anything imported the registry before our hook_mode
-    patch took effect, the BailingMoe converter would be silently missing. Clear
-    the cache and rebuild now that the patch is in place.
+    patch took effect, a native converter could be silently missing. Clear the
+    cache and rebuild now that the patch is in place.
+
+    The explicit architecture list is diagnostic only: AWEX remains the source
+    of truth for model registration, transfer plans, conversion, and sharding.
+    In particular, Qwen3.5 Dense and MoE reuse AWEX's native implementations
+    for both causal-language-model and multimodal conditional-generation
+    runtimes. Keeping those architecture names here makes an unavailable or
+    failed AWEX model import visible before the first colocated weight update,
+    without duplicating any model-specific transfer logic in AReaL.
     """
     try:
         from awex.models import registry as _reg
@@ -128,6 +136,10 @@ def _ensure_awex_models_registered() -> None:
                 "BailingMoeV2ForCausalLM",
                 "Qwen3VLForConditionalGeneration",
                 "Qwen3VLMoeForConditionalGeneration",
+                "Qwen3_5ForCausalLM",
+                "Qwen3_5MoeForCausalLM",
+                "Qwen3_5ForConditionalGeneration",
+                "Qwen3_5MoeForConditionalGeneration",
             )
             if m not in _reg.ModelRegistry.models
         ]

--- a/examples/vlm/qwen3_5_35b_a3b_megatron_geometry3k_grpo_awex_colocate.yaml
+++ b/examples/vlm/qwen3_5_35b_a3b_megatron_geometry3k_grpo_awex_colocate.yaml
@@ -1,0 +1,187 @@
+experiment_name: qwen3-5-35b-a3b-geometry3k-grpo-awex-colocate
+trial_name: trial1
+
+seed: 1
+enable_offload: true
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 2
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+scheduler:
+  type: slurm
+
+rollout:
+  # Two node-local TP=8 SGLang instances use the same 16 GPUs as the actor.
+  backend: "sglang:d2t8p1"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 64
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 1
+  enable_rollout_tracing: false
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 2048
+  greedy: false
+  temperature: 1.0
+
+actor:
+  # Both hybrid parallel layouts have world size 16:
+  # attention: DP=4, PP=2, TP=2; FFN: DP=2, PP=2, TP=1, EP=4.
+  backend: "megatron:(attn:d4p2t2|ffn:d2p2t1e4)"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3.5-35B-A3B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 8192
+  optimizer:
+    type: adam
+    lr: 1e-6
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  rejection_sampling:
+    metric: ratio
+    upper: 5.0
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  weight_update_mode: awex
+  megatron:
+    bridge_type: megatron-bridge
+    enable_mtp: false
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_strategy:
+    type: separation
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      mem: 32
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars:
+        PYTORCH_ALLOC_CONF: "expandable_segments:True"
+        # SGLang owns memory-saver regions during the colocated rollout.
+        TMS_INIT_ENABLE: "0"
+        TMS_INIT_ENABLE_CPU_BACKUP: "0"
+
+ref:
+  backend: ${actor.backend}
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 4096
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  max_running_requests: 64
+  context_length: 32768
+  mem_fraction_static: 0.3
+  enable_multimodal: true
+  enable_memory_saver: true
+
+# datasets
+train_dataset:
+  batch_size: 128
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: hiyouga/geometry3k
+  type: rl
+
+valid_dataset:
+  batch_size: 128
+  pin_memory: true
+  num_workers: 4
+  path: hiyouga/geometry3k
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  enabled: false
+  session_tracer:
+    enabled: false


### PR DESCRIPTION
## Description

Add AReaL-side support for Qwen3.5 Dense and MoE AWEX colocated weight updates without duplicating AWEX transfer or sharding logic.

- Make missing Qwen3.5 causal-LM and conditional-generation registrations visible before the first colocated weight update.
- Add a two-node, 8-GPU-per-node Geometry3K GRPO example using Megatron training and SGLang inference.

Awex verison: 0.8.1
## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None.

## Additional Context

- AWEX remains the source of truth for Qwen3.5 model registration, transfer plans, conversion, and sharding.
- Unit tests and GPU experiments were intentionally skipped per request; this change was prepared and validated as code/config only.
- Full pre-commit completed successfully with `UV_DEFAULT_INDEX=https://pypi.org/simple`.
