### PR TITLE
chore(deps): bump awex to 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ dependencies = [
     # Distributed computing
     "ray[default]",
     "redis",
-    "awex==0.8.0",
+    "awex==0.8.1",
 
     # Web frameworks
     "fastapi>=0.115.12",

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -138,7 +138,7 @@ dependencies = [
     # Distributed computing
     "ray[default]",
     "redis",
-    "awex==0.8.0",
+    "awex==0.8.1",
 
     # Web frameworks
     "fastapi>=0.115.12",

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ requires-dist = [
     { name = "areal", extras = ["megatron"], marker = "extra == 'cuda-train'" },
     { name = "areal", extras = ["sglang"], marker = "extra == 'cuda'" },
     { name = "areal", extras = ["tms"], marker = "extra == 'cuda-train'" },
-    { name = "awex", specifier = "==0.8.0" },
+    { name = "awex", specifier = "==0.8.1" },
     { name = "blosc" },
     { name = "build", specifier = ">=1.2.1" },
     { name = "claude-agent-sdk" },
@@ -664,10 +664,10 @@ wheels = [
 
 [[package]]
 name = "awex"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/93/e3ba1d310d20362ea6a89cdccfac64de4cc8fb74af69d73e0fa2204b130b/awex-0.8.0-py3-none-any.whl", hash = "sha256:529deca51a575ec44c9511ee252490b06d457a409dd198b7f37e760e460bf8ff", size = 244189, upload-time = "2026-07-23T03:04:54.118Z" },
+    { url = "https://files.pythonhosted.org/packages/13/11/16b4aed68bc2761516c125d9182c5f77ac3674d390dcc57ffeca92d77362/awex-0.8.1-py3-none-any.whl", hash = "sha256:abe5e5c23964e88e1b268274a9d7e64dd52809349e2c87aef703b347ba8c67d7", size = 268145, upload-time = "2026-08-20T07:45:46.522Z" },
 ]
 
 [[package]]

--- a/uv.vllm.lock
+++ b/uv.vllm.lock
@@ -526,7 +526,7 @@ requires-dist = [
     { name = "areal", extras = ["megatron"], marker = "extra == 'cuda-train'" },
     { name = "areal", extras = ["tms"], marker = "extra == 'cuda-train'" },
     { name = "areal", extras = ["vllm"], marker = "extra == 'cuda'" },
-    { name = "awex", specifier = "==0.8.0" },
+    { name = "awex", specifier = "==0.8.1" },
     { name = "blosc" },
     { name = "build", specifier = ">=1.2.1" },
     { name = "claude-agent-sdk" },
@@ -707,10 +707,10 @@ wheels = [
 
 [[package]]
 name = "awex"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/93/e3ba1d310d20362ea6a89cdccfac64de4cc8fb74af69d73e0fa2204b130b/awex-0.8.0-py3-none-any.whl", hash = "sha256:529deca51a575ec44c9511ee252490b06d457a409dd198b7f37e760e460bf8ff", size = 244189, upload-time = "2026-07-23T03:04:54.118Z" },
+    { url = "https://files.pythonhosted.org/packages/13/11/16b4aed68bc2761516c125d9182c5f77ac3674d390dcc57ffeca92d77362/awex-0.8.1-py3-none-any.whl", hash = "sha256:abe5e5c23964e88e1b268274a9d7e64dd52809349e2c87aef703b347ba8c67d7", size = 268145, upload-time = "2026-08-20T07:45:46.522Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Upgrade the Awex dependency from 0.8.0 to 0.8.1 in both the SGLang and vLLM manifests and regenerate their lockfiles.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

Dependency maintenance only; the template has no dependency-specific type.

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Validation:

- `UV_DEFAULT_INDEX=https://pypi.org/simple pre-commit run --files pyproject.toml pyproject.vllm.toml uv.lock uv.vllm.lock`

Compatibility smoke tests and transitive dependency analysis were intentionally omitted from this dependency-only update.