### PR TITLE
fix(v2): balance offline session routing

### DIFF
--- a/areal/v2/inference_service/gateway/app.py
+++ b/areal/v2/inference_service/gateway/app.py
@@ -273,14 +273,14 @@ def create_app(config: GatewayConfig) -> FastAPI:
 
     @app.post("/rl/start_session")
     async def start_session(request: Request):
-        token = require_admin_key(request, config.admin_api_key)
+        require_admin_key(request, config.admin_api_key)
 
         try:
             worker_addr = await query_router(
                 config.router_addr,
-                token,
-                "/rl/start_session",
-                config.router_timeout,
+                api_key=None,
+                path="/rl/start_session",
+                timeout=config.router_timeout,
                 admin_api_key=config.admin_api_key,
                 client=_client(),
             )

--- a/tests/v2/inference_service/test_gateway.py
+++ b/tests/v2/inference_service/test_gateway.py
@@ -195,6 +195,12 @@ class TestAdminEndpoints:
             {"session_id": "task-1-0", "session_api_key": "sess-key-xyz"}
         ]
 
+        route_call = mock_query_router.call_args
+        assert route_call.args == ("http://mock-router:8081",)
+        assert route_call.kwargs["api_key"] is None
+        assert route_call.kwargs["path"] == "/rl/start_session"
+        assert route_call.kwargs["admin_api_key"] == ADMIN_KEY
+
         # Verify router registration
         mock_register.assert_called_once()
         reg_args = mock_register.call_args

--- a/tests/v2/inference_service/test_gateway_integration.py
+++ b/tests/v2/inference_service/test_gateway_integration.py
@@ -249,6 +249,17 @@ def gateway_stack(sglang_server, model_path):
     # Wait briefly for router health poller to mark worker healthy
     time.sleep(3)
 
+    # Register the internal model through the gateway, matching the production
+    # initialization order. New sessions do not have a session key yet, so the
+    # router selects their data proxy from the registered model's worker pool.
+    resp = httpx.post(
+        f"{gateway_addr}/register_model",
+        json={"model": "sglang", "data_proxy_addrs": [data_proxy_addr]},
+        headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+        timeout=5.0,
+    )
+    assert resp.status_code == 200, f"Failed to register model: {resp.text}"
+
     yield {
         "gateway_addr": gateway_addr,
         "router_addr": router_addr,
@@ -278,6 +289,13 @@ class TestGatewayStackHealth:
             resp = await client.get(f"{gateway_stack['gateway_addr']}/health")
             assert resp.status_code == 200
             assert resp.json()["status"] == "ok"
+
+            resp = await client.get(
+                f"{gateway_stack['gateway_addr']}/models",
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+            )
+            assert resp.status_code == 200
+            assert "sglang" in resp.json()["models"]
 
             # Router health (should show 1 worker)
             resp = await client.get(f"{gateway_stack['router_addr']}/health")


### PR DESCRIPTION
## Description

The v2 gateway previously reused its admin credential as the routing key when
creating offline rollout sessions.

The router treats a provided API key as a session-affinity identity. As a
result, the first `/rl/start_session` request pinned the admin key to one
inference worker, and subsequent offline session groups continued routing to
that same worker instead of using the available worker pool.

This change separates authentication from routing identity:

- The gateway still validates the admin credential before accepting the
  request.
- New offline session groups use model-only routing, allowing the router's
  round-robin policy to select a worker.
- After the group is created, its actual session IDs and API keys are
  registered to the selected worker as before. Subsequent requests therefore
  remain sticky and can reuse that worker's KV cache.
- Existing HITL routing behavior is unchanged.

The gateway test now verifies that the admin key is used for router
authentication but is not forwarded as the session routing key.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Validation performed in the project development image:

- `tests/v2/inference_service/test_gateway.py`
- `tests/v2/inference_service/test_router.py`
- Result: `76 passed`

Changed-file pre-commit checks and sanitization scans also passed.
