### PR TITLE
fix: harden workflow dispatcher task lifecycle

### DIFF
--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -960,6 +960,8 @@ class RolloutController:
         # `arun_episode` should return None instead.
         if task_id is None:
             task_id = self._task_id_generator.next()
+        else:
+            self._task_id_generator.reserve_at_least(task_id)
         task_input = _RemoteRolloutTaskInput(
             data=data,
             workflow=workflow_str,

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -1240,9 +1240,6 @@ class RemoteInfEngine(InferenceEngine):
             raise ValueError(
                 "workflow must be specified for submit (unless mode='online')"
             )
-        if callback_addr:
-            self.workflow_executor.dispatcher.register_callback(task_id, callback_addr)
-
         # Resolve workflow to a RolloutWorkflow instance
         resolved_workflow = self._resolve_workflow(
             workflow,
@@ -1260,6 +1257,7 @@ class RemoteInfEngine(InferenceEngine):
             should_accept_fn=resolved_should_accept_fn,
             task_id=task_id,
             is_eval=is_eval,
+            callback_addr=callback_addr,
         )
 
     def wait(

--- a/areal/infra/workflow_executor.py
+++ b/areal/infra/workflow_executor.py
@@ -335,11 +335,19 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
 
     def register_callback(self, task_id: int, callback_addr: str):
         """Register a callback address for a task."""
-        self._task_callbacks[task_id] = callback_addr
+        with self._result_cv:
+            if task_id in self._task_callbacks:
+                raise ValueError(f"Callback for task {task_id} is already registered")
+            self._task_callbacks[task_id] = callback_addr
 
-    def cancel_callback(self, task_id: int):
+    def cancel_callback(self, task_id: int, callback_addr: str | None = None):
         """Remove a registered callback for a task (e.g., on timeout)."""
-        self._task_callbacks.pop(task_id, None)
+        with self._result_cv:
+            if (
+                callback_addr is None
+                or self._task_callbacks.get(task_id) == callback_addr
+            ):
+                self._task_callbacks.pop(task_id, None)
 
     def _send_callback(self, addr: str, task_id: int, result: TResult):
         """Send task result to callback address (fire-and-forget)."""
@@ -535,14 +543,28 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
             Task input to be processed.
         """
         self._check_thread_exception()
-        with self._input_cv:
-            self._pending_inputs.append(task_input)
-            self.staleness_manager.on_rollout_enqueued()
-            if self.enable_tracing:
-                self.logger.info(f"Enqueue rollout. {self._rollout_stats()}")
-            self._input_cv.notify()
         with self._result_cv:
+            if task_input.task_id in self._active_task_ids:
+                raise ValueError(f"Task id {task_input.task_id} is already active")
             self._active_task_ids.add(task_input.task_id)
+            self._result_cv.notify_all()
+        try:
+            with self._input_cv:
+                self._pending_inputs.append(task_input)
+                try:
+                    self.staleness_manager.on_rollout_enqueued()
+                except Exception:
+                    removed = self._pending_inputs.pop()
+                    assert removed is task_input
+                    raise
+                self._input_cv.notify()
+        except Exception:
+            with self._result_cv:
+                self._active_task_ids.discard(task_input.task_id)
+                self._result_cv.notify_all()
+            raise
+        if self.enable_tracing:
+            self.logger.info(f"Enqueue rollout. {self._rollout_stats()}")
 
     def wait_results(
         self, count: int, timeout: float | None = None, raise_timeout: bool = True
@@ -573,6 +595,8 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
         with self._result_cv:
             while len(self._pending_results) < count:
                 self._check_thread_exception()
+                if self._shutdown_event.is_set():
+                    raise RuntimeError("Task dispatcher is shutting down")
 
                 elapsed = time.perf_counter() - start_time
                 remaining = timeout - elapsed
@@ -586,18 +610,14 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
 
                 self._result_cv.wait(timeout=remaining)
 
-            drained: list[TimedResult[TResult]] = list(self._pending_results.values())
-            self._pending_results.clear()
-
-        drained.sort(key=lambda x: x.create_time)
-        selected, pending = drained[:count], drained[count:]
-        with self._result_cv:
-            if pending:
-                for result in pending:
-                    self._pending_results[result.task_id] = result
-                self._result_cv.notify_all()
+            ordered = sorted(
+                self._pending_results.values(), key=lambda result: result.create_time
+            )
+            selected = ordered[:count]
             for r in selected:
+                del self._pending_results[r.task_id]
                 self._active_task_ids.discard(r.task_id)
+            self._result_cv.notify_all()
 
         random.shuffle(selected)
 
@@ -617,6 +637,10 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
 
             while task_id not in self._pending_results:
                 self._check_thread_exception()
+                if self._shutdown_event.is_set():
+                    raise RuntimeError("Task dispatcher is shutting down")
+                if task_id not in self._active_task_ids:
+                    raise RuntimeError(f"Task {task_id} was consumed by another waiter")
 
                 elapsed = time.perf_counter() - start_time
                 remaining = timeout - elapsed
@@ -700,8 +724,9 @@ class BatchTaskDispatcher(Generic[TInput, TResult]):
                             "Input generator exhausted before batch completion. "
                             "Use cycle_dataloader() or provide an infinite generator."
                         ) from None
+            remaining = batch_size - (total_attempts if dynamic_bs else accepted_cnt)
             try:
-                arrived = self.wait_results(count=batch_size - accepted_cnt, timeout=1)
+                arrived = self.wait_results(count=remaining, timeout=1)
             except TimeoutError:
                 arrived = []
 
@@ -742,6 +767,11 @@ class TaskIdGenerator:
             task_id = self._task_cnt
             self._task_cnt += 1
         return task_id
+
+    def reserve_at_least(self, task_id: int) -> None:
+        """Keep future automatic IDs above an explicitly supplied task ID."""
+        with self._lock:
+            self._task_cnt = max(self._task_cnt, task_id + 1)
 
 
 class WorkflowExecutor:
@@ -1255,6 +1285,7 @@ class WorkflowExecutor:
         should_accept_fn: Callable[[dict[str, Any]], bool] = None,
         task_id: int | None = None,
         is_eval: bool = False,
+        callback_addr: str | None = None,
     ) -> int:
         """Submit a rollout request to the workflow executor.
 
@@ -1265,6 +1296,8 @@ class WorkflowExecutor:
         """
         if task_id is None:
             task_id = self._task_id_generator.next()
+        else:
+            self._task_id_generator.reserve_at_least(task_id)
         perf_tracer.register_task(task_id)
         task_input = _RolloutTaskInput(
             data=data,
@@ -1274,8 +1307,14 @@ class WorkflowExecutor:
             is_eval=is_eval,
         )
 
-        # Delegate to dispatcher
-        self.dispatcher.submit_task_input(task_input)
+        if callback_addr is not None:
+            self.dispatcher.register_callback(task_id, callback_addr)
+        try:
+            self.dispatcher.submit_task_input(task_input)
+        except Exception:
+            if callback_addr is not None:
+                self.dispatcher.cancel_callback(task_id, callback_addr)
+            raise
         return task_id
 
     def wait(

--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -1,0 +1,255 @@
+"""Tests for generic workflow dispatcher correctness."""
+
+import threading
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from areal.infra import workflow_executor as workflow_executor_module
+from areal.infra.controller.rollout_controller import RolloutController
+from areal.infra.remote_inf_engine import RemoteInfEngine
+from areal.infra.workflow_executor import (
+    BatchTaskDispatcher,
+    TaskIdGenerator,
+    WorkflowExecutor,
+)
+
+
+def _dispatcher_for_batch_wait(results):
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._result_cv = threading.Condition()
+    dispatcher._pending_results = {result.task_id: result for result in results}
+    dispatcher._active_task_ids = {result.task_id for result in results}
+    dispatcher._shutdown_event = threading.Event()
+    dispatcher._check_thread_exception = lambda: None
+    return dispatcher
+
+
+def test_callback_registration_rejects_duplicate_task_id():
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._result_cv = threading.Condition()
+    dispatcher._task_callbacks = {}
+
+    dispatcher.register_callback(7, "http://first")
+
+    with pytest.raises(ValueError, match="already registered"):
+        dispatcher.register_callback(7, "http://second")
+    assert dispatcher._task_callbacks == {7: "http://first"}
+
+
+def test_cancel_callback_only_removes_matching_registration():
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._result_cv = threading.Condition()
+    dispatcher._task_callbacks = {7: "http://current"}
+
+    dispatcher.cancel_callback(7, "http://stale")
+    assert dispatcher._task_callbacks == {7: "http://current"}
+
+    dispatcher.cancel_callback(7, "http://current")
+    assert dispatcher._task_callbacks == {}
+
+
+def test_submit_task_input_rejects_duplicate_active_task_id():
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._check_thread_exception = lambda: None
+    dispatcher._result_cv = threading.Condition()
+    dispatcher._input_cv = threading.Condition()
+    dispatcher._active_task_ids = {7}
+    dispatcher._pending_inputs = deque()
+    dispatcher.staleness_manager = SimpleNamespace(on_rollout_enqueued=Mock())
+    dispatcher.enable_tracing = False
+
+    with pytest.raises(ValueError, match="already active"):
+        dispatcher.submit_task_input(SimpleNamespace(task_id=7))
+
+    dispatcher.staleness_manager.on_rollout_enqueued.assert_not_called()
+    assert list(dispatcher._pending_inputs) == []
+
+
+def test_submit_task_input_rolls_back_when_enqueue_hook_fails():
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._check_thread_exception = lambda: None
+    dispatcher._result_cv = threading.Condition()
+    dispatcher._input_cv = threading.Condition()
+    dispatcher._active_task_ids = set()
+    dispatcher._pending_inputs = deque()
+    dispatcher.staleness_manager = SimpleNamespace(
+        on_rollout_enqueued=Mock(side_effect=RuntimeError("hook failed"))
+    )
+    dispatcher.enable_tracing = False
+    task_input = SimpleNamespace(task_id=7)
+
+    with pytest.raises(RuntimeError, match="hook failed"):
+        dispatcher.submit_task_input(task_input)
+
+    assert dispatcher._active_task_ids == set()
+    assert list(dispatcher._pending_inputs) == []
+
+
+def test_wait_results_fails_fast_when_dispatcher_is_shutting_down():
+    dispatcher = _dispatcher_for_batch_wait([])
+    dispatcher._shutdown_event.set()
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        dispatcher.wait_results(1, timeout=1)
+
+
+def test_wait_for_task_detects_result_consumed_by_another_waiter():
+    dispatcher = _dispatcher_for_batch_wait([])
+    dispatcher._active_task_ids = {7}
+    waiter_entered = threading.Event()
+    dispatcher._check_thread_exception = waiter_entered.set
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(dispatcher.wait_for_task, 7, 1)
+        assert waiter_entered.wait(timeout=1)
+        with dispatcher._result_cv:
+            dispatcher._active_task_ids.remove(7)
+            dispatcher._result_cv.notify_all()
+
+        with pytest.raises(RuntimeError, match="consumed by another waiter"):
+            future.result(timeout=1)
+
+
+def test_wait_results_removes_only_selected_results_atomically():
+    results = [
+        SimpleNamespace(task_id=0, create_time=3.0, data="newest"),
+        SimpleNamespace(task_id=1, create_time=1.0, data="oldest"),
+        SimpleNamespace(task_id=2, create_time=2.0, data="middle"),
+    ]
+    dispatcher = _dispatcher_for_batch_wait(results)
+
+    selected = dispatcher.wait_results(2, timeout=0)
+
+    assert set(selected) == {"oldest", "middle"}
+    assert set(dispatcher._pending_results) == {0}
+    assert dispatcher._active_task_ids == {0}
+
+
+def test_workflow_executor_binds_callback_to_allocated_task_id(monkeypatch):
+    executor = object.__new__(WorkflowExecutor)
+    executor._task_id_generator = TaskIdGenerator()
+    executor._dispatcher = Mock()
+    monkeypatch.setattr(
+        workflow_executor_module.perf_tracer, "register_task", lambda _: None
+    )
+
+    task_id = executor.submit({}, workflow=Mock(), callback_addr="http://callback")
+
+    assert task_id == 0
+    executor.dispatcher.register_callback.assert_called_once_with(0, "http://callback")
+    submitted = executor.dispatcher.submit_task_input.call_args.args[0]
+    assert submitted.task_id == 0
+
+
+def test_workflow_executor_cancels_own_callback_when_submit_fails(monkeypatch):
+    executor = object.__new__(WorkflowExecutor)
+    executor._task_id_generator = TaskIdGenerator()
+    executor._dispatcher = Mock()
+    executor.dispatcher.submit_task_input.side_effect = ValueError("duplicate")
+    monkeypatch.setattr(
+        workflow_executor_module.perf_tracer, "register_task", lambda _: None
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        executor.submit({}, workflow=Mock(), callback_addr="http://callback")
+
+    executor.dispatcher.cancel_callback.assert_called_once_with(0, "http://callback")
+
+
+def test_dynamic_batch_counts_rejections_as_attempts():
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._input_cv = threading.Condition()
+    dispatcher._pending_inputs = []
+    dispatcher.staleness_manager = SimpleNamespace(get_pending_limit=lambda: 0)
+    dispatcher.runner = SimpleNamespace(
+        max_queue_size=4, get_input_queue_size=lambda: 4
+    )
+    dispatcher.enable_tracing = False
+    dispatcher.wait_results = Mock(side_effect=[[None], ["accepted"]])
+
+    results = dispatcher.active_submit_and_wait(iter(()), batch_size=2, dynamic_bs=True)
+
+    assert results == ["accepted"]
+    assert [
+        call.kwargs["count"] for call in dispatcher.wait_results.call_args_list
+    ] == [2, 1]
+
+
+def test_fixed_batch_replaces_rejected_attempts_in_order():
+    dispatcher = object.__new__(BatchTaskDispatcher)
+    dispatcher._input_cv = threading.Condition()
+    dispatcher._pending_inputs = []
+    dispatcher.staleness_manager = SimpleNamespace(get_pending_limit=lambda: 0)
+    dispatcher.runner = SimpleNamespace(
+        max_queue_size=4, get_input_queue_size=lambda: 4
+    )
+    dispatcher.enable_tracing = False
+    dispatcher.wait_results = Mock(side_effect=[[None, "first"], ["replacement"]])
+
+    results = dispatcher.active_submit_and_wait(iter(()), batch_size=2)
+
+    assert results == ["first", "replacement"]
+    assert [
+        call.kwargs["count"] for call in dispatcher.wait_results.call_args_list
+    ] == [2, 1]
+
+
+def test_task_id_generator_advances_past_explicit_id():
+    generator = TaskIdGenerator()
+
+    generator.reserve_at_least(7)
+
+    assert generator.next() == 8
+
+
+def test_workflow_executor_reserves_explicit_task_id(monkeypatch):
+    executor = object.__new__(WorkflowExecutor)
+    executor._task_id_generator = TaskIdGenerator()
+    executor._dispatcher = Mock()
+    monkeypatch.setattr(
+        workflow_executor_module.perf_tracer, "register_task", lambda _: None
+    )
+
+    assert executor.submit({}, workflow=Mock(), task_id=7) == 7
+    assert executor.submit({}, workflow=Mock()) == 8
+
+
+def test_rollout_controller_reserves_explicit_task_id():
+    controller = object.__new__(RolloutController)
+    controller._task_id_generator = TaskIdGenerator()
+    controller._dispatcher = Mock()
+    controller._resolve_workflow_str = Mock(return_value="workflow.path")
+    controller._resolve_should_accept_fn = Mock(return_value=None)
+
+    assert controller.submit({}, workflow=Mock(), task_id=7) == 7
+    assert controller.submit({}, workflow=Mock()) == 8
+
+
+def test_remote_engine_delegates_callback_after_task_id_allocation():
+    engine = object.__new__(RemoteInfEngine)
+    engine.config = SimpleNamespace(agent=None)
+    engine._resolve_workflow = Mock(return_value="resolved-workflow")
+    engine._resolve_should_accept_fn = Mock(return_value="resolved-filter")
+    engine.workflow_executor = Mock()
+    engine.workflow_executor.submit.return_value = 9
+
+    task_id = engine.submit(
+        {},
+        workflow=Mock(),
+        callback_addr="http://callback",
+    )
+
+    assert task_id == 9
+    engine.workflow_executor.dispatcher.register_callback.assert_not_called()
+    engine.workflow_executor.submit.assert_called_once_with(
+        {},
+        workflow="resolved-workflow",
+        should_accept_fn="resolved-filter",
+        task_id=None,
+        is_eval=False,
+        callback_addr="http://callback",
+    )


### PR DESCRIPTION
## Summary

Splits the generic workflow-dispatcher correctness fixes out of #1607, as requested during review. The deterministic rollout work now lives independently in #1625.

This PR hardens task identity, callback registration, enqueue rollback, result consumption, shutdown behavior, and dynamic-batch rejection accounting. It contains no deterministic sampling, seed propagation, result-order policy, or submission-order frontier changes.

## Changes

### Task and callback lifecycle

- Allocate or reserve the final task ID before registering its callback.
- Forward `callback_addr` from `RemoteInfEngine` to `WorkflowExecutor`, instead of registering a callback against a possibly `None` task ID.
- Synchronize callback registration and cancellation with result delivery.
- Reject duplicate callback registrations instead of silently overwriting them.
- Make rollback cancellation conditional on the callback address owned by that submit attempt.
- Advance automatic task IDs past explicitly supplied IDs in both workflow executor paths.

### Transactional enqueue

- Reject duplicate active task IDs before enqueueing.
- Register the active task before making input visible to the producer.
- Roll back both active-task state and the pending input when the staleness enqueue hook fails.

### Waiter and shutdown correctness

- Select and remove completed results atomically under the result condition lock, avoiding transient clear/reinsert state for concurrent waiters.
- Fail waiting calls promptly when the dispatcher is shutting down.
- Report when a specific task was consumed by another waiter instead of waiting until timeout.

### Dynamic batching

- In dynamic-batch mode, count rejected rollouts as attempts when determining how many additional results to wait for.
- Preserve fixed-batch replacement behavior, which continues waiting for accepted replacements.

## Testing

Added `tests/test_workflow_executor.py` with focused coverage for:

- duplicate and conditional callback handling;
- duplicate task submission and enqueue-hook rollback;
- atomic completed-result removal;
- shutdown and competing-waiter failure paths;
- callback binding after task-ID allocation and submit-failure cleanup;
- dynamic and fixed batch rejection behavior;
- explicit task-ID reservation in both executor paths;
- `RemoteInfEngine` callback delegation.

Executed in the project Slurm development image:

```text
pre-commit run --all-files (uv-lock skipped because dependency inputs are unchanged): passed
focused pytest: 15 passed
git diff --check: passed
Python compilation: passed
uv.lock / uv.vllm.lock diff: none
```
