### PR TITLE
fix(v2): forward retry-orphan cleanup

### DIFF
--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -1595,6 +1595,7 @@ class RolloutControllerV2:
             export_style=export_style,
             group_size=group_size,
             serialize_group_samples=self.config.serialize_group_samples,
+            drop_retry_orphans=agent_cfg.drop_retry_orphans,
         )
 
     def _resolve_workflow(
@@ -1649,6 +1650,9 @@ class RolloutControllerV2:
 
             online_kwargs = dict(workflow_kwargs or {})
             online_kwargs.pop("controller", None)
+            online_kwargs.setdefault(
+                "drop_retry_orphans", self._agent_config.drop_retry_orphans
+            )
             return InferenceServiceWorkflow(
                 controller=self,
                 agent=None,

--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -54,6 +54,7 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         timeout: float | None = None,
         group_size: int = 1,
         serialize_group_samples: bool = False,
+        drop_retry_orphans: bool = False,
     ):
         self.controller = controller
         self.agent = agent
@@ -64,6 +65,7 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         self.timeout = timeout
         self.group_size = group_size
         self.serialize_group_samples = serialize_group_samples
+        self.drop_retry_orphans = drop_retry_orphans
 
     @async_http_retry
     async def _start_session(
@@ -118,6 +120,7 @@ class InferenceServiceWorkflow(RolloutWorkflow):
             "discount": self.discount,
             "style": self.export_style,
             "remove_session": True,
+            "drop_retry_orphans": self.drop_retry_orphans,
         }
         async with session.post(url, json=payload, headers=headers) as resp:
             resp.raise_for_status()

--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -761,6 +761,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                     discount=body.discount,
                     style=body.style,
                     trajectory_id=body.trajectory_id,
+                    drop_retry_orphans=body.drop_retry_orphans,
                 )
                 merged.update(interactions)
             except KeyError:

--- a/areal/v2/inference_service/data_proxy/session.py
+++ b/areal/v2/inference_service/data_proxy/session.py
@@ -75,6 +75,7 @@ class ExportTrajectoriesRequest(BaseModel):
     discount: float = 1.0
     style: str = "individual"
     remove_session: bool = True
+    drop_retry_orphans: bool = False
 
 
 class ExportTrajectoriesResponse(BaseModel):
@@ -322,6 +323,7 @@ class SessionData:
         discount: float,
         style: str,
         trajectory_id: int | None = None,
+        drop_retry_orphans: bool = False,
     ) -> tuple[int, dict[str, InteractionWithTokenLogpReward]]:
         """Export a ready trajectory.
 
@@ -335,6 +337,9 @@ class SessionData:
         trajectory_id : int | None
             Specific trajectory to export.  When ``None``, the latest
             ready trajectory is exported.
+        drop_retry_orphans : bool
+            Remove duplicate responses left by upstream request retries before
+            reward discounting and concat export.
 
         Returns
         -------
@@ -364,6 +369,7 @@ class SessionData:
         interactions = ready.completions.export_interactions(
             style=style,
             reward_discount=discount,
+            drop_retry_orphans=drop_retry_orphans,
         )
         return ready.trajectory_id, interactions
 

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -126,6 +126,10 @@ class TestControllerWorkflowResolution:
         cfg = InferenceEngineConfig(
             backend="sglang:d1",
             admin_api_key="test-admin-key",
+            agent=AgentConfig(
+                agent_cls_path="tests.experimental.openai.utils.SimpleAgent",
+                drop_retry_orphans=True,
+            ),
         )
         scheduler = MagicMock(n_gpus_per_node=8)
         controller = RolloutControllerV2(config=cfg, scheduler=scheduler)
@@ -140,11 +144,16 @@ class TestControllerWorkflowResolution:
         assert resolved.controller is controller
         assert resolved.agent is None
         assert resolved.timeout == 3.0
+        assert resolved.drop_retry_orphans is True
 
     def test_resolve_workflow_agent_class_creates_offline_workflow(self):
         cfg = InferenceEngineConfig(
             backend="sglang:d1",
             admin_api_key="test-admin-key",
+            agent=AgentConfig(
+                agent_cls_path="tests.experimental.openai.utils.SimpleAgent",
+                drop_retry_orphans=True,
+            ),
         )
         scheduler = MagicMock(n_gpus_per_node=8)
         controller = RolloutControllerV2(config=cfg, scheduler=scheduler)
@@ -162,6 +171,7 @@ class TestControllerWorkflowResolution:
         assert isinstance(resolved, InferenceServiceWorkflow)
         assert resolved.agent is not None
         assert isinstance(resolved.agent, MockAgent)
+        assert resolved.drop_retry_orphans is True
 
     def test_resolve_should_accept_fn_none(self):
         assert RolloutControllerV2._resolve_should_accept_fn(None) is None
@@ -645,6 +655,28 @@ class TestInferenceServiceWorkflow:
             group_id="grp-test-42",
         )
         return result, max_active, start_order, tracker, workflow
+
+    @pytest.mark.asyncio
+    async def test_export_interactions_forwards_drop_retry_orphans(self):
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            gateway_addr="http://test:8080",
+            admin_api_key="test-key",
+            drop_retry_orphans=True,
+        )
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json = AsyncMock(return_value={"traj": {}})
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=response)
+        context.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.post = MagicMock(return_value=context)
+
+        result = await workflow._export_interactions(session, ["session-1"])
+
+        assert result == {}
+        assert session.post.call_args.kwargs["json"]["drop_retry_orphans"] is True
 
     @pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
     @pytest.mark.asyncio

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -1031,6 +1031,77 @@ async def test_export_trajectories_without_admin_key(client):
     assert resp.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_export_trajectories_drops_retry_orphans_before_discount(
+    client, monkeypatch
+):
+    from areal.infra.rpc.serialization import deserialize_value
+
+    monkeypatch.setattr(
+        "areal.v2.inference_service.data_proxy.app.RTensor.remotize",
+        lambda obj, node_addr: obj,
+    )
+    start = await client.post(
+        "/rl/start_session",
+        json={"task_id": "retry-orphan"},
+        headers=admin_headers(),
+    )
+    session = start.json()["sessions"][0]
+    headers = session_headers(session["session_api_key"])
+    initial_messages = [{"role": "user", "content": "hi"}]
+
+    await client.post(
+        "/chat/completions",
+        json={"model": "sglang", "messages": initial_messages},
+        headers=headers,
+    )
+    await client.post(
+        "/chat/completions",
+        json={"model": "sglang", "messages": initial_messages},
+        headers=headers,
+    )
+    await client.post(
+        "/chat/completions",
+        json={
+            "model": "sglang",
+            "messages": initial_messages
+            + [
+                {"role": "assistant", "content": "Hello!"},
+                {"role": "user", "content": "more"},
+            ],
+        },
+        headers=headers,
+    )
+    reward_response = await client.post(
+        "/rl/set_reward",
+        json={"reward": 1.0},
+        headers=headers,
+    )
+    assert reward_response.status_code == 200
+
+    app = client._transport.app
+    session_data = app.state.session_store.get_session(session["session_id"])
+    assert session_data is not None
+    ready = next(iter(session_data._ready_trajectories.values()))
+    for interaction in ready.completions.values():
+        interaction.chat_template_type = "concat"
+
+    export_response = await client.post(
+        "/export_trajectories",
+        json={
+            "session_ids": [session["session_id"]],
+            "discount": 1.0,
+            "style": "concat",
+            "drop_retry_orphans": True,
+        },
+        headers=admin_headers(),
+    )
+
+    assert export_response.status_code == 200
+    trajectory = deserialize_value(export_response.json()["traj"])
+    assert trajectory["input_ids"].shape[0] == 1
+
+
 # =============================================================================
 # =============================================================================
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`AgentConfig.drop_retry_orphans` is already supported by the shared
`InteractionCache` export path and is used by the v1 proxy workflow. The v2
inference-service workflow, however, did not forward this option when exporting
trajectories.

As a result, duplicate completions left behind by upstream request retries could
remain as independent leaf interactions and enter the exported training
trajectory.

This change threads the existing option through the complete v2 export path:

- `RolloutControllerV2` reads the option from `AgentConfig` for both online and
  offline workflows.
- `InferenceServiceWorkflow` includes it in `/export_trajectories` requests.
- The Data Proxy request model and `SessionData` forward it to
  `InteractionCache.export_interactions`.
- Retry orphans are removed before reward discounting and concat export.

The option remains disabled by default, so existing configurations are
unchanged. This PR does not introduce a new cleanup algorithm or configuration
field; it connects v2 to the behavior already implemented by the shared cache.

Tests cover controller configuration propagation, workflow request payloads,
and an end-to-end Data Proxy export containing duplicate retry responses.

## Related Issue

Follow-up to #1498

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Validation performed in the project development image:

- `tests/v2/inference_service/test_controller.py`
- `tests/v2/inference_service/test_data_proxy_chat.py`
- `tests/experimental/openai/test_retry_orphan.py`
- Result: `97 passed, 4 skipped`

Changed-file pre-commit checks and sanitization scans also passed.
