### PR TITLE
feat(v2): support SWE proxy compatibility

### DIFF
--- a/areal/experimental/openai/anthropic.py
+++ b/areal/experimental/openai/anthropic.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Anthropic Messages API translation helpers shared by proxy generations."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Callable, Iterable
+from typing import Any
+
+from anthropic.types.message import Message
+from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+    AnthropicAdapter,
+)
+from litellm.types.utils import ModelResponse as LitellmModelResponse
+
+MessagePreprocessor = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
+
+_adapter = AnthropicAdapter()
+
+
+def _flatten_content_lists(messages: list[dict[str, Any]]) -> None:
+    """Flatten Anthropic text content blocks to strings in place."""
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        text_parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text_parts.append(str(block.get("text", "")))
+            elif isinstance(block, str):
+                text_parts.append(block)
+        message["content"] = "\n".join(text_parts)
+
+
+def translate_anthropic_request(
+    anthropic_request: dict[str, Any],
+    message_preprocessors: Iterable[MessagePreprocessor] = (),
+) -> dict[str, Any]:
+    """Translate an Anthropic request to OpenAI chat-completion parameters."""
+    translated = _adapter.translate_completion_input_params(anthropic_request.copy())
+    if translated is None:
+        raise ValueError("Failed to translate request")
+    openai_request = dict(translated)
+    messages = openai_request.get("messages")
+    if isinstance(messages, list):
+        _flatten_content_lists(messages)
+        for preprocessor in message_preprocessors:
+            messages = preprocessor(messages)
+        openai_request["messages"] = messages
+    return openai_request
+
+
+def translate_anthropic_response(openai_response: Any) -> Message:
+    """Translate a non-streaming OpenAI chat completion to Anthropic format."""
+    model_response = LitellmModelResponse(**openai_response.model_dump())
+    translated = _adapter.translate_completion_output_params(model_response)
+    if translated is None:
+        raise ValueError("Failed to translate response")
+
+    content = translated.get("content")
+    if content:
+        translated["content"] = [
+            block.model_dump() if hasattr(block, "model_dump") else block
+            for block in content
+        ]
+    return Message(**translated)
+
+
+def translate_anthropic_stream(
+    openai_stream: AsyncGenerator[Any, None],
+    model: str,
+) -> AsyncGenerator[Any, None]:
+    """Translate an OpenAI chat-completion stream to Anthropic SSE events."""
+    return _adapter.translate_completion_output_params_streaming(
+        completion_stream=openai_stream,
+        model=model,
+    )

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -18,10 +18,6 @@ from anthropic.types.message import Message
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
-from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
-    AnthropicAdapter,
-)
-from litellm.types.utils import ModelResponse as LitellmModelResponse
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.completion_create_params import CompletionCreateParams
 from openai.types.responses import Response
@@ -29,6 +25,11 @@ from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel
 
 from areal.api.cli_args import NameResolveConfig
+from areal.experimental.openai.anthropic import (
+    translate_anthropic_request,
+    translate_anthropic_response,
+    translate_anthropic_stream,
+)
 from areal.experimental.openai.client import ArealOpenAI
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.utils.http import validate_admin_api_key
@@ -139,9 +140,6 @@ _trial_name: str | None = None
 _name_resolve_type: str = "nfs"
 _nfs_record_root: str = "/tmp/areal/name_resolve"
 _etcd3_addr: str = "localhost:2379"
-
-# Adapter to convert Anthropic request to OpenAI format
-_adapter = AnthropicAdapter()
 
 # =============================================================================
 # Request Validation
@@ -750,34 +748,12 @@ async def responses(
     )
 
 
-def _flatten_content_lists(messages: list[dict]) -> None:
-    """Flatten Anthropic content block lists to strings in-place."""
-    for msg in messages:
-        if isinstance(msg.get("content"), list):
-            text_parts = []
-            for block in msg["content"]:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    text_parts.append(block.get("text", ""))
-                elif isinstance(block, str):
-                    text_parts.append(block)
-            msg["content"] = "\n".join(text_parts)
-
-
 def _translate_anthropic_to_openai_request(anthropic_request: dict[str, Any]) -> dict:
     """Translate an Anthropic Messages API request to OpenAI format."""
-    openai_request = _adapter.translate_completion_input_params(
-        anthropic_request.copy()
+    return translate_anthropic_request(
+        anthropic_request,
+        message_preprocessors=_message_preprocessors,
     )
-    if openai_request is None:
-        raise ValueError("Failed to translate request")
-    openai_request = dict(openai_request)
-
-    if "messages" in openai_request:
-        _flatten_content_lists(openai_request["messages"])
-        for preprocessor in _message_preprocessors:
-            openai_request["messages"] = preprocessor(openai_request["messages"])
-
-    return openai_request
 
 
 async def _safe_stream_wrapper(
@@ -869,11 +845,9 @@ async def anthropic_messages(
             )
 
             # Use LiteLLM's adapter to convert to Anthropic SSE format
-            anthropic_sse_stream = (
-                _adapter.translate_completion_output_params_streaming(
-                    completion_stream=openai_stream,
-                    model=anthropic_request.get("model", "default"),
-                )
+            anthropic_sse_stream = translate_anthropic_stream(
+                openai_stream,
+                model=anthropic_request.get("model", "default"),
             )
 
             # Wrap the stream to handle client disconnection gracefully
@@ -906,21 +880,7 @@ async def anthropic_messages(
 
     # Convert OpenAI response to Anthropic format using LiteLLM's adapter
     try:
-        # Convert ChatCompletion to LitellmModelResponse
-        openai_response_dict = openai_response.model_dump()
-        model_response = LitellmModelResponse(**openai_response_dict)
-        anthropic_response = _adapter.translate_completion_output_params(model_response)
-        if anthropic_response is None:
-            raise ValueError("Failed to translate response")
-
-        # LiteLLM returns Pydantic BaseModel objects in content list,
-        # Convert them to dict.
-        if "content" in anthropic_response and anthropic_response["content"]:
-            anthropic_response["content"] = [
-                block.model_dump() if hasattr(block, "model_dump") else block
-                for block in anthropic_response["content"]
-            ]
-        return Message(**anthropic_response)
+        return translate_anthropic_response(openai_response)
     except Exception as e:
         logger.error(f"Failed to convert OpenAI response to Anthropic format: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to convert response: {e}")

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -479,6 +479,16 @@ class RolloutControllerV2:
             ]
         if cfg.deterministic_sampling:
             data_proxy_base_cmd.append("--deterministic-sampling")
+        for preprocessor_path in agent_cfg.message_preprocessors:
+            data_proxy_base_cmd += [
+                "--message-preprocessor",
+                preprocessor_path,
+            ]
+        if agent_cfg.prefix_matcher:
+            data_proxy_base_cmd += [
+                "--prefix-matcher",
+                agent_cfg.prefix_matcher,
+            ]
 
         async def _fork_data_proxy(group_idx: int) -> tuple[str, int, str]:
             if self.external_mode:

--- a/areal/v2/inference_service/data_proxy/__main__.py
+++ b/areal/v2/inference_service/data_proxy/__main__.py
@@ -80,6 +80,15 @@ def main():
         default="hf",
         choices=("hf", "concat"),
     )
+    parser.add_argument(
+        "--message-preprocessor",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
+        "--prefix-matcher",
+        default=None,
+    )
     args, _ = parser.parse_known_args()
 
     validate_admin_api_key(args.host, args.admin_api_key)
@@ -108,6 +117,8 @@ def main():
         reasoning_parser=args.reasoning_parser,
         engine_max_tokens=args.engine_max_tokens,
         chat_template_type=args.chat_template_type,
+        message_preprocessors=tuple(args.message_preprocessor),
+        prefix_matcher=args.prefix_matcher,
     )
     suppress_http_loggers()
     app = create_app(config)

--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -6,10 +6,12 @@ import asyncio
 import hmac
 import json
 import uuid
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
+from anthropic.types.message import Message
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.wsgi import WSGIMiddleware
 from fastapi.responses import Response as RawResponse
@@ -17,6 +19,12 @@ from fastapi.responses import StreamingResponse
 from flask import Flask
 from pydantic import BaseModel
 
+from areal.experimental.openai.anthropic import (
+    MessagePreprocessor,
+    translate_anthropic_request,
+    translate_anthropic_response,
+    translate_anthropic_stream,
+)
 from areal.experimental.openai.client import ArealOpenAI
 from areal.experimental.openai.types import (
     InteractionWithTokenLogpReward,
@@ -30,6 +38,7 @@ from areal.infra.rpc.serialization import serialize_value
 from areal.infra.utils.http import create_httpx_client
 from areal.utils import logging
 from areal.utils.data import concat_padded_tensors
+from areal.utils.dynamic_import import import_from_string
 from areal.utils.seeding import derive_deterministic_seed
 from areal.v2.inference_service.data_proxy.config import DataProxyConfig
 from areal.v2.inference_service.data_proxy.pause import PauseState
@@ -52,6 +61,16 @@ from areal.v2.inference_service.sglang.bridge import SGLangBridgeBackend
 from areal.v2.inference_service.vllm.bridge import VLLMBridgeBackend
 
 logger = logging.getLogger("InferenceDataProxy")
+
+
+async def _safe_stream_wrapper(stream: AsyncGenerator[Any, None]):
+    """Close an upstream stream when forwarding ends or the client disconnects."""
+    try:
+        async for chunk in stream:
+            yield chunk
+    finally:
+        if hasattr(stream, "aclose"):
+            await stream.aclose()
 
 
 # =============================================================================
@@ -110,16 +129,22 @@ class ConfigureBackendResponse(BaseModel):
 
 
 def _extract_bearer_token(request: Request) -> str:
-    """Extract API token from Authorization header.
+    """Extract API token from an OpenAI or Anthropic authentication header.
 
     Raises HTTPException(401) if missing or malformed.
     """
     auth_header = request.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
         return auth_header[7:].strip()
+    x_api_key = request.headers.get("x-api-key", "")
+    if x_api_key:
+        return x_api_key
     raise HTTPException(
         status_code=401,
-        detail="Missing or malformed Authorization header. Expected 'Bearer <token>'.",
+        detail=(
+            "Missing or malformed authentication header. Expected "
+            "'Bearer <token>' or 'x-api-key: <token>'."
+        ),
     )
 
 
@@ -132,7 +157,7 @@ def _require_admin_key(request: Request, store: SessionStore) -> str:
 
 
 def _require_session_key(request: Request, store: SessionStore) -> str:
-    """Resolve session_id from the session API key in the Authorization header."""
+    """Resolve session_id from an OpenAI or Anthropic session API key."""
     token = _extract_bearer_token(request)
     session = store.get_session_by_api_key(token)
     if session is None:
@@ -146,7 +171,7 @@ def _resolve_session_from_token(
     token: str | None,
     store: SessionStore,
 ) -> SessionData | None:
-    """Resolve a session from the bearer token.
+    """Resolve a session from an API token.
 
     Session key → lookup by API key.
     Admin key → persistent HITL session.
@@ -162,7 +187,7 @@ def _resolve_session_from_token(
 
 
 def _try_extract_bearer_token(request: Request) -> str | None:
-    """Extract bearer token if present. Returns None if missing/malformed.
+    """Extract an OpenAI or Anthropic token if present.
 
     Unlike _extract_bearer_token, this never raises — it's for endpoints
     that accept requests with or without auth.
@@ -170,6 +195,9 @@ def _try_extract_bearer_token(request: Request) -> str | None:
     auth_header = request.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
         return auth_header[7:].strip()
+    x_api_key = request.headers.get("x-api-key", "")
+    if x_api_key:
+        return x_api_key
     return None
 
 
@@ -317,6 +345,17 @@ async def _ready_trajectory_loop(app: FastAPI) -> None:
 def create_app(config: DataProxyConfig) -> FastAPI:
     """Factory that creates the FastAPI app with lifespan-managed resources."""
 
+    message_preprocessors: list[MessagePreprocessor] = []
+    for path in config.message_preprocessors:
+        preprocessor_cls = import_from_string(path)
+        message_preprocessors.append(preprocessor_cls())
+        logger.info("Loaded message preprocessor: %s", path)
+
+    prefix_matcher = None
+    if config.prefix_matcher:
+        prefix_matcher = import_from_string(config.prefix_matcher)
+        logger.info("Loaded prefix matcher: %s", config.prefix_matcher)
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         logger.info(
@@ -330,6 +369,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         app.state.config = config
         app.state.session_store = SessionStore(
             set_reward_finish_timeout=config.set_reward_finish_timeout,
+            prefix_matcher=prefix_matcher,
         )
         app.state.session_store.set_admin_key(config.admin_api_key)
         app.state.version = 0
@@ -363,6 +403,47 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
     app = FastAPI(title="AReaL Data Proxy", lifespan=lifespan)
     _registered_models: dict[str, dict[str, str | None]] = {}
+
+    async def _create_internal_chat_result(
+        body_json: dict[str, Any],
+        session: SessionData | None,
+    ) -> tuple[Any, bool]:
+        areal_client: ArealOpenAI | None = app.state.areal_client
+        if areal_client is None:
+            raise HTTPException(status_code=503, detail="Inference backend unavailable")
+
+        kwargs = dict(body_json)
+        kwargs.pop("model", None)
+        is_streaming = bool(kwargs.get("stream", False))
+        kwargs.setdefault("temperature", 1.0)
+        kwargs.setdefault("top_p", 1.0)
+        areal_cache = session.active_completions if session is not None else None
+
+        deterministic_sampling = session is not None and config.deterministic_sampling
+        request_index = (
+            session.next_sampling_request_index() if deterministic_sampling else None
+        )
+        if deterministic_sampling and kwargs.get("seed") is None:
+            assert session is not None
+            assert request_index is not None
+            kwargs["seed"] = derive_deterministic_seed(
+                session.sampling_seed_identity,
+                request_index,
+            )
+
+        try:
+            result = await areal_client.chat.completions.create(
+                areal_cache=areal_cache,
+                **kwargs,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        return result, is_streaming
 
     # =========================================================================
     # Health
@@ -518,7 +599,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     # =========================================================================
     # Chat completions — OpenAI-compatible
     #
-    # If the bearer token is a known session key, use session cache.
+    # If the API token is a known session key, use session cache.
     # Otherwise (no token, admin key, unknown key) → standalone mode.
     # Data proxy never rejects requests on /chat/completions.
     # =========================================================================
@@ -645,52 +726,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         # -----------------------------------------------------------------
         # Internal model path: use AReaL inference server
         # -----------------------------------------------------------------
-        areal_client: ArealOpenAI = app.state.areal_client
-
-        if session is not None:
-            areal_cache: Any = session.active_completions
-        else:
-            areal_cache = None
-
-        # Build kwargs from request body
-        kwargs = dict(body_json)
-        # Remove model (ArealOpenAI ignores it)
-        kwargs.pop("model", None)
-
-        # Determine streaming
-        is_streaming = kwargs.get("stream", False) or False
-
-        # Apply defaults for temperature/top_p if not set
-        if "temperature" not in kwargs:
-            kwargs["temperature"] = 1.0
-        if "top_p" not in kwargs:
-            kwargs["top_p"] = 1.0
-
-        deterministic_sampling = (
-            session is not None and app.state.config.deterministic_sampling
-        )
-        request_index = (
-            session.next_sampling_request_index() if deterministic_sampling else None
-        )
-        if deterministic_sampling and kwargs.get("seed") is None:
-            assert session is not None
-            assert request_index is not None
-            kwargs["seed"] = derive_deterministic_seed(
-                session.sampling_seed_identity,
-                request_index,
-            )
-
-        create_fn: Any = areal_client.chat.completions.create
-
-        try:
-            result = await create_fn(
-                areal_cache=areal_cache,
-                **kwargs,
-            )
-        except ValueError as e:
-            raise HTTPException(status_code=500, detail=str(e))
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}")
+        result, is_streaming = await _create_internal_chat_result(body_json, session)
 
         if is_streaming:
             # result is an async generator of ChatCompletionChunk
@@ -711,6 +747,74 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             )
 
         return result
+
+    @app.post("/v1/messages", response_model=None)
+    async def anthropic_messages(request: Request) -> Message | StreamingResponse:
+        """Serve Anthropic Messages API requests for session-backed agent rollouts."""
+        store: SessionStore = app.state.session_store
+        token = _try_extract_bearer_token(request)
+        session = _resolve_session_from_token(token, store)
+        if session is None:
+            raise HTTPException(status_code=401, detail="Invalid session key")
+        session.update_last_access()
+
+        try:
+            anthropic_request = await request.json()
+            openai_request = translate_anthropic_request(
+                anthropic_request,
+                message_preprocessors=message_preprocessors,
+            )
+        except (ValueError, TypeError, KeyError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid Anthropic request format: {exc}",
+            ) from exc
+        except Exception as exc:
+            logger.error(
+                "Unexpected Anthropic request conversion failure: %s",
+                exc,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="Internal server error during request conversion.",
+            ) from exc
+
+        result, is_streaming = await _create_internal_chat_result(
+            openai_request,
+            session,
+        )
+        model = str(anthropic_request.get("model", "default"))
+
+        if is_streaming:
+            try:
+                anthropic_stream = translate_anthropic_stream(result, model=model)
+                return StreamingResponse(
+                    _safe_stream_wrapper(anthropic_stream),
+                    media_type="text/event-stream",
+                    headers={
+                        "Cache-Control": "no-cache",
+                        "Connection": "keep-alive",
+                        "X-Accel-Buffering": "no",
+                    },
+                )
+            except Exception as exc:
+                if hasattr(result, "aclose"):
+                    await result.aclose()
+                logger.error("Anthropic streaming setup failed: %s", exc)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Streaming setup failed: {exc}",
+                ) from exc
+
+        try:
+            return translate_anthropic_response(result)
+        except Exception as exc:
+            logger.error("Anthropic response conversion failed: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to convert response: {exc}",
+            ) from exc
 
     @app.post("/register_model", response_model=RegisterModelResponse)
     async def register_model(request: Request):

--- a/areal/v2/inference_service/data_proxy/config.py
+++ b/areal/v2/inference_service/data_proxy/config.py
@@ -27,3 +27,5 @@ class DataProxyConfig:
     reasoning_parser: str = "qwen3"
     engine_max_tokens: int | None = None
     chat_template_type: str = "hf"
+    message_preprocessors: tuple[str, ...] = ()
+    prefix_matcher: str | None = None

--- a/areal/v2/inference_service/data_proxy/session.py
+++ b/areal/v2/inference_service/data_proxy/session.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from areal.experimental.openai.cache import InteractionCache
+from areal.experimental.openai.cache import InteractionCache, PrefixMatcher
 from areal.experimental.openai.types import InteractionWithTokenLogpReward
 
 # Session timeout for cleanup (1 hour)
@@ -134,13 +134,15 @@ class SessionData:
         session_id: str,
         set_reward_finish_timeout: float = 0.0,
         sampling_seed_identity: str | None = None,
+        prefix_matcher: PrefixMatcher | None = None,
     ):
         self.session_id = session_id
         self.sampling_seed_identity = sampling_seed_identity or session_id
         self._set_reward_finish_timeout = set_reward_finish_timeout
+        self._prefix_matcher = prefix_matcher
         self._last_access_time = time.time()
         self._lock = threading.Lock()
-        self._active_completions = InteractionCache()
+        self._active_completions = self._new_interaction_cache()
         self._ready_trajectories: OrderedDict[int, ReadyTrajectory] = OrderedDict()
         self._next_trajectory_id = 0
         self._next_sampling_request_index = 0
@@ -153,6 +155,12 @@ class SessionData:
             request_index = self._next_sampling_request_index
             self._next_sampling_request_index += 1
         return request_index
+
+    def _new_interaction_cache(self) -> InteractionCache:
+        return InteractionCache(
+            session_id=self.session_id,
+            prefix_matcher=self._prefix_matcher,
+        )
 
     def update_last_access(self) -> None:
         with self._lock:
@@ -215,7 +223,7 @@ class SessionData:
             needs_online_callback=True,
         )
         self._ready_trajectories[trajectory_id] = ready
-        self._active_completions = InteractionCache()
+        self._active_completions = self._new_interaction_cache()
         self._last_set_reward_time = None
         self._last_reward_interaction_id = None
 
@@ -376,7 +384,11 @@ class SessionData:
 class SessionStore:
     """Thread-safe store for session lifecycle management."""
 
-    def __init__(self, set_reward_finish_timeout: float = 0.0):
+    def __init__(
+        self,
+        set_reward_finish_timeout: float = 0.0,
+        prefix_matcher: PrefixMatcher | None = None,
+    ):
         self._sessions: dict[str, SessionData] = {}
         self._api_key_to_session: dict[str, str] = {}
         self._session_to_api_key: dict[str, str] = {}
@@ -384,6 +396,7 @@ class SessionStore:
         self._capacity: int = 0
         self._admin_api_key: str = "areal-admin-key"
         self._set_reward_finish_timeout = set_reward_finish_timeout
+        self._prefix_matcher = prefix_matcher
 
     def set_capacity(self, n: int) -> None:
         with self._lock:
@@ -439,6 +452,7 @@ class SessionStore:
                 session_id=session_id,
                 set_reward_finish_timeout=self._set_reward_finish_timeout,
                 sampling_seed_identity=sampling_seed_identity,
+                prefix_matcher=self._prefix_matcher,
             )
             self._api_key_to_session[session_api_key] = session_id
             self._session_to_api_key[session_id] = session_api_key
@@ -460,6 +474,7 @@ class SessionStore:
                 session = SessionData(
                     session_id="__hitl__",
                     set_reward_finish_timeout=self._set_reward_finish_timeout,
+                    prefix_matcher=self._prefix_matcher,
                 )
                 self._sessions["__hitl__"] = session
             return session

--- a/areal/v2/inference_service/gateway/app.py
+++ b/areal/v2/inference_service/gateway/app.py
@@ -118,12 +118,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
     async def health():
         return GatewayHealthResponse(status="ok", router_addr=config.router_addr)
 
-    # =========================================================================
-    # POST /chat/completions — admin OR session key, streaming or non-streaming
-    # =========================================================================
-
-    @app.post("/chat/completions")
-    async def chat_completions(request: Request):
+    async def _forward_generation_request(request: Request, path: str) -> Response:
         token = extract_bearer_token(request)
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
@@ -133,7 +128,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
         try:
             body_json = json.loads(body)
             model_name = body_json.get("model")
-            is_streaming = body_json.get("stream", False) or False
+            is_streaming = bool(body_json.get("stream", False))
         except (json.JSONDecodeError, AttributeError):
             pass
 
@@ -141,7 +136,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             worker_addr = await query_router(
                 config.router_addr,
                 token,
-                "/chat/completions",
+                path,
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
                 model=model_name,
@@ -153,7 +148,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
         if is_streaming:
             return StreamingResponse(
                 forward_sse_stream(
-                    f"{worker_addr}/chat/completions",
+                    f"{worker_addr}{path}",
                     body,
                     headers,
                     config.forward_timeout,
@@ -162,18 +157,30 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
             )
 
-        resp = await forward_request(
-            f"{worker_addr}/chat/completions",
+        response = await forward_request(
+            f"{worker_addr}{path}",
             body,
             headers,
             config.forward_timeout,
             client=_client(),
         )
         return Response(
-            content=resp.content,
-            status_code=resp.status_code,
-            media_type=resp.headers.get("content-type"),
+            content=response.content,
+            status_code=response.status_code,
+            media_type=response.headers.get("content-type"),
         )
+
+    # =========================================================================
+    # POST /chat/completions — admin OR session key, streaming or non-streaming
+    # =========================================================================
+
+    @app.post("/chat/completions")
+    async def chat_completions(request: Request):
+        return await _forward_generation_request(request, "/chat/completions")
+
+    @app.post("/v1/messages")
+    async def anthropic_messages(request: Request):
+        return await _forward_generation_request(request, "/v1/messages")
 
     @app.post("/register_model")
     async def register_model(request: Request):

--- a/areal/v2/inference_service/gateway/auth.py
+++ b/areal/v2/inference_service/gateway/auth.py
@@ -27,16 +27,22 @@ class AuthError(Exception):
 
 
 def extract_bearer_token(request: Request) -> str:
-    """Extract API token from Authorization header.
+    """Extract API token from an OpenAI or Anthropic authentication header.
 
     Raises HTTPException(401) if missing or malformed.
     """
     auth_header = request.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
         return auth_header[7:].strip()
+    x_api_key = request.headers.get("x-api-key", "")
+    if x_api_key:
+        return x_api_key
     raise HTTPException(
         status_code=401,
-        detail="Missing or malformed Authorization header. Expected 'Bearer <token>'.",
+        detail=(
+            "Missing or malformed authentication header. Expected "
+            "'Bearer <token>' or 'x-api-key: <token>'."
+        ),
     )
 
 

--- a/tests/experimental/openai/test_anthropic.py
+++ b/tests/experimental/openai/test_anthropic.py
@@ -1,0 +1,48 @@
+from areal.experimental.openai.anthropic import translate_anthropic_request
+
+
+def test_translate_anthropic_request_preserves_tool_round_trip():
+    translated = translate_anthropic_request(
+        {
+            "model": "claude-compatible",
+            "max_tokens": 64,
+            "tools": [
+                {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                }
+            ],
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool-1",
+                            "name": "Read",
+                            "input": {"path": "/tmp/example"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-1",
+                            "content": "example contents",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    tool_call = translated["messages"][0]["tool_calls"][0]
+    assert tool_call["id"] == "tool-1"
+    assert tool_call["function"]["name"] == "Read"
+    assert translated["messages"][1]["tool_call_id"] == "tool-1"

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -416,6 +416,11 @@ class TestRolloutControllerV2Construction:
             agent=AgentConfig(
                 agent_cls_path="tests.experimental.openai.utils.SimpleAgent",
                 set_reward_finish_timeout=7.5,
+                message_preprocessors=[
+                    "examples.swe.preprocessors.StripAnthropicBillingHeader",
+                    "examples.swe.preprocessors.StripAllSystemReminders",
+                ],
+                prefix_matcher="examples.swe.prefix_matchers.swe_prefix_matcher",
             ),
             scheduling_spec=(
                 SchedulingSpec(
@@ -457,6 +462,15 @@ class TestRolloutControllerV2Construction:
         assert "--callback-server-addr" in data_proxy_cmd
         assert "http://127.0.0.1:19000" in data_proxy_cmd
         assert ("--deterministic-sampling" in data_proxy_cmd) is deterministic_sampling
+        assert data_proxy_cmd.count("--message-preprocessor") == 2
+        first = data_proxy_cmd.index("--message-preprocessor")
+        second = data_proxy_cmd.index("--message-preprocessor", first + 1)
+        assert data_proxy_cmd[first + 1].endswith("StripAnthropicBillingHeader")
+        assert data_proxy_cmd[second + 1].endswith("StripAllSystemReminders")
+        matcher = data_proxy_cmd.index("--prefix-matcher")
+        assert data_proxy_cmd[matcher + 1] == (
+            "examples.swe.prefix_matchers.swe_prefix_matcher"
+        )
 
 
 class TestOnlineCallbackFlow:

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -159,6 +159,13 @@ def session_headers(api_key: str):
     return {"Authorization": f"Bearer {api_key}"}
 
 
+def anthropic_headers(api_key: str):
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+
+
 # =============================================================================
 # SessionStore unit tests
 # =============================================================================
@@ -296,6 +303,28 @@ class TestSessionStore:
         assert online_session1 is online_session2
         assert online_session1.session_id == "__hitl__"
 
+    def test_prefix_matcher_is_preserved_when_active_cache_rotates(self):
+        from examples.swe.prefix_matchers import swe_prefix_matcher
+
+        from areal.experimental.openai.types import InteractionWithTokenLogpReward
+
+        store = SessionStore(prefix_matcher=swe_prefix_matcher)
+        session_id, _ = store.start_session("task-prefix")
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        assert session.active_completions._prefix_matcher is swe_prefix_matcher
+
+        interaction = InteractionWithTokenLogpReward(
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        interaction.interaction_id = "interaction-1"
+        interaction.output_message_list = [{"role": "assistant", "content": "hello"}]
+        session.active_completions["interaction-1"] = interaction
+
+        session.set_reward("interaction-1", 1.0)
+
+        assert session.active_completions._prefix_matcher is swe_prefix_matcher
+
     def test_online_session_count(self):
         store = SessionStore()
         store.set_admin_key(ADMIN_KEY)
@@ -331,6 +360,120 @@ async def test_start_session_without_admin_key(client):
         json={"task_id": "test-task"},
     )
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_applies_preprocessors_and_uses_session_cache(
+    config,
+    mock_areal_client,
+):
+    from examples.swe.prefix_matchers import swe_prefix_matcher
+
+    cc_config = DataProxyConfig(
+        **{
+            **config.__dict__,
+            "message_preprocessors": (
+                "examples.swe.preprocessors.StripAnthropicBillingHeader",
+                "examples.swe.preprocessors.StripAllSystemReminders",
+            ),
+            "prefix_matcher": "examples.swe.prefix_matchers.swe_prefix_matcher",
+        }
+    )
+    app = create_app(cc_config)
+    store = SessionStore(prefix_matcher=swe_prefix_matcher)
+    store.set_admin_key(cc_config.admin_api_key)
+    store.set_capacity(1)
+    app.state.session_store = store
+    app.state.areal_client = mock_areal_client
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        start = await c.post(
+            "/rl/start_session",
+            json={"task_id": "cc-task"},
+            headers=admin_headers(),
+        )
+        session_key = start.json()["sessions"][0]["session_api_key"]
+        response = await c.post(
+            "/v1/messages",
+            json={
+                "model": "claude-compatible",
+                "max_tokens": 64,
+                "system": (
+                    "x-anthropic-billing-header: volatile\n"
+                    "stable<system-reminder>volatile</system-reminder>"
+                ),
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hello"}],
+                    }
+                ],
+            },
+            headers=anthropic_headers(session_key),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["type"] == "message"
+    call_kwargs = mock_areal_client.chat.completions.create.await_args.kwargs
+    messages = call_kwargs["messages"]
+    serialized_messages = str(messages)
+    assert "x-anthropic-billing-header" not in serialized_messages
+    assert "system-reminder" not in serialized_messages
+    assert "stable" in serialized_messages
+
+    session = store.get_session_by_api_key(session_key)
+    assert session is not None
+    assert session.active_completions._prefix_matcher is swe_prefix_matcher
+    assert len(session.active_completions) == 1
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_streams_translated_events(
+    config,
+    mock_areal_client,
+    monkeypatch,
+):
+    app = create_app(config)
+    store = SessionStore()
+    store.set_admin_key(config.admin_api_key)
+    store.set_capacity(1)
+    app.state.session_store = store
+    app.state.areal_client = mock_areal_client
+
+    async def _translated_stream():
+        yield "event: message_start\ndata: {}\n\n"
+        yield "event: message_stop\ndata: {}\n\n"
+
+    monkeypatch.setattr(
+        "areal.v2.inference_service.data_proxy.app.translate_anthropic_stream",
+        lambda _stream, model: _translated_stream(),
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        start = await c.post(
+            "/rl/start_session",
+            json={"task_id": "cc-stream"},
+            headers=admin_headers(),
+        )
+        session_key = start.json()["sessions"][0]["session_api_key"]
+        response = await c.post(
+            "/v1/messages",
+            json={
+                "model": "claude-compatible",
+                "max_tokens": 64,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            headers=anthropic_headers(session_key),
+        )
+
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+    assert "event: message_start" in response.text
+    assert "event: message_stop" in response.text
+    assert mock_areal_client.chat.completions.create.await_args.kwargs["stream"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/v2/inference_service/test_gateway.py
+++ b/tests/v2/inference_service/test_gateway.py
@@ -61,6 +61,13 @@ def session_headers():
     return {"Authorization": f"Bearer {SESSION_KEY}"}
 
 
+def anthropic_headers():
+    return {
+        "x-api-key": SESSION_KEY,
+        "anthropic-version": "2023-06-01",
+    }
+
+
 # =============================================================================
 # Health endpoint
 # =============================================================================
@@ -105,6 +112,75 @@ class TestAuthRejection:
             headers=session_headers(),
         )
         assert resp.status_code == 403
+
+
+class TestAnthropicMessages:
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{MODULE}.query_router", new_callable=AsyncMock)
+    async def test_x_api_key_routes_non_streaming_messages(
+        self,
+        mock_query_router,
+        mock_forward,
+        client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(
+            200,
+            json={"id": "msg-1", "type": "message", "content": []},
+        )
+
+        response = await client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-compatible",
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            headers=anthropic_headers(),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["id"] == "msg-1"
+        assert mock_query_router.await_args.args[1] == SESSION_KEY
+        assert mock_query_router.await_args.args[2] == "/v1/messages"
+        assert mock_forward.await_args.args[0] == f"{WORKER_ADDR}/v1/messages"
+        forwarded_headers = mock_forward.await_args.args[2]
+        assert forwarded_headers["x-api-key"] == SESSION_KEY
+        assert forwarded_headers["anthropic-version"] == "2023-06-01"
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.forward_sse_stream")
+    @patch(f"{MODULE}.query_router", new_callable=AsyncMock)
+    async def test_streaming_messages_forward_anthropic_sse(
+        self,
+        mock_query_router,
+        mock_forward_sse,
+        client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+
+        async def _stream():
+            yield b"event: message_start\ndata: {}\n\n"
+            yield b"event: message_stop\ndata: {}\n\n"
+
+        mock_forward_sse.return_value = _stream()
+
+        response = await client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-compatible",
+                "max_tokens": 64,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            headers=anthropic_headers(),
+        )
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        assert "event: message_start" in response.text
+        assert mock_forward_sse.call_args.args[0] == f"{WORKER_ADDR}/v1/messages"
 
 
 # =============================================================================

--- a/tests/v2/inference_service/test_ipv6_entrypoints.py
+++ b/tests/v2/inference_service/test_ipv6_entrypoints.py
@@ -25,6 +25,8 @@ def test_data_proxy_main_formats_ipv6_serving_addr():
         reasoning_parser="qwen3",
         engine_max_tokens=None,
         chat_template_type="hf",
+        message_preprocessor=[],
+        prefix_matcher=None,
     )
 
     with (
@@ -43,6 +45,8 @@ def test_data_proxy_main_formats_ipv6_serving_addr():
     config = mock_create_app.call_args.args[0]
     assert config.serving_addr == "[::1]:8082"
     assert config.deterministic_sampling is False
+    assert config.message_preprocessors == ()
+    assert config.prefix_matcher is None
     mock_run.assert_called_once()
 
 


### PR DESCRIPTION
## Description

The v1 OpenAI proxy already supports the proxy features required by SWE agent
workflows:

- configurable message preprocessors;
- custom prefix matching for interaction-cache parent selection;
- Anthropic Messages API requests used by Claude-compatible agents.

The v2 inference service did not expose these capabilities through its Gateway
and Data Proxy stack. As a result, agents using the Anthropic API could not use
session-aware v2 inference routing, and v2 interaction caches could not apply
the same SWE-specific preprocessing and prefix-matching behavior as v1.

This PR adds the missing v2 integration in three layers.

### Shared Anthropic translation

Anthropic request, response, and streaming translation are extracted from the
v1 proxy into a shared helper module. The v1 proxy is updated to use this
module without changing its request-processing order.

The shared translation preserves OpenAI tool calls and Anthropic
`tool_use`/`tool_result` relationships.

### Data Proxy configuration

`RolloutControllerV2` forwards the existing
`AgentConfig.message_preprocessors` and `AgentConfig.prefix_matcher` settings
when launching Data Proxy workers.

Each Data Proxy dynamically loads the configured preprocessors and matcher.
The matcher is injected into every new `InteractionCache` and remains active
when a session rotates to a new cache after a reward boundary.

### Session-routed Anthropic Messages API

The v2 Gateway and Data Proxy add `/v1/messages` support:

- `x-api-key` is accepted as the Anthropic session credential;
- the Gateway uses the session key to route requests to the worker that owns
  the session;
- Anthropic requests are translated to OpenAI chat-completion parameters;
- configured message preprocessors run before inference;
- requests use the session's existing interaction cache;
- non-streaming responses and streaming SSE events are translated back to
  Anthropic format.

The endpoint is limited to authenticated, session-backed inference requests.
Existing `/chat/completions` and v1 proxy behavior remain unchanged.

This PR reuses existing `AgentConfig` fields and does not add new public
configuration options.

## Related Issue

Follow-up to #1458 and #1462

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Validation performed in the project development image:

- `tests/v2/inference_service/test_controller.py`
- `tests/v2/inference_service/test_data_proxy_chat.py`
- `tests/v2/inference_service/test_gateway.py`
- `tests/experimental/openai/test_proxy_rollout_server.py`
- Result: `124 passed, 4 skipped`

A focused Anthropic `tool_use`/`tool_result` round-trip test also passed.

Changed-file pre-commit checks and sanitization scans passed. This branch is
self-contained and does not depend on the v2 reward-normalization,
retry-orphan, or weight-update changes.
