### PR TITLE
perf(megatron): avoid synthetic BSHD padding rows

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -81,6 +81,7 @@ from areal.engine.megatron_utils.packed_context_parallel import (
     _is_multi_modal_payload_key,
     extract_vision_from_multi_modal,
     packed_context_parallel_forward,
+    prepare_microbatches_for_sequence_layout,
     reassemble_cp_packed_logprobs,
     split_packed_seqs_for_context_parallel,
 )
@@ -126,7 +127,6 @@ from areal.utils.data import (
     broadcast_tensor,
     concat_batch,
     pack_tensor_dict,
-    pad_mb_list,
     split_batch,
     split_padded_tensor_dict_into_mb_list,
     unpad_logits,
@@ -2721,20 +2721,21 @@ class MegatronEngine(TrainEngine):
             group=mpu.get_data_parallel_group(),
         )
         mb_list.mbs = [pack_tensor_dict(mb) for mb in mb_list.mbs]
-        # NOTE: Pad micro-batches to:
-        # 1. Reduce GPU memory fragmentation, pad actual # tokens per mb to integer multiples
-        #  of GPU page size or max_tokens_per_mb
-        # 2. Align sequence lengths to integer multiples of `align_to_multiple_of=tp_size*cp_size*2`
-        #    to satisfy the requirement of Megatron parallelism.
+        # Project each micro-batch to the model's sequence layout. Wrapper-owned
+        # THD can use a trailing padding segment to reduce memory fragmentation;
+        # The default BSHD/model-owned THD path cannot, because reconstruction
+        # would turn that segment into a synthetic batch row. Every layout
+        # still aligns each real sequence for Megatron parallelism.
         align_to_multiple_of = tp_size * cp_size * 2 if cp_size > 1 else tp_size
         align_to_multiple_of = (
             math.lcm(align_to_multiple_of, DEFAULT_VECTORIZED_ALIGNMENT_BYTES)
             if self.enable_fp8
             else align_to_multiple_of
         )
-        mb_list = pad_mb_list(
+        assert self.sequence_packing_mode is not None
+        mb_list = prepare_microbatches_for_sequence_layout(
             mb_list,
-            pad_value=0.0,
+            sequence_packing_mode=self.sequence_packing_mode,
             pad_to_maximum=self.config.pad_to_maximum,
             seq_align_to=align_to_multiple_of,
         )

--- a/areal/engine/megatron_utils/packed_context_parallel.py
+++ b/areal/engine/megatron_utils/packed_context_parallel.py
@@ -9,7 +9,40 @@ import torch.distributed.nn.functional as dist_F
 from megatron.core import parallel_state as mpu
 from megatron.core.packed_seq_params import PackedSeqParams
 
-from areal.utils.data import is_multi_modal_key
+from areal.engine.core.model import SequencePackingMode
+from areal.utils.data import (
+    MicroBatchList,
+    align_mb_list_sequences,
+    is_multi_modal_key,
+    pad_mb_list,
+)
+
+
+def prepare_microbatches_for_sequence_layout(
+    mb_list: MicroBatchList,
+    sequence_packing_mode: SequencePackingMode,
+    pad_to_maximum: bool,
+    seq_align_to: int,
+) -> MicroBatchList:
+    """Apply padding that remains inert in the model's input layout.
+
+    Wrapper-owned THD consumes trailing packed-token padding as a segment.
+    BSHD and model-owned THD reconstruct every segment as a batch row, so their
+    default path aligns only real sequences. ``pad_to_maximum`` keeps its
+    explicit legacy packed-axis behavior until it has a BSHD-native contract.
+    """
+    if sequence_packing_mode == SequencePackingMode.WRAPPER_THD or pad_to_maximum:
+        return pad_mb_list(
+            mb_list,
+            pad_value=0.0,
+            pad_to_maximum=pad_to_maximum,
+            seq_align_to=seq_align_to,
+        )
+    return align_mb_list_sequences(
+        mb_list,
+        pad_value=0.0,
+        seq_align_to=seq_align_to,
+    )
 
 
 def _unwrap_language_model(model: torch.nn.Module) -> torch.nn.Module:

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -821,10 +821,10 @@ N_TOKENS_PER_PAGE = 256
 
 def pad_packed_tensor_dict(
     data: dict[str, Any],
-    pad_to_length: int,
+    pad_to_length: int | None,
     pad_value: float = 0.0,
     seq_align_to: int | None = None,
-) -> tuple[dict[str, Any], int, torch.Tensor, int]:
+) -> tuple[dict[str, Any], int, torch.Tensor, int | None]:
     """Pad a packed dict of tensors to a specified length.
     This function assumes that the input data contains "cu_seqlens" and "max_seqlen" key,
     and all other tensors of shape [total_length, ] will be padded to `pad_to_length`.
@@ -833,7 +833,9 @@ def pad_packed_tensor_dict(
 
     Args:
         data (Dict): Dictionary containing tensors to be packed.
-        pad_to_length (int): The length to pad the tensors to. All tensors
+        pad_to_length (int | None): The total packed length to pad tensors to.
+            If None, only align individual sequences without appending a
+            batch-level padding sequence.
 
     Returns:
         Dict: Dictionary with padded tensors and modified "cu_seqlens" and
@@ -919,18 +921,21 @@ def pad_packed_tensor_dict(
 
         data = sequence_padded_data
         align_to_length = cu_seqlens_padded[-1].item()
-        # ensure pad_to_length is a integer multiple of both seq_align_to and N_TOKENS_PER_PAGE
-        lcm = np.lcm(seq_align_to, N_TOKENS_PER_PAGE).item()
-        pad_to_length = (pad_to_length + lcm - 1) // lcm * lcm
-
         cu_seqlens = data["cu_seqlens"]
         max_seqlen = data["max_seqlen"]
         total_length = data["cu_seqlens"][-1].item()
-        if pad_to_length < total_length:
-            # NOTE: In some occasion where sequence lengths, sequence padding will make total length
-            # exceed expected `pad_to_length`. This happens more often when sequence lengths are small.
-            # In this case, we increase pad_to_length.
-            pad_to_length = (total_length + lcm - 1) // lcm * lcm
+        if pad_to_length is not None:
+            # Ensure pad_to_length is an integer multiple of both
+            # seq_align_to and N_TOKENS_PER_PAGE.
+            lcm = np.lcm(seq_align_to, N_TOKENS_PER_PAGE).item()
+            pad_to_length = (pad_to_length + lcm - 1) // lcm * lcm
+            if pad_to_length < total_length:
+                # Sequence alignment can make the total exceed the original
+                # target, especially when sequences are short.
+                pad_to_length = (total_length + lcm - 1) // lcm * lcm
+
+    if pad_to_length is None:
+        return data, 0, old_cu_seqlens, align_to_length
 
     # Pad batch
     pad_length = pad_to_length - total_length
@@ -980,6 +985,40 @@ def pad_packed_tensor_dict(
         old_cu_seqlens,
         align_to_length,
     )
+
+
+def align_mb_list_sequences(
+    mb_list: MicroBatchList,
+    pad_value: float = 0.0,
+    seq_align_to: int = 1,
+) -> MicroBatchList:
+    """Align real sequences without adding a synthetic padding sequence.
+
+    This projection is for model inputs that are reconstructed as BSHD. A
+    trailing batch-level padding segment in ``cu_seqlens`` would become an
+    extra batch row rather than inert packed-token padding.
+    """
+    padded_mbs = []
+    old_cu_seqlens_list = []
+    align_to_lengths = []
+    for mb in mb_list.mbs:
+        padded_mb, _, old_cu_seqlens, align_to_length = pad_packed_tensor_dict(
+            mb,
+            pad_to_length=None,
+            pad_value=pad_value,
+            seq_align_to=seq_align_to,
+        )
+        assert align_to_length is not None
+        padded_mbs.append(padded_mb)
+        old_cu_seqlens_list.append(old_cu_seqlens)
+        align_to_lengths.append(align_to_length)
+
+    mb_list.padded_mbs = padded_mbs
+    mb_list.padding_lengths = [0] * len(padded_mbs)
+    mb_list.padded_to_lengths = align_to_lengths.copy()
+    mb_list.old_cu_seqlens_list = old_cu_seqlens_list
+    mb_list.align_to_lengths = align_to_lengths
+    return mb_list
 
 
 def pad_mb_list(

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -203,7 +203,7 @@ class TestExtractVisionFromMultiModal:
 
 
 class TestPackedContextParallelForward:
-    def test_padding_keeps_model_thd_sequence_offsets_tp_aligned(self):
+    def test_wrapper_thd_padding_keeps_sequence_offsets_tp_aligned(self):
         from areal.utils.data import pad_packed_tensor_dict
 
         padded, _, _, _ = pad_packed_tensor_dict(
@@ -219,6 +219,90 @@ class TestPackedContextParallelForward:
         seq_lens = padded["cu_seqlens"][1:] - padded["cu_seqlens"][:-1]
         assert seq_lens.tolist() == [4, 4, 248]
         assert torch.all(seq_lens % 4 == 0)
+
+    @pytest.mark.parametrize(
+        ("sequence_packing_mode", "expected_cu_seqlens", "expected_bshd_shape"),
+        [
+            ("wrapper_thd", [0, 14_010, 14_080], None),
+            ("padded", [0, 14_010], (1, 14_010)),
+            ("model_thd", [0, 14_010], (1, 14_010)),
+        ],
+    )
+    def test_sequence_layout_controls_batch_padding(
+        self, sequence_packing_mode, expected_cu_seqlens, expected_bshd_shape
+    ):
+        from areal.api.cli_args import MicroBatchSpec
+        from areal.engine.core.model import SequencePackingMode
+        from areal.engine.megatron_utils.packed_context_parallel import (
+            _reconstruct_padded_2d,
+            prepare_microbatches_for_sequence_layout,
+        )
+        from areal.utils.data import MicroBatchList
+
+        input_ids = torch.arange(14_010)
+        mb = {
+            "input_ids": input_ids,
+            "cu_seqlens": torch.tensor([0, 14_010], dtype=torch.int32),
+            "max_seqlen": 14_010,
+        }
+        mb_list = MicroBatchList(
+            data=mb,
+            mb_spec=MicroBatchSpec(),
+            mbs=[mb],
+            group_lens=[14_010],
+        )
+
+        prepared = prepare_microbatches_for_sequence_layout(
+            mb_list,
+            sequence_packing_mode=SequencePackingMode(sequence_packing_mode),
+            pad_to_maximum=False,
+            seq_align_to=1,
+        )
+
+        assert prepared.padded_mbs is not None
+        padded_mb = prepared.padded_mbs[0]
+        assert padded_mb["cu_seqlens"].tolist() == expected_cu_seqlens
+        if expected_bshd_shape is None:
+            return
+
+        reconstructed, _, seq_lens, _ = _reconstruct_padded_2d(
+            padded_mb["input_ids"],
+            padded_mb["cu_seqlens"],
+            padded_mb["max_seqlen"],
+        )
+        assert seq_lens.tolist() == [14_010]
+        assert reconstructed.shape == expected_bshd_shape
+
+    def test_bshd_pad_to_maximum_preserves_legacy_packed_axis_behavior(self):
+        from areal.api.cli_args import MicroBatchSpec
+        from areal.engine.core.model import SequencePackingMode
+        from areal.engine.megatron_utils.packed_context_parallel import (
+            prepare_microbatches_for_sequence_layout,
+        )
+        from areal.utils.data import MicroBatchList
+
+        input_ids = torch.arange(14_010)
+        mb = {
+            "input_ids": input_ids,
+            "cu_seqlens": torch.tensor([0, 14_010], dtype=torch.int32),
+            "max_seqlen": 14_010,
+        }
+        mb_list = MicroBatchList(
+            data=mb,
+            mb_spec=MicroBatchSpec(max_tokens_per_mb=14_080),
+            mbs=[mb],
+            group_lens=[14_010],
+        )
+
+        prepared = prepare_microbatches_for_sequence_layout(
+            mb_list,
+            sequence_packing_mode=SequencePackingMode.PADDED,
+            pad_to_maximum=True,
+            seq_align_to=1,
+        )
+
+        assert prepared.padded_mbs is not None
+        assert prepared.padded_mbs[0]["cu_seqlens"].tolist() == [0, 14_010, 14_080]
 
     @pytest.mark.parametrize(
         ("use_padded_seq", "expected_mask"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,18 +3,72 @@ import torch
 
 from areal.api.cli_args import MicroBatchSpec
 from areal.utils.data import (
+    MicroBatchList,
+    align_mb_list_sequences,
     pack_tensor_dict,
     pad_and_stack_tensors_along_first_dim,
     pad_sequences_to_tensors,
     reorder_list,
     split_padded_tensor_dict_into_mb_list,
     unpack_sequence,
+    unpad_logits,
 )
 
 BS = 16
 MAX_ANSWER_LEN = 16
 MAX_PROMPT_LEN = 8
 VOCAB_SIZE = 100
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "seq_align_to", "expected_cu_seqlens"),
+    [
+        ([14010], 1, [0, 14010]),
+        ([7, 130], 8, [0, 8, 144]),
+    ],
+)
+def test_align_mb_list_sequences_does_not_add_batch_row(
+    seq_lens, seq_align_to, expected_cu_seqlens
+):
+    """BSHD sequence alignment must preserve the number of real batch rows."""
+    total_length = sum(seq_lens)
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(seq_lens).cumsum(0).tolist()], dtype=torch.int32
+    )
+    input_ids = torch.arange(total_length)
+    mb = {
+        "input_ids": input_ids,
+        "position_ids": torch.cat([torch.arange(length) for length in seq_lens]),
+        "cu_seqlens": cu_seqlens,
+        "max_seqlen": max(seq_lens),
+    }
+    mb_list = MicroBatchList(
+        data=mb,
+        mb_spec=MicroBatchSpec(),
+        mbs=[mb],
+        group_lens=[total_length],
+    )
+
+    aligned = align_mb_list_sequences(mb_list, seq_align_to=seq_align_to)
+
+    assert aligned.padded_mbs is not None
+    assert aligned.old_cu_seqlens_list is not None
+    padded_mb = aligned.padded_mbs[0]
+    assert padded_mb["cu_seqlens"].tolist() == expected_cu_seqlens
+    assert padded_mb["cu_seqlens"].numel() == len(seq_lens) + 1
+    assert aligned.padding_lengths == [0]
+    assert aligned.padded_to_lengths == [expected_cu_seqlens[-1]]
+    assert torch.all(
+        (padded_mb["cu_seqlens"][1:] - padded_mb["cu_seqlens"][:-1]) % seq_align_to == 0
+    ).item()
+
+    restored_ids = unpad_logits(
+        padded_mb["input_ids"],
+        padding_length=0,
+        cu_seqlens=padded_mb["cu_seqlens"],
+        old_cu_seqlens=aligned.old_cu_seqlens_list[0],
+    )
+    torch.testing.assert_close(restored_ids, input_ids, rtol=0, atol=0)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Megatron microbatches are stored as packed token streams. The default padding path appends page padding as another `cu_seqlens` segment, which is inert for wrapper-owned THD. `PADDED` and model-owned THD forwards, however, reconstruct every segment as a BSHD row. That turns storage-only page padding into a synthetic model-visible sequence.

For one real 14,010-token sequence, the old default path produced:

```text
cu_seqlens: [0, 14010, 14080]
BSHD shape: (2, 14010)
```

This PR makes the existing `SequencePackingMode` the owner of that projection:

- `WRAPPER_THD` keeps the existing trailing page-padding segment.
- The default `PADDED` and `MODEL_THD` paths align each real sequence for TP/FP8 requirements without adding another segment, so the same example remains one row with shape `(1, 14010)`.
- Explicit `pad_to_maximum=True` keeps its legacy packed-axis behavior. Changing that public opt-in needs a separate row-aware fixed-shape contract and is intentionally outside this focused fix.

The original `cu_seqlens` metadata is retained, and the existing unpad path round-trips aligned tokens exactly. This does not change microbatch membership or the separate `max_tokens_per_mb` capacity model.

## Fixed-shape trade-off

Removing the trailing segment avoids a model-visible dummy row but can produce more layout shapes than padding every packed microbatch to its configured capacity. Users who intentionally need `max_tokens_per_mb`-sized packed buffers or fixed-shape behavior can keep `pad_to_maximum=True`, at the cost of retaining the legacy padding segment in `PADDED` and `MODEL_THD`. The default remains the existing `False`; this PR claims the representation fix, not a universal throughput improvement.

## Related Issue

Fixes #1631

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Verification

- `pre-commit run --all-files`
- `pytest -q tests/test_utils.py tests/test_sequence_packing_mode.py` — 60 passed
- Focused sequence-layout routing/reconstruction tests in `tests/test_megatron_engine_vlm.py` — 5 passed, 116 deselected

The layout decision and reconstruction are deterministic CPU tensor operations, so these tests establish the representation invariant without a GPU. I did not run distributed Megatron/GPU numerical parity or make CUDA memory/throughput claims. The full VLM module additionally requires the GPU-only TransformerEngine/FlashAttention stack in this environment.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable; no user-facing contract changed)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

The fix deliberately lives at the sequence-layout projection boundary instead of special-casing Qwen3.5. That keeps page padding valid for the representation that can consume it and prevents it only where segment count becomes batch size.
