### PR TITLE
fix(infra): prevent leaks after RTensor delete failures

### DIFF
--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -821,14 +821,16 @@ class TrainController:
 
     async def _async_clear_batches(
         self, *targets: dict[str, RTensor]
-    ) -> tuple[list[Any], dict[str, int]]:
-        """Extract shard IDs and clear tensors on each worker.
+    ) -> tuple[list[Any], dict[str, list[Any]]]:
+        """Extract shard IDs and stage storage cleanup results.
 
         HTTP DELETEs to each storage node's ``/data/clear`` — this evicts
         ``_storage`` (mandatory, otherwise HTTP storage grows unboundedly)
         and, via :func:`rtensor.remove`, also pops the storage owner's own
         ``_fetch_buffer`` (covers storage-owner-as-consumer). Failed shards
-        remain pending for one cross-step retry. See #1209 and #1581.
+        remain pending for one cross-step retry. Exhausted shards stay pending
+        until consumer-worker buffers are drained, so a worker RPC failure
+        cannot lose the storage-leak state. See #1209 and #1581.
         """
         shards_by_node = RTensor.collect_shards(targets)
         with self._clear_shards_lock:
@@ -861,26 +863,25 @@ class TrainController:
         if fatal_error is not None:
             raise fatal_error
 
-        exhausted: dict[str, int] = {}
+        exhausted: dict[str, list[Any]] = {}
         for (addr, sids), result in zip(clear_requests, results, strict=True):
             if isinstance(result, Exception):
                 with self._clear_shards_lock:
                     pending = self._pending_clear_shards.get(addr, {})
-                    exhausted_count = 0
+                    exhausted_sids = []
                     for sid in sids:
                         if sid not in pending:
                             continue
-                        failures = pending[sid] + 1
+                        failures = min(pending[sid] + 1, _MAX_CLEAR_STEP_FAILURES)
+                        pending[sid] = failures
                         if failures >= _MAX_CLEAR_STEP_FAILURES:
-                            pending.pop(sid)
-                            exhausted_count += 1
-                        else:
-                            pending[sid] = failures
-                    if not pending:
-                        self._pending_clear_shards.pop(addr, None)
-                    pending_count = len(pending)
-                if exhausted_count:
-                    exhausted[addr] = exhausted_count
+                            exhausted_sids.append(sid)
+                    pending_count = sum(
+                        failures < _MAX_CLEAR_STEP_FAILURES
+                        for failures in pending.values()
+                    )
+                if exhausted_sids:
+                    exhausted[addr] = exhausted_sids
                 logger.warning(
                     "Failed to clear %d RTensor shards on storage node %s: "
                     "%s: %s (%d pending, %d retries exhausted)",
@@ -889,7 +890,7 @@ class TrainController:
                     type(result).__name__,
                     result,
                     pending_count,
-                    exhausted_count,
+                    len(exhausted_sids),
                 )
                 continue
             with self._clear_shards_lock:
@@ -913,6 +914,18 @@ class TrainController:
 
         attempted_sids = [sid for _, sids in clear_requests for sid in sids]
         return attempted_sids, exhausted
+
+    def _commit_exhausted_clear_shards(self, exhausted: dict[str, list[Any]]) -> None:
+        """Remove exhausted shards after every consumer worker is drained."""
+        with self._clear_shards_lock:
+            for addr, sids in exhausted.items():
+                pending = self._pending_clear_shards.get(addr)
+                if pending is None:
+                    continue
+                for sid in sids:
+                    pending.pop(sid, None)
+                if not pending:
+                    self._pending_clear_shards.pop(addr, None)
 
     def clear_batches(self, *targets: dict[str, RTensor]):
         """Clear distributed batch shards from workers to free memory.
@@ -946,6 +959,10 @@ class TrainController:
         # list[str] is not tensor-like → _replicate_inputs copies the full
         # sid set to every DP head.
         self._custom_function_call("clear_batches", sids, rpc_meta={"broadcast": False})
+        # Commit retry exhaustion only after every consumer worker accepted the
+        # buffer drain. If that RPC raises, exhausted shards remain pending so
+        # the next call can retry or report the remote storage leak.
+        self._commit_exhausted_clear_shards(exhausted)
         # Always observe post-drain state. _custom_function_call returns
         # the first DP head's stats (scalar dispatch collapses via
         # _collect_results[0]); all heads are symmetric in steady state,
@@ -978,7 +995,7 @@ class TrainController:
 
         if exhausted:
             summary = ", ".join(
-                f"{addr}: {count}" for addr, count in sorted(exhausted.items())
+                f"{addr}: {len(sids)}" for addr, sids in sorted(exhausted.items())
             )
             raise RuntimeError(
                 "RTensor storage cleanup failed across two clear_batches calls "

--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+from threading import Lock
 from typing import Any
 
 import torch
@@ -20,7 +21,7 @@ from areal.api import (
 )
 from areal.api.alloc_mode import ModelAllocation
 from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
-from areal.infra.rpc.rtensor import RTensor, flatten_shard_ids
+from areal.infra.rpc.rtensor import RTensor
 from areal.infra.utils.concurrent import run_async_task
 from areal.utils import logging, stats_tracker
 from areal.utils.data import make_dummy_eval_item
@@ -31,6 +32,8 @@ from .rollout_callback import RolloutCallback
 from .rollout_controller import RolloutController
 
 logger = logging.getLogger("TrainController")
+
+_MAX_CLEAR_STEP_FAILURES = 2
 
 
 def _find_in_structure(obj: Any, type_: type) -> Any | None:
@@ -206,6 +209,9 @@ class TrainController:
 
         self._worker_role: str = "default"
         self._own_process_group = False
+        self._pending_clear_shards: dict[str, dict[Any, int]] = {}
+        self._clear_shards_lock = Lock()
+        self._clear_batches_lock = Lock()
 
         self.rollout: RolloutController = None
 
@@ -813,23 +819,100 @@ class TrainController:
                 " before using rollout/update_weight methods."
             )
 
-    async def _async_clear_batches(self, *targets: dict[str, RTensor]):
+    async def _async_clear_batches(
+        self, *targets: dict[str, RTensor]
+    ) -> tuple[list[Any], dict[str, int]]:
         """Extract shard IDs and clear tensors on each worker.
 
         HTTP DELETEs to each storage node's ``/data/clear`` — this evicts
         ``_storage`` (mandatory, otherwise HTTP storage grows unboundedly)
         and, via :func:`rtensor.remove`, also pops the storage owner's own
-        ``_fetch_buffer`` (covers storage-owner-as-consumer). See #1209.
+        ``_fetch_buffer`` (covers storage-owner-as-consumer). Failed shards
+        remain pending for one cross-step retry. See #1209 and #1581.
         """
         shards_by_node = RTensor.collect_shards(targets)
+        with self._clear_shards_lock:
+            for addr, sids in shards_by_node.items():
+                pending = self._pending_clear_shards.setdefault(addr, {})
+                for sid in sids:
+                    pending.setdefault(sid, 0)
+            clear_requests = [
+                (addr, list(pending))
+                for addr, pending in self._pending_clear_shards.items()
+                if pending
+            ]
 
-        if not shards_by_node:
-            return
+        if not clear_requests:
+            return [], {}
 
-        await asyncio.gather(
-            *[RTensor.clear_node(addr, sids) for addr, sids in shards_by_node.items()],
+        results = await asyncio.gather(
+            *[RTensor.clear_node(addr, sids) for addr, sids in clear_requests],
             return_exceptions=True,
         )
+        fatal_error = next(
+            (
+                result
+                for result in results
+                if isinstance(result, BaseException)
+                and not isinstance(result, Exception)
+            ),
+            None,
+        )
+        if fatal_error is not None:
+            raise fatal_error
+
+        exhausted: dict[str, int] = {}
+        for (addr, sids), result in zip(clear_requests, results, strict=True):
+            if isinstance(result, Exception):
+                with self._clear_shards_lock:
+                    pending = self._pending_clear_shards.get(addr, {})
+                    exhausted_count = 0
+                    for sid in sids:
+                        if sid not in pending:
+                            continue
+                        failures = pending[sid] + 1
+                        if failures >= _MAX_CLEAR_STEP_FAILURES:
+                            pending.pop(sid)
+                            exhausted_count += 1
+                        else:
+                            pending[sid] = failures
+                    if not pending:
+                        self._pending_clear_shards.pop(addr, None)
+                    pending_count = len(pending)
+                if exhausted_count:
+                    exhausted[addr] = exhausted_count
+                logger.warning(
+                    "Failed to clear %d RTensor shards on storage node %s: "
+                    "%s: %s (%d pending, %d retries exhausted)",
+                    len(sids),
+                    addr,
+                    type(result).__name__,
+                    result,
+                    pending_count,
+                    exhausted_count,
+                )
+                continue
+            with self._clear_shards_lock:
+                pending = self._pending_clear_shards.get(addr)
+                if pending is not None:
+                    for sid in sids:
+                        pending.pop(sid, None)
+                    if not pending:
+                        self._pending_clear_shards.pop(addr, None)
+            if isinstance(result, dict):
+                logger.debug(
+                    "Cleared RTensor shards on storage node %s "
+                    "(requested=%d, cleared=%s, remaining_tensors=%s, "
+                    "remaining_bytes=%s)",
+                    addr,
+                    len(sids),
+                    result.get("cleared_count", "unknown"),
+                    result.get("num_tensors", "unknown"),
+                    result.get("total_bytes", "unknown"),
+                )
+
+        attempted_sids = [sid for _, sids in clear_requests for sid in sids]
+        return attempted_sids, exhausted
 
     def clear_batches(self, *targets: dict[str, RTensor]):
         """Clear distributed batch shards from workers to free memory.
@@ -848,10 +931,15 @@ class TrainController:
            full sid set.
 
         After the second fan-out, a ``fetch_buffer_stats`` RPC logs the
-        drain result — WARNING on leak, DEBUG when clean.
+        drain result — WARNING on leak, DEBUG when clean. A shard that also
+        fails on the next call raises after worker buffers have been drained,
+        preventing training from silently accumulating remote storage.
         """
-        run_async_task(self._async_clear_batches, *targets)
-        sids = flatten_shard_ids(targets)
+        with self._clear_batches_lock:
+            self._clear_batches_locked(*targets)
+
+    def _clear_batches_locked(self, *targets: dict[str, RTensor]) -> None:
+        sids, exhausted = run_async_task(self._async_clear_batches, *targets)
         if not sids:
             return
         # broadcast=False → purely local per-head op (no NCCL collective).
@@ -873,17 +961,26 @@ class TrainController:
                 self._worker_role,
                 e,
             )
-            return
-        n_entries = stats.get("num_entries", 0) if isinstance(stats, dict) else 0
-        if n_entries > 0:
-            logger.warning(
-                "clear_batches: _fetch_buffer non-empty on DP head 0 "
-                "(role=%s, num_entries=%d) — possible leak, see #1209",
-                self._worker_role,
-                n_entries,
-            )
         else:
-            logger.debug(
-                "clear_batches: _fetch_buffer drained on DP head 0 (role=%s)",
-                self._worker_role,
+            n_entries = stats.get("num_entries", 0) if isinstance(stats, dict) else 0
+            if n_entries > 0:
+                logger.warning(
+                    "clear_batches: _fetch_buffer non-empty on DP head 0 "
+                    "(role=%s, num_entries=%d) — possible leak, see #1209",
+                    self._worker_role,
+                    n_entries,
+                )
+            else:
+                logger.debug(
+                    "clear_batches: _fetch_buffer drained on DP head 0 (role=%s)",
+                    self._worker_role,
+                )
+
+        if exhausted:
+            summary = ", ".join(
+                f"{addr}: {count}" for addr, count in sorted(exhausted.items())
+            )
+            raise RuntimeError(
+                "RTensor storage cleanup failed across two clear_batches calls "
+                f"({summary})"
             )

--- a/areal/infra/data_service/controller/controller.py
+++ b/areal/infra/data_service/controller/controller.py
@@ -413,20 +413,28 @@ class DataController:
 
     async def _async_clear_batches(self) -> None:
         async def _clear_one(session: aiohttp.ClientSession, addr: str) -> None:
-            try:
-                async with session.delete(
-                    f"{addr}/data/clear",
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as resp:
-                    resp.raise_for_status()
-            except Exception:
-                logger.debug("Failed to clear batches on %s", addr)
+            async with session.delete(
+                f"{addr}/data/clear",
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                resp.raise_for_status()
 
         async with aiohttp.ClientSession(trust_env=False) as session:
-            await asyncio.gather(
-                *(_clear_one(session, addr) for addr in self._worker_addrs),
+            clear_requests = list(self._worker_addrs)
+            results = await asyncio.gather(
+                *(_clear_one(session, addr) for addr in clear_requests),
                 return_exceptions=True,
             )
+            for addr, result in zip(clear_requests, results, strict=True):
+                if isinstance(result, asyncio.CancelledError):
+                    raise result
+                if isinstance(result, BaseException):
+                    logger.warning(
+                        "Failed to clear batches on data worker %s: %s: %s",
+                        addr,
+                        type(result).__name__,
+                        result,
+                    )
 
     # -- Destroy -----------------------------------------------------------
 

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -15,7 +15,11 @@ import orjson
 import torch
 
 from areal.infra.utils.concurrent import run_async_task
-from areal.infra.utils.http import DEFAULT_REQUEST_TIMEOUT, get_default_connector
+from areal.infra.utils.http import (
+    DEFAULT_REQUEST_TIMEOUT,
+    arequest_with_retry,
+    get_default_connector,
+)
 from areal.utils import logging
 
 logger = logging.getLogger("HttpRTensor")
@@ -52,7 +56,9 @@ class RTensorBackend(Protocol):
         """
         ...
 
-    async def delete(self, node_addr: str, shard_ids: list[Any]) -> None:
+    async def delete(
+        self, node_addr: str, shard_ids: list[Any]
+    ) -> dict[str, Any] | None:
         """Delete shards from storage.
 
         Parameters
@@ -61,6 +67,11 @@ class RTensorBackend(Protocol):
             The node address where shards are stored
         shard_ids : list[Any]
             List of shard IDs to delete
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Storage-node cleanup statistics when provided by the backend.
         """
         ...
 
@@ -252,21 +263,24 @@ class HttpRTensorBackend:
         _store_local(shard_id, tensor)
         return shard_id
 
-    async def delete(self, node_addr: str, shard_ids: list[str]) -> None:
-        """Delete shards via HTTP DELETE request."""
-        from areal.utils.network import format_hostport, split_hostport
-
-        try:
-            host, port = split_hostport(node_addr)
-            base = format_hostport(host, port)
-        except ValueError:
-            base = node_addr
+    async def delete(self, node_addr: str, shard_ids: list[str]) -> dict[str, Any]:
+        """Delete shards with retries and return storage-node cleanup statistics."""
         async with self._create_session() as session:
-            async with session.delete(
-                f"http://{base}/data/clear", json={"shard_ids": shard_ids}
-            ) as resp:
-                if resp.status == 200:
-                    await resp.json()
+            result = await arequest_with_retry(
+                node_addr,
+                "/data/clear",
+                payload={"shard_ids": shard_ids},
+                session=session,
+                method="DELETE",
+                max_retries=3,
+                timeout=10,
+            )
+        if not isinstance(result, dict) or result.get("status") != "ok":
+            raise RuntimeError(
+                f"Invalid response while clearing RTensor shards on {node_addr}: "
+                f"{result!r}"
+            )
+        return result
 
 
 _backend: RTensorBackend | None = None
@@ -528,7 +542,7 @@ class RTensor:
         return shards_by_node
 
     @staticmethod
-    async def clear_node(node_addr: str, shard_ids: list[Any]) -> None:
+    async def clear_node(node_addr: str, shard_ids: list[Any]) -> dict[str, Any] | None:
         """Clear shards from a node and evict them from the fetch buffer.
 
         Parameters
@@ -537,11 +551,16 @@ class RTensor:
             The node address
         shard_ids : list[Any]
             List of shard IDs to delete
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Storage-node cleanup statistics when provided by the backend.
         """
         with _fetch_buffer_lock:
             for sid in shard_ids:
                 _fetch_buffer.pop(sid, None)
-        await get_backend().delete(node_addr, shard_ids)
+        return await get_backend().delete(node_addr, shard_ids)
 
     @property
     def shape(self) -> torch.Size:

--- a/areal/infra/utils/http.py
+++ b/areal/infra/utils/http.py
@@ -172,7 +172,7 @@ async def arequest_with_retry(
             elif method.upper() == "PUT":
                 ctx = _session.put(url, json=payload, timeout=timeo)
             elif method.upper() == "DELETE":
-                ctx = _session.delete(url, timeout=timeo)
+                ctx = _session.delete(url, json=payload, timeout=timeo)
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
             async with ctx as response:

--- a/areal/trainer/dpo_trainer.py
+++ b/areal/trainer/dpo_trainer.py
@@ -27,6 +27,7 @@ from areal.infra.data_service import DataController
 from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.data import (
     broadcast_tensor_container,
     cycle_dataloader,
@@ -300,14 +301,17 @@ class DPOTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(batch)
+                    cleanups = [("actor", lambda: self.actor.clear_batches(batch))]
                     # ref DP heads also localized `batch` in compute_logp —
                     # drain their per-process fetch buffers. See
                     # areal-project/AReaL#1209.
                     if self.ref is not None:
-                        self.ref.clear_batches(batch)
+                        cleanups.append(("ref", lambda: self.ref.clear_batches(batch)))
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -47,6 +47,7 @@ from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.infra.utils.concurrent import call_maybe_async
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.dataloader import create_dataloader
 from areal.utils.dte import apply_dte_config_envvars
 from areal.utils.environ import is_single_controller
@@ -943,13 +944,30 @@ class PPOTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(rollout_batch, adv_batch)
+                    cleanups = [
+                        (
+                            "actor",
+                            lambda: self.actor.clear_batches(rollout_batch, adv_batch),
+                        )
+                    ]
                     if self.critic is not None:
-                        self.critic.clear_batches(rollout_batch, adv_batch)
+                        cleanups.append(
+                            (
+                                "critic",
+                                lambda: self.critic.clear_batches(
+                                    rollout_batch, adv_batch
+                                ),
+                            )
+                        )
                     if self.ref is not None:
-                        self.ref.clear_batches(rollout_batch)
+                        cleanups.append(
+                            ("ref", lambda: self.ref.clear_batches(rollout_batch))
+                        )
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/trainer/rw_trainer.py
+++ b/areal/trainer/rw_trainer.py
@@ -27,6 +27,7 @@ from areal.infra.data_service import DataController
 from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.data import (
     broadcast_tensor_container,
     cycle_dataloader,
@@ -293,9 +294,12 @@ class RWTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(batch)
+                    cleanups = [("actor", lambda: self.actor.clear_batches(batch))]
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -26,6 +26,7 @@ from areal.infra.data_service import DataController
 from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.data import (
     broadcast_tensor_container,
     collate_samples_to_list,
@@ -278,9 +279,12 @@ class SFTTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(batch)
+                    cleanups = [("actor", lambda: self.actor.clear_batches(batch))]
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/utils/cleanup.py
+++ b/areal/utils/cleanup.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable, Iterable
+
+
+def run_batch_cleanups(
+    cleanups: Iterable[tuple[str, Callable[[], None]]],
+) -> None:
+    """Run every batch cleanup before propagating any ordinary failures."""
+    failures: list[tuple[str, Exception]] = []
+    for role, cleanup in cleanups:
+        try:
+            cleanup()
+        except Exception as error:
+            failures.append((role, error))
+
+    if failures:
+        first_role, first_error = failures[0]
+        first_error.add_note(f"clear_batches failed first for role: {first_role}")
+        for role, error in failures[1:]:
+            first_error.add_note(
+                "Additional clear_batches failure for "
+                f"{role}: {type(error).__name__}: {error}"
+            )
+        raise first_error

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("GatewayTrainController")
 
+_MAX_CLEAR_STEP_FAILURES = 2
+
 
 class GatewayTrainController:
     _GUARD_SUFFIX = "-guard"
@@ -64,6 +66,9 @@ class GatewayTrainController:
         # Shared HTTP client (lazy, per-event-loop)
         self._async_client: Any | None = None
         self._async_client_loop: asyncio.AbstractEventLoop | None = None
+        self._pending_clear_shards: dict[str, dict[Any, int]] = {}
+        self._clear_shards_lock = Lock()
+        self._clear_batches_lock = Lock()
 
         # Pipelined initialization state
         self._init_future: concurrent.futures.Future | None = None
@@ -872,27 +877,100 @@ class GatewayTrainController:
         self._gateway_post("/save_perf_tracer", payload)
 
     def clear_batches(self, *targets: Any) -> None:
-        from areal.infra.rpc.rtensor import RTensor, flatten_shard_ids
+        """Clear worker buffers and retry failed storage deletes across one step."""
+        with self._clear_batches_lock:
+            self._clear_batches_locked(*targets)
+
+    def _clear_batches_locked(self, *targets: Any) -> None:
+        from areal.infra.rpc.rtensor import RTensor
         from areal.infra.rpc.serialization import serialize_value
 
         # Step 1: HTTP DELETE to storage nodes to evict _storage entries
         # (mirrors TrainController._async_clear_batches)
         shards_by_node = RTensor.collect_shards(targets)
-        if shards_by_node:
+        with self._clear_shards_lock:
+            for addr, sids in shards_by_node.items():
+                pending = self._pending_clear_shards.setdefault(addr, {})
+                for sid in sids:
+                    pending.setdefault(sid, 0)
+            clear_requests = [
+                (addr, list(pending))
+                for addr, pending in self._pending_clear_shards.items()
+                if pending
+            ]
+        exhausted: dict[str, int] = {}
+        if clear_requests:
 
             async def _clear_storage():
-                await asyncio.gather(
-                    *[
-                        RTensor.clear_node(addr, sids)
-                        for addr, sids in shards_by_node.items()
-                    ],
+                results = await asyncio.gather(
+                    *[RTensor.clear_node(addr, sids) for addr, sids in clear_requests],
                     return_exceptions=True,
                 )
+                fatal_error = next(
+                    (
+                        result
+                        for result in results
+                        if isinstance(result, BaseException)
+                        and not isinstance(result, Exception)
+                    ),
+                    None,
+                )
+                if fatal_error is not None:
+                    raise fatal_error
+
+                for (addr, sids), result in zip(clear_requests, results, strict=True):
+                    if isinstance(result, Exception):
+                        with self._clear_shards_lock:
+                            pending = self._pending_clear_shards.get(addr, {})
+                            exhausted_count = 0
+                            for sid in sids:
+                                if sid not in pending:
+                                    continue
+                                failures = pending[sid] + 1
+                                if failures >= _MAX_CLEAR_STEP_FAILURES:
+                                    pending.pop(sid)
+                                    exhausted_count += 1
+                                else:
+                                    pending[sid] = failures
+                            if not pending:
+                                self._pending_clear_shards.pop(addr, None)
+                            pending_count = len(pending)
+                        if exhausted_count:
+                            exhausted[addr] = exhausted_count
+                        logger.warning(
+                            "Failed to clear %d RTensor shards on storage node "
+                            "%s: %s: %s (%d pending, %d retries exhausted)",
+                            len(sids),
+                            addr,
+                            type(result).__name__,
+                            result,
+                            pending_count,
+                            exhausted_count,
+                        )
+                        continue
+                    with self._clear_shards_lock:
+                        pending = self._pending_clear_shards.get(addr)
+                        if pending is not None:
+                            for sid in sids:
+                                pending.pop(sid, None)
+                            if not pending:
+                                self._pending_clear_shards.pop(addr, None)
+                    if isinstance(result, dict):
+                        logger.debug(
+                            "Cleared RTensor shards on storage node %s "
+                            "(requested=%d, cleared=%s, remaining_tensors=%s, "
+                            "remaining_bytes=%s)",
+                            addr,
+                            len(sids),
+                            result.get("cleared_count", "unknown"),
+                            result.get("num_tensors", "unknown"),
+                            result.get("total_bytes", "unknown"),
+                        )
 
             run_async_task(_clear_storage)
 
         # Step 2: Drain _fetch_buffer on workers via engine.clear_batches(shard_ids)
-        shard_ids = flatten_shard_ids(targets)
+        shard_ids = [sid for _, sids in clear_requests for sid in sids]
         if not shard_ids:
             return
         payload = {
@@ -900,6 +978,15 @@ class GatewayTrainController:
             "kwargs": serialize_value({}),
         }
         self._gateway_post("/clear_batches", payload)
+
+        if exhausted:
+            summary = ", ".join(
+                f"{addr}: {count}" for addr, count in sorted(exhausted.items())
+            )
+            raise RuntimeError(
+                "RTensor storage cleanup failed across two clear_batches calls "
+                f"({summary})"
+            )
 
     def current_data_parallel_head(self) -> int:
         return 0

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -898,7 +898,7 @@ class GatewayTrainController:
                 for addr, pending in self._pending_clear_shards.items()
                 if pending
             ]
-        exhausted: dict[str, int] = {}
+        exhausted: dict[str, list[Any]] = {}
         if clear_requests:
 
             async def _clear_storage():
@@ -922,21 +922,22 @@ class GatewayTrainController:
                     if isinstance(result, Exception):
                         with self._clear_shards_lock:
                             pending = self._pending_clear_shards.get(addr, {})
-                            exhausted_count = 0
+                            exhausted_sids = []
                             for sid in sids:
                                 if sid not in pending:
                                     continue
-                                failures = pending[sid] + 1
+                                failures = min(
+                                    pending[sid] + 1, _MAX_CLEAR_STEP_FAILURES
+                                )
+                                pending[sid] = failures
                                 if failures >= _MAX_CLEAR_STEP_FAILURES:
-                                    pending.pop(sid)
-                                    exhausted_count += 1
-                                else:
-                                    pending[sid] = failures
-                            if not pending:
-                                self._pending_clear_shards.pop(addr, None)
-                            pending_count = len(pending)
-                        if exhausted_count:
-                            exhausted[addr] = exhausted_count
+                                    exhausted_sids.append(sid)
+                            pending_count = sum(
+                                failures < _MAX_CLEAR_STEP_FAILURES
+                                for failures in pending.values()
+                            )
+                        if exhausted_sids:
+                            exhausted[addr] = exhausted_sids
                         logger.warning(
                             "Failed to clear %d RTensor shards on storage node "
                             "%s: %s: %s (%d pending, %d retries exhausted)",
@@ -945,7 +946,7 @@ class GatewayTrainController:
                             type(result).__name__,
                             result,
                             pending_count,
-                            exhausted_count,
+                            len(exhausted_sids),
                         )
                         continue
                     with self._clear_shards_lock:
@@ -979,9 +980,22 @@ class GatewayTrainController:
         }
         self._gateway_post("/clear_batches", payload)
 
+        # Keep retry exhaustion pending until every worker has accepted the
+        # buffer drain. A gateway failure then leaves enough state for the next
+        # call to retry or report the remote storage leak.
+        with self._clear_shards_lock:
+            for addr, sids in exhausted.items():
+                pending = self._pending_clear_shards.get(addr)
+                if pending is None:
+                    continue
+                for sid in sids:
+                    pending.pop(sid, None)
+                if not pending:
+                    self._pending_clear_shards.pop(addr, None)
+
         if exhausted:
             summary = ", ".join(
-                f"{addr}: {count}" for addr, count in sorted(exhausted.items())
+                f"{addr}: {len(sids)}" for addr, sids in sorted(exhausted.items())
             )
             raise RuntimeError(
                 "RTensor storage cleanup failed across two clear_batches calls "

--- a/tests/infra/data_service/test_controller.py
+++ b/tests/infra/data_service/test_controller.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from areal.api.cli_args import (
@@ -239,3 +240,59 @@ class TestDataControllerRegisterDataset:
 
         assert "key-1" not in controller._datasets
         assert "key-2" in controller._datasets
+
+
+class _FakeClearResponse:
+    def __init__(self, error=None):
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+
+class _FakeClearSession:
+    def __init__(self):
+        self.urls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def delete(self, url, *, timeout):
+        self.urls.append(url)
+        error = RuntimeError("clear failed") if "bad-worker" in url else None
+        return _FakeClearResponse(error)
+
+
+class TestDataControllerClearBatches:
+    def test_worker_failure_warns_without_stopping_other_clears(self):
+        controller = DataController(DataServiceConfig(), MagicMock())
+        controller._worker_addrs = ["http://good-worker", "http://bad-worker"]
+        session = _FakeClearSession()
+
+        with (
+            patch(
+                "areal.infra.data_service.controller.controller.aiohttp.ClientSession",
+                return_value=session,
+            ),
+            patch(
+                "areal.infra.data_service.controller.controller.logger.warning"
+            ) as mock_warning,
+        ):
+            asyncio.run(controller._async_clear_batches())
+
+        assert session.urls == [
+            "http://good-worker/data/clear",
+            "http://bad-worker/data/clear",
+        ]
+        mock_warning.assert_called_once()
+        assert "http://bad-worker" in str(mock_warning.call_args)

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -6,6 +6,7 @@ import sys
 import time
 import uuid
 
+import aiohttp
 import orjson
 import pytest
 import requests
@@ -19,6 +20,44 @@ from areal.infra.rpc.rtensor import (
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.utils.proc import kill_process_tree
 from areal.utils.network import find_free_ports
+
+
+class _FakeDeleteResponse:
+    content_type = "application/json"
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def json(self):
+        return self.payload
+
+
+class _FakeDeleteSession:
+    def __init__(self, responses_or_errors):
+        self.responses_or_errors = list(responses_or_errors)
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def delete(self, url, *, json, timeout):
+        self.requests.append((url, json, timeout))
+        item = self.responses_or_errors.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return _FakeDeleteResponse(item)
 
 
 @pytest.fixture(scope="module")
@@ -262,6 +301,60 @@ class TestRTensorIntegration:
 
 class TestHttpRTensorBackendBatching:
     """Unit tests for HTTP batch fetching behavior."""
+
+    def test_delete_retries_with_payload_and_returns_storage_stats(self, monkeypatch):
+        async def no_sleep(_delay):
+            return None
+
+        result_payload = {
+            "status": "ok",
+            "cleared_count": 2,
+            "num_tensors": 3,
+            "total_bytes": 128,
+        }
+        session = _FakeDeleteSession(
+            [aiohttp.ClientConnectionError("temporary failure"), result_payload]
+        )
+        backend = HttpRTensorBackend()
+        monkeypatch.setattr(backend, "_create_session", lambda: session)
+        monkeypatch.setattr("areal.infra.utils.http.asyncio.sleep", no_sleep)
+
+        result = asyncio.run(backend.delete("node-a", ["s0", "s1"]))
+
+        assert result == result_payload
+        assert len(session.requests) == 2
+        for url, payload, timeout in session.requests:
+            assert url == "http://node-a/data/clear"
+            assert payload == {"shard_ids": ["s0", "s1"]}
+            assert timeout.total == 10
+
+    def test_delete_raises_after_three_failed_attempts(self, monkeypatch):
+        async def no_sleep(_delay):
+            return None
+
+        session = _FakeDeleteSession(
+            [aiohttp.ClientConnectionError("offline") for _ in range(3)]
+        )
+        backend = HttpRTensorBackend()
+        monkeypatch.setattr(backend, "_create_session", lambda: session)
+        monkeypatch.setattr("areal.infra.utils.http.asyncio.sleep", no_sleep)
+
+        with pytest.raises(RuntimeError, match="Failed after 3 retries"):
+            asyncio.run(backend.delete("node-a", ["s0"]))
+
+        assert len(session.requests) == 3
+
+    @pytest.mark.parametrize(
+        "payload",
+        ["not-a-dict", {"status": "error", "message": "clear failed"}],
+    )
+    def test_delete_rejects_invalid_success_payload(self, monkeypatch, payload):
+        session = _FakeDeleteSession([payload])
+        backend = HttpRTensorBackend()
+        monkeypatch.setattr(backend, "_create_session", lambda: session)
+
+        with pytest.raises(RuntimeError, match="Invalid response"):
+            asyncio.run(backend.delete("node-a", ["s0"]))
 
     def test_fetch_chunks_large_requests(self, monkeypatch):
         """Large same-node fetches are split into bounded batch requests."""
@@ -1023,6 +1116,25 @@ class TestFetchBuffer:
         # clear_node evicts from buffer
         asyncio.run(RTensor.clear_node(rpc_server, [shard_id]))
         assert shard_id not in _fetch_buffer
+
+    def test_clear_node_evicts_from_buffer_when_delete_fails(self):
+        """A failed remote delete must not regress local buffer cleanup."""
+        from areal.infra.rpc.rtensor import _fetch_buffer, set_backend
+
+        class _FailingBackend:
+            async def delete(self, _node_addr, _shard_ids):
+                raise RuntimeError("storage node unavailable")
+
+        shard_id = "failed-delete-shard"
+        _fetch_buffer[shard_id] = torch.tensor([1])
+        set_backend(_FailingBackend())
+        try:
+            with pytest.raises(RuntimeError, match="storage node unavailable"):
+                asyncio.run(RTensor.clear_node("node-a", [shard_id]))
+            assert shard_id not in _fetch_buffer
+        finally:
+            set_backend(None)
+            _fetch_buffer.pop(shard_id, None)
 
     def test_clear_fetch_buffer_selective(self):
         """clear_fetch_buffer(sids) pops only the listed entries, misses are no-ops."""

--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -5,7 +5,8 @@ RPC wrappers, PPO/SFT methods, weight management, and error handling.
 """
 
 import asyncio
-from unittest.mock import Mock
+from threading import Lock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -21,6 +22,7 @@ from areal.api import (
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
 from areal.infra import TrainController
 from areal.infra.controller.train_controller import _merge_tensors
+from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
 
 
 class MockTrainEngine(TrainEngine):
@@ -164,6 +166,13 @@ def create_mock_distributed_batch(size=4, seq_len=10):
         }
         for _ in range(size)
     ]
+
+
+def create_mock_rtensor(shard_id: str, node_addr: str) -> RTensor:
+    return RTensor(
+        shard=TensorShardInfo(shard_id=shard_id, node_addr=node_addr),
+        data=torch.empty(1, device="meta"),
+    )
 
 
 # ==================== TEST CLASSES ====================
@@ -756,3 +765,149 @@ class TestTrainControllerDispatchInputs:
         assert "learning_rate" in split_kwargs
         assert len(split_kwargs["input_"]) == train_controller.parallel_strategy.dp_size
         assert all(lr == 0.001 for lr in split_kwargs["learning_rate"])
+
+
+class TestTrainControllerClearBatches:
+    def test_storage_clear_surfaces_per_node_failures_and_stats(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        target = {
+            "good": create_mock_rtensor("s-good", "good-node"),
+            "bad": create_mock_rtensor("s-bad", "bad-node"),
+        }
+        calls = []
+
+        async def fake_clear_node(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if addr == "bad-node":
+                raise RuntimeError("delete failed")
+            return {
+                "status": "ok",
+                "cleared_count": 1,
+                "num_tensors": 2,
+                "total_bytes": 64,
+            }
+
+        with (
+            patch.object(RTensor, "clear_node", new=fake_clear_node),
+            patch(
+                "areal.infra.controller.train_controller.logger.warning"
+            ) as mock_warning,
+            patch("areal.infra.controller.train_controller.logger.debug") as mock_debug,
+        ):
+            asyncio.run(controller._async_clear_batches(target))
+
+        assert calls == [
+            ("good-node", ["s-good"]),
+            ("bad-node", ["s-bad"]),
+        ]
+        mock_warning.assert_called_once()
+        assert "bad-node" in str(mock_warning.call_args)
+        mock_debug.assert_called_once()
+        assert "good-node" in str(mock_debug.call_args)
+        assert "64" in str(mock_debug.call_args)
+        assert controller._pending_clear_shards == {"bad-node": {"s-bad": 1}}
+
+    def test_failed_storage_clear_is_retried_on_next_call(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+        next_target = {"batch": create_mock_rtensor("s1", "node-a")}
+        calls = []
+
+        async def fail_then_succeed(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if len(calls) == 1:
+                raise RuntimeError("delete failed")
+            return {"status": "ok", "cleared_count": 1}
+
+        with patch.object(RTensor, "clear_node", new=fail_then_succeed):
+            asyncio.run(controller._async_clear_batches(target))
+            asyncio.run(controller._async_clear_batches(next_target))
+
+        assert calls == [("node-a", ["s0"]), ("node-a", ["s0", "s1"])]
+        assert controller._pending_clear_shards == {}
+
+    def test_second_storage_clear_failure_cleans_workers_then_raises(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        controller._clear_batches_lock = Lock()
+        controller._worker_role = "test"
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+        calls = []
+
+        async def fail_clear(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            raise RuntimeError("delete failed")
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_clear),
+            patch.object(
+                controller,
+                "_custom_function_call",
+                return_value={"num_entries": 0},
+            ) as mock_worker_call,
+        ):
+            controller.clear_batches(target)
+            with pytest.raises(RuntimeError, match="two clear_batches calls"):
+                controller.clear_batches({})
+
+        assert calls == [("node-a", ["s0"]), ("node-a", ["s0"])]
+        assert controller._pending_clear_shards == {}
+        assert mock_worker_call.call_count == 4
+
+    def test_storage_clear_propagates_cancellation(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+
+        async def cancel_clear(_addr, _shard_ids):
+            raise asyncio.CancelledError
+
+        with patch.object(RTensor, "clear_node", new=cancel_clear):
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(controller._async_clear_batches(target))
+
+        assert controller._pending_clear_shards == {"node-a": {"s0": 0}}
+
+    def test_storage_clear_cancellation_keeps_batch_state_atomic(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {"retry-node": {"s-retry": 1}}
+        controller._clear_shards_lock = Lock()
+        controller._clear_batches_lock = Lock()
+        target = {
+            "good": create_mock_rtensor("s-good", "good-node"),
+            "cancel": create_mock_rtensor("s-cancel", "cancel-node"),
+        }
+        calls = []
+
+        async def mixed_results(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if addr == "retry-node":
+                raise RuntimeError("second failure")
+            if addr == "cancel-node":
+                raise asyncio.CancelledError
+            return {"status": "ok", "cleared_count": 1}
+
+        with (
+            patch.object(RTensor, "clear_node", new=mixed_results),
+            patch.object(controller, "_custom_function_call") as mock_worker_call,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                controller.clear_batches(target)
+
+        assert {addr: sids for addr, sids in calls} == {
+            "retry-node": ["s-retry"],
+            "good-node": ["s-good"],
+            "cancel-node": ["s-cancel"],
+        }
+        assert controller._pending_clear_shards == {
+            "retry-node": {"s-retry": 1},
+            "good-node": {"s-good": 0},
+            "cancel-node": {"s-cancel": 0},
+        }
+        mock_worker_call.assert_not_called()

--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -859,6 +859,45 @@ class TestTrainControllerClearBatches:
         assert controller._pending_clear_shards == {}
         assert mock_worker_call.call_count == 4
 
+    def test_worker_cleanup_failure_preserves_exhausted_storage_state(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        controller._clear_batches_lock = Lock()
+        controller._worker_role = "test"
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+        storage_calls = []
+        worker_clear_calls = 0
+
+        async def fail_clear(addr, shard_ids):
+            storage_calls.append((addr, shard_ids))
+            raise RuntimeError("delete failed")
+
+        def fail_second_worker_clear(method, *_args, **_kwargs):
+            nonlocal worker_clear_calls
+            if method == "clear_batches":
+                worker_clear_calls += 1
+                if worker_clear_calls == 2:
+                    raise RuntimeError("worker cleanup failed")
+                return None
+            return {"num_entries": 0}
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_clear),
+            patch.object(
+                controller,
+                "_custom_function_call",
+                side_effect=fail_second_worker_clear,
+            ) as mock_worker_call,
+        ):
+            controller.clear_batches(target)
+            with pytest.raises(RuntimeError, match="worker cleanup failed"):
+                controller.clear_batches({})
+
+        assert storage_calls == [("node-a", ["s0"]), ("node-a", ["s0"])]
+        assert controller._pending_clear_shards == {"node-a": {"s0": 2}}
+        assert mock_worker_call.call_count == 3
+
     def test_storage_clear_propagates_cancellation(self):
         controller = TrainController.__new__(TrainController)
         controller._pending_clear_shards = {}

--- a/tests/test_trainer_utils.py
+++ b/tests/test_trainer_utils.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from areal.utils.cleanup import run_batch_cleanups
+
+
+def test_run_batch_cleanups_continues_after_one_role_fails():
+    calls = []
+    actor_error = RuntimeError("actor cleanup failed")
+
+    def fail_actor():
+        calls.append("actor")
+        raise actor_error
+
+    def record(role):
+        return lambda: calls.append(role)
+
+    with pytest.raises(RuntimeError, match="actor cleanup failed") as exc_info:
+        run_batch_cleanups(
+            [
+                ("actor", fail_actor),
+                ("critic", record("critic")),
+                ("ref", record("ref")),
+                ("data", record("data")),
+            ]
+        )
+
+    assert exc_info.value is actor_error
+    assert calls == ["actor", "critic", "ref", "data"]
+
+
+def test_run_batch_cleanups_preserves_first_of_multiple_failures():
+    calls = []
+
+    def fail(role):
+        def cleanup():
+            calls.append(role)
+            raise RuntimeError(f"{role} cleanup failed")
+
+        return cleanup
+
+    with pytest.raises(RuntimeError, match="actor cleanup failed") as exc_info:
+        run_batch_cleanups(
+            [
+                ("actor", fail("actor")),
+                ("critic", lambda: calls.append("critic")),
+                ("data", fail("data")),
+            ]
+        )
+
+    assert calls == ["actor", "critic", "data"]
+    assert exc_info.value.__notes__ == [
+        "clear_batches failed first for role: actor",
+        "Additional clear_batches failure for data: RuntimeError: data cleanup failed",
+    ]

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import torch
 
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
+from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
 from areal.v2.training_service.controller.controller import (
     GatewayTrainController,
 )
@@ -42,6 +45,13 @@ def _make_controller(scheduler: MagicMock | None = None) -> GatewayTrainControll
             request_timeout=5.0,
             setup_timeout=5.0,
         ),
+    )
+
+
+def _make_rtensor(shard_id: str, node_addr: str) -> RTensor:
+    return RTensor(
+        shard=TensorShardInfo(shard_id=shard_id, node_addr=node_addr),
+        data=torch.empty(1, device="meta"),
     )
 
 
@@ -162,3 +172,140 @@ class TestGatewayTrainControllerInitialization:
         assert controller._gateway_addr == "http://127.0.0.1:18080"
         assert controller.api_key is not None
         assert controller.api_key.startswith("ak-train-role-")
+
+
+class TestGatewayTrainControllerClearBatches:
+    def test_storage_clear_surfaces_failure_and_continues_worker_cleanup(self):
+        controller = _make_controller()
+        target = {
+            "good": _make_rtensor("s-good", "good-node"),
+            "bad": _make_rtensor("s-bad", "bad-node"),
+        }
+        calls = []
+
+        async def fake_clear_node(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if addr == "bad-node":
+                raise RuntimeError("delete failed")
+            return {
+                "status": "ok",
+                "cleared_count": 1,
+                "num_tensors": 0,
+                "total_bytes": 0,
+            }
+
+        with (
+            patch.object(RTensor, "clear_node", new=fake_clear_node),
+            patch.object(controller, "_gateway_post") as mock_gateway_post,
+            patch(f"{MODULE}.logger.warning") as mock_warning,
+            patch(f"{MODULE}.logger.debug") as mock_debug,
+        ):
+            controller.clear_batches(target)
+
+        assert calls == [
+            ("good-node", ["s-good"]),
+            ("bad-node", ["s-bad"]),
+        ]
+        mock_warning.assert_called_once()
+        assert "bad-node" in str(mock_warning.call_args)
+        mock_debug.assert_called_once()
+        assert "good-node" in str(mock_debug.call_args)
+        mock_gateway_post.assert_called_once()
+        assert controller._pending_clear_shards == {"bad-node": {"s-bad": 1}}
+
+    def test_failed_storage_clear_is_retried_on_next_call(self):
+        controller = _make_controller()
+        target = {"batch": _make_rtensor("s0", "node-a")}
+        next_target = {"batch": _make_rtensor("s1", "node-a")}
+        calls = []
+
+        async def fail_then_succeed(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if len(calls) == 1:
+                raise RuntimeError("delete failed")
+            return {"status": "ok", "cleared_count": 1}
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_then_succeed),
+            patch.object(controller, "_gateway_post") as mock_gateway_post,
+        ):
+            controller.clear_batches(target)
+            controller.clear_batches(next_target)
+
+        assert calls == [("node-a", ["s0"]), ("node-a", ["s0", "s1"])]
+        assert controller._pending_clear_shards == {}
+        assert mock_gateway_post.call_count == 2
+
+    def test_second_storage_clear_failure_cleans_workers_then_raises(self):
+        controller = _make_controller()
+        target = {"batch": _make_rtensor("s0", "node-a")}
+        calls = []
+
+        async def fail_clear(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            raise RuntimeError("delete failed")
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_clear),
+            patch.object(controller, "_gateway_post") as mock_gateway_post,
+        ):
+            controller.clear_batches(target)
+            with pytest.raises(RuntimeError, match="two clear_batches calls"):
+                controller.clear_batches({})
+
+        assert calls == [("node-a", ["s0"]), ("node-a", ["s0"])]
+        assert controller._pending_clear_shards == {}
+        assert mock_gateway_post.call_count == 2
+
+    def test_storage_clear_propagates_cancellation(self):
+        controller = _make_controller()
+        target = {"batch": _make_rtensor("s0", "node-a")}
+
+        async def cancel_clear(_addr, _shard_ids):
+            raise asyncio.CancelledError
+
+        with (
+            patch.object(RTensor, "clear_node", new=cancel_clear),
+            patch.object(controller, "_gateway_post") as mock_gateway_post,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                controller.clear_batches(target)
+
+        mock_gateway_post.assert_not_called()
+        assert controller._pending_clear_shards == {"node-a": {"s0": 0}}
+
+    def test_storage_clear_cancellation_keeps_batch_state_atomic(self):
+        controller = _make_controller()
+        controller._pending_clear_shards = {"retry-node": {"s-retry": 1}}
+        target = {
+            "good": _make_rtensor("s-good", "good-node"),
+            "cancel": _make_rtensor("s-cancel", "cancel-node"),
+        }
+        calls = []
+
+        async def mixed_results(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if addr == "retry-node":
+                raise RuntimeError("second failure")
+            if addr == "cancel-node":
+                raise asyncio.CancelledError
+            return {"status": "ok", "cleared_count": 1}
+
+        with (
+            patch.object(RTensor, "clear_node", new=mixed_results),
+            patch.object(controller, "_gateway_post") as mock_gateway_post,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                controller.clear_batches(target)
+
+        assert {addr: sids for addr, sids in calls} == {
+            "retry-node": ["s-retry"],
+            "good-node": ["s-good"],
+            "cancel-node": ["s-cancel"],
+        }
+        assert controller._pending_clear_shards == {
+            "retry-node": {"s-retry": 1},
+            "good-node": {"s-good": 0},
+            "cancel-node": {"s-cancel": 0},
+        }
+        mock_gateway_post.assert_not_called()

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -257,6 +257,31 @@ class TestGatewayTrainControllerClearBatches:
         assert controller._pending_clear_shards == {}
         assert mock_gateway_post.call_count == 2
 
+    def test_worker_cleanup_failure_preserves_exhausted_storage_state(self):
+        controller = _make_controller()
+        target = {"batch": _make_rtensor("s0", "node-a")}
+        storage_calls = []
+
+        async def fail_clear(addr, shard_ids):
+            storage_calls.append((addr, shard_ids))
+            raise RuntimeError("delete failed")
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_clear),
+            patch.object(
+                controller,
+                "_gateway_post",
+                side_effect=[None, RuntimeError("worker cleanup failed")],
+            ) as mock_gateway_post,
+        ):
+            controller.clear_batches(target)
+            with pytest.raises(RuntimeError, match="worker cleanup failed"):
+                controller.clear_batches({})
+
+        assert storage_calls == [("node-a", ["s0"]), ("node-a", ["s0"])]
+        assert controller._pending_clear_shards == {"node-a": {"s0": 2}}
+        assert mock_gateway_post.call_count == 2
+
     def test_storage_clear_propagates_cancellation(self):
         controller = _make_controller()
         target = {"batch": _make_rtensor("s0", "node-a")}


### PR DESCRIPTION
## Description

`DELETE /data/clear` failures currently disappear at several layers, so a storage
node can retain CPU tensors indefinitely while training continues normally.

This change closes that failure path by:

- sending RTensor DELETE payloads through the existing bounded HTTP retry helper
  and validating the storage node's success response;
- inspecting every per-node cleanup result in both legacy and v2 train
  controllers, while also surfacing data-worker cleanup failures;
- retaining failed shard IDs for one cross-step retry, merging them with the next
  step's shards, and failing explicitly after a second failed step only after
  worker-side fetch buffers have been drained;
- keeping pending cleanup state atomic on cancellation or another fatal
  `BaseException`, so the whole idempotent DELETE batch can be retried safely;
- logging successful storage statistics and adding focused retry, fail-fast,
  cancellation, and compatibility tests.

The controller state and locks are private; this does not add configuration,
change scheduler/launcher behavior, or break custom RTensor backends that return
`None` from `delete`.

## Related Issue

Fixes #1581

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

Not applicable. A repeatedly unreachable storage node now produces an explicit
`RuntimeError` instead of allowing an unbounded remote CPU-memory leak.

## Additional Context

Validation after the review follow-up (`1d88e916`):

- 47 directly affected tests pass: the complete legacy TrainController suite,
  the v2 clear-batches suite, and the new all-role cleanup regressions.
- Targeted pre-commit passes for all ten changed files, including Ruff
  lint/format, whitespace, license, large-file, and private-key checks.
- A clean-worktree `pre-commit run --all-files` completed all code, style, and
  security hooks; three environment-dependent hooks could not execute on this
  Windows host (GBK output in the repository consistency script, no `bash` for
  lock regeneration, and missing `mdformat` for docs generation).
- The repository's `uv` lock declares Linux/macOS platforms only, so validation
  used the existing Windows test environment rather than claiming a supported
  `uv run` result.
- Self-review found no remaining actionable correctness issue. Real multi-node
  fault injection remains for upstream CI or maintainer validation.