### PR TITLE
fix(examples): retune GSM8K GRPO learning rate for FP32 master weights

### DIFF
--- a/examples/math/README.md
+++ b/examples/math/README.md
@@ -1,8 +1,20 @@
 ## Hyper-parameters for GSM8K Finetuning on Qwen2.5-1.5b-Instruct
 
-The hyperparameters given in gsm8k_grpo.yaml is the set that we found to achieve the
-highest max `grpo-eval/task_reward/avg` during training for `Qwen2.5-1.5b-Instruct`. You
-are free to try out more of the hyperparameters listed below!
+`gsm8k_grpo.yaml` uses `6e-6`, retuned for the current FSDP FP32-master optimizer path.
+
+### Current FP32-Master Recipe
+
+A seed-1 run on 8 NVIDIA A800 GPUs completed the official 10-epoch schedule with the
+following held-out evaluation results:
+
+| lr     | weight decay | group size | best eval reward | final eval reward |
+| ------ | ------------ | ---------- | ---------------- | ----------------- |
+| 6.0E-6 | 0.017        | 4          | **0.78412**      | 0.77767           |
+
+### Historical Pre-FP32-Master Sweep
+
+The results below were collected with BF16 parameter and optimizer-state storage. They
+are retained for reference and are not directly comparable with the current recipe.
 
 | lr       | weight decay | group size | max task_reward |
 | -------- | ------------ | ---------- | --------------- |
@@ -13,7 +25,7 @@ are free to try out more of the hyperparameters listed below!
 | 1.00E-05 | 0.02         | 4          | 0.78311         |
 | 1.00E-05 | 0.01         | 8          | 0.78066         |
 
-### Other Training Details
+#### Training Details
 
 - Devices: 8 Nvidia H800 GPUs
 - Optimizer: Adam

--- a/examples/math/gsm8k_grpo.yaml
+++ b/examples/math/gsm8k_grpo.yaml
@@ -58,7 +58,7 @@ actor:
     packing_algorithm: ffd
   optimizer:
     type: adam
-    lr: 1.70e-5
+    lr: 6.00e-6
     weight_decay: 0.017
     beta1: 0.9
     beta2: 0.999


### PR DESCRIPTION
## Description

This PR lowers the actor learning rate in the Qwen2.5-1.5B-Instruct GSM8K
GRPO example from `1.7e-5` to `6e-6`, records the current full-schedule
validation result, and marks the existing README sweep as historical.

### Why the recipe needs retuning

The previous learning rate predates #1369. Before that change, the FSDP path
loaded actor parameters in BF16, and ordinary AdamW inherited BF16 parameter
and optimizer-state storage. #1369 correctly introduced FP32 master parameters
and optimizer states, preserving small updates that the former BF16 path could
quantize away. The GSM8K recipe learning rate was not retuned for this changed
optimizer behavior.

Four matched 15-step runs on current AReaL support this mechanism. Values below
are means over steps 3–15:

| Parameter storage / optimizer |       LR | Mean Taylor log-prob divergence | Mean rollout reward |
| ----------------------------- | -------: | ------------------------------: | ------------------: |
| FP32 / AdamW                  | `1.7e-5` |                         0.20790 |              0.7332 |
| FP32 / AdamW                  |   `6e-6` |                         0.00456 |              0.8380 |
| BF16 / AdamW                  | `1.7e-5` |                         0.00388 |              0.8178 |
| BF16 / Kahan AdamW            | `1.7e-5` |                         0.13100 |              0.7394 |

Ordinary BF16 AdamW appeared stable because low-precision storage damped small
updates. Restoring the suppressed residual updates with Kahan summation also
restored large policy movement and reward degradation. Keeping the intended
FP32-master path while lowering LR restored stable behavior.

The divergence above compares behavior-policy log probabilities with the
current actor under asynchronous rollout, so it is a diagnostic proxy that can
include staleness, not a pure single-step pre/post-update KL. In an earlier
per-step diagnostic, the divergence scale differed by about 7.5x. Using the
local heuristic `KL ∝ LR²` gave:

```text
1.7e-5 / sqrt(7.5) ≈ 6.2e-6
```

This suggested `6e-6` as the first candidate; it is not intended as a universal
BF16-to-FP32 conversion or a claim of an optimal LR. The full-schedule A/B below
is the validation for the recipe change.

## Related Issue

Related to #1369.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Validation

Two matched jobs ran serially from clean `main@3cf0dfbd` on the same 8× A800
host with seed 1. Both completed the official 10-epoch/290-step schedule. Apart
from run identity and local path overrides, actor learning rate was the only
algorithmic difference.

```bash
# Control
python3 examples/math/gsm8k_rl.py \
  --config examples/math/gsm8k_grpo.yaml \
  scheduler.type=local \
  actor.optimizer.lr=1.7e-5

# Candidate
python3 examples/math/gsm8k_rl.py \
  --config examples/math/gsm8k_grpo.yaml \
  scheduler.type=local \
  actor.optimizer.lr=6e-6
```

| Actor LR | Epoch 1 eval reward |    Best | Epoch 10 | Outcome                       |
| -------: | ------------------: | ------: | -------: | ----------------------------- |
| `1.7e-5` |             0.49981 | 0.53563 |  0.01782 | Collapsed from epoch 3 onward |
|   `6e-6` |             0.76308 | 0.78412 |  0.77767 | Stable through all 10 epochs  |

Epoch 1 is the evaluation after the first training epoch, not an untrained
version-zero baseline. Each configuration was run with one seed; the conclusion
is based on the large and persistent separation across all ten evaluations.

<details>
<summary>Per-epoch evaluation trajectories</summary>

- `1.7e-5`:
  `0.49981, 0.53563, 0.00000, 0.01914, 0.02483, 0.03146, 0.02976, 0.03090, 0.02350, 0.01782`
- `6e-6`:
  `0.76308, 0.74488, 0.77028, 0.76137, 0.76137, 0.76403, 0.75303, 0.76782, 0.78412, 0.77767`

</details>

The patch keeps FP32 master weights and changes no optimizer, algorithm, reward,
data, batch-size, or scheduling settings. It is intentionally limited to the
standard FSDP GSM8K GRPO recipe; other examples have not been retuned without
matching validation.

Local checks on current `main@cbff54d6`:

- changed-files pre-commit hooks pass;
- the YAML parses successfully and resolves `actor.optimizer.lr` to `6e-6`;
- `git diff --check` passes.

No deterministic unit test is added for this stochastic recipe parameter.

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass for the changed files
- [x] Relevant validation is described above
- [x] Documentation updated
- [x] Branch is up to date with `main`
- [x] Self-reviewed
- [x] This PR was created with coding-agent assistance
- [ ] This PR is a breaking change

## Additional Context

The README's existing H800 result (`0.79570` at `1.7e-5`) was collected before
the FP32-master default. It is retained for reference rather than overwritten
with results from different hardware and optimizer semantics. The current
FP32-master result is reported separately to keep the two evaluation contexts
explicit.
