### PR TITLE
docs: clarify terminology in the M2PO guides

### DIFF
--- a/docs/en/algorithms/m2po.md
+++ b/docs/en/algorithms/m2po.md
@@ -6,17 +6,17 @@ Author: [Jingyuan Ma](https://github.com/tsjyma)
 
 ![m2po figure](../figures/m2po.png)
 
-Second-Moment Trust Policy Optimization (M2PO) (Zheng et al., 2025), is an RL method
-that achieves stable off-policy training even with data stale by at least 256 model
+Second-Moment Trust Policy Optimization (M2PO) (Zheng et al., 2025) is an RL method
+that achieves stable off-policy training even when data is stale by at least 256 model
 updates and matches on-policy performance by constraining the second moment of
 importance weights to suppress only extreme outliers while preserving informative
 updates.
 
-The first step of M2PO is to compute the second momentum: $$
+The first step of M2PO is to compute the second moment: $$
 \hat{M_2}=\frac{1}{N}\sum_{i=1}^NM_{2,i}=\frac{1}{N}\sum_{i=1}^N(\log{r_i})^2=\frac{1}{N}\sum_{i=1}^N\left(\log\frac{\pi_\theta
 (a_i|s_i)}{\pi_{behav}(a_i|s_i)}\right)^2 $$
 
-The second step is to compute the second momentum mask:
+The second step is to compute the second-moment mask:
 
 <center>
 <img src="../figures/m2po_masking.png" width = "298" height = "217" alt="m2po masking"/>
@@ -34,19 +34,19 @@ $$ A_{i,t}=\frac{r_i-mean({R_i}_{i=1}^G)}{std({R_i}_{i=1}^G)}. $$
 
 For more details:
 
-- AReal Detail: [Paper of AReal](https://arxiv.org/abs/2505.24298)
+- AReaL details: [AReaL paper](https://arxiv.org/abs/2505.24298)
 
-- M2PO Detail: [Paper of M2PO](https://arxiv.org/abs/2510.01161)
+- M2PO details: [M2PO paper](https://arxiv.org/abs/2510.01161)
 
 ## Core Parameters
 
-- `actor.m2_threshold`: The threshold for the mean of the second momentum, used in
+- `actor.m2_threshold`: The threshold for the mean of the second moment, used in
   computing the M2PO mask as $\tau_{M_2}$
 
 ## Example Usage
 
-We recommend to change the parameter within the configuration file
-(i.e.gsm8k_m2po.yaml).
+We recommend changing the parameters in the configuration file
+(`examples/math/gsm8k_m2po.yaml`).
 
 | Backend   | CMD                                                                                                                         |
 | --------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -58,16 +58,16 @@ We recommend to change the parameter within the configuration file
 
 ![m2po test figure](../figures/m2po_test.png)
 
-In this test, we name the trails by the rules as follow:
+In this test, trial names follow these conventions:
 
 - **stale:** the value of `max_head_offpolicyness`
-- **dx+dy**: x for the number of rollout workers and y for the number of training
+- **dx+dy**: `x` is the number of rollout workers and `y` is the number of training
   workers
 - **rollout**: the value of `max_concurrent_rollout`
 
-The setting for GRPO is stale 256 d2+d1 rollout 96
+The GRPO setting is `stale 256 d2+d1 rollout 96`.
 
-The key findings in the trails are as follow:
+The key findings across the trials are as follows:
 
 - The `grad_norm` of GRPO is higher than M2PO, which may cause training instability.
-- The evaluate reward of M2PO is higher than GRPO.
+- The evaluation reward of M2PO is higher than GRPO.

--- a/docs/zh/algorithms/m2po.md
+++ b/docs/zh/algorithms/m2po.md
@@ -31,9 +31,9 @@ $$ A_{i,t}=\frac{r_i-mean({R_i}_{i=1}^G)}{std({R_i}_{i=1}^G)}. $$
 
 更多详情：
 
-- AReal详情：[AReal论文](https://arxiv.org/abs/2505.24298)
+- AReaL 详情：[AReaL 论文](https://arxiv.org/abs/2505.24298)
 
-- M2PO详情：[M2PO论文](https://arxiv.org/abs/2510.01161)
+- M2PO 详情：[M2PO 论文](https://arxiv.org/abs/2510.01161)
 
 ## 核心参数
 
@@ -41,7 +41,7 @@ $$ A_{i,t}=\frac{r_i-mean({R_i}_{i=1}^G)}{std({R_i}_{i=1}^G)}. $$
 
 ## 示例用法
 
-我们建议在配置文件中修改参数（即gsm8k_m2po.yaml）。
+我们建议在配置文件 `examples/math/gsm8k_m2po.yaml` 中修改参数。
 
 | 后端      | CMD                                                                                                                         |
 | --------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -56,10 +56,10 @@ $$ A_{i,t}=\frac{r_i-mean({R_i}_{i=1}^G)}{std({R_i}_{i=1}^G)}. $$
 在本测试中，我们按以下规则命名实验：
 
 - **stale：** `max_head_offpolicyness` 的值
-- **dx+dy**：x为rollout worker数量，y为训练worker数量
+- **dx+dy**：`x` 为 rollout worker 数量，`y` 为训练 worker 数量
 - **rollout：** `max_concurrent_rollout` 的值
 
-GRPO的设置为stale 256 d2+d1 rollout 96
+GRPO 的设置为 `stale 256 d2+d1 rollout 96`。
 
 实验的关键发现如下：
 


### PR DESCRIPTION
## Description

Correct terminology and wording in the English and Chinese M2PO guides:

- replace “second momentum” with the statistically correct “second moment”;
- fix trial terminology and grammar in the test-result explanation;
- provide the copyable path to `examples/math/gsm8k_m2po.yaml`;
- normalize AReaL naming and corresponding Chinese formatting.

This is documentation-only and does not change runtime behavior or APIs.

## Related Issue

N/A — this is a small documentation correction, and no matching existing issue was found.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Validation completed:

- `git diff --check`
- Markdown parsing for both changed files
- local target checks for the configuration file and referenced images
- accessibility checks for both arXiv links

The full documentation build was not run because the current environment does not
contain Jupyter Book or pre-commit. The repository's pre-commit configuration excludes
the algorithm guides from its mdformat hook.
