### PR TITLE
fix(trainer): run initial evaluation before first update

### DIFF
--- a/areal/trainer/dpo_trainer.py
+++ b/areal/trainer/dpo_trainer.py
@@ -202,6 +202,12 @@ class DPOTrainer:
 
         global_step = 0
         data_generator = cycle_dataloader(self.train_dataloader)
+        if self.recover_info is None and self._evaluate_before_train():
+            self._export_and_commit_stats(
+                epoch=-1,
+                epoch_step=-1,
+                global_step=-1,
+            )
         for global_step in range(start_step, max_steps):
             if (
                 config.total_train_steps is not None
@@ -488,6 +494,27 @@ class DPOTrainer:
 
         dist.barrier(group=self.actor.cpu_group)
         current_platform.synchronize()
+
+    def _evaluate_before_train(self) -> bool:
+        if self.valid_dataloader is None:
+            return self.evaluator.evaluate_before_train(None)
+
+        def evaluate_fn() -> None:
+            with (
+                stats_tracker.record_timing("eval"),
+                perf_tracer.trace_scope(
+                    "train.eval",
+                    category=Category.COMPUTE,
+                    args={"global_step": -1},
+                ),
+            ):
+                self._evaluate_fn()
+
+        evaluated = self.evaluator.evaluate_before_train(evaluate_fn)
+        if evaluated:
+            dist.barrier(group=self.actor.cpu_group)
+            current_platform.synchronize()
+        return evaluated
 
     def _evaluate(
         self,

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -674,6 +674,16 @@ class PPOTrainer:
         elif self._requires_proxy_workflow(workflow):
             self._ensure_proxy_started()
 
+        if self.recover_info is None and self._evaluate_before_train(
+            eval_workflow=eval_workflow,
+            eval_workflow_kwargs=eval_workflow_kwargs,
+        ):
+            self._export_and_commit_stats(
+                epoch=-1,
+                epoch_step=-1,
+                global_step=-1,
+            )
+
         for global_step in range(start_step, max_steps):
             if (
                 config.total_train_steps is not None
@@ -1421,6 +1431,44 @@ class PPOTrainer:
         if not is_single_controller():
             dist.barrier(group=self.actor.cpu_group)
             current_platform.synchronize()
+
+    def _evaluate_before_train(
+        self,
+        eval_workflow: WorkflowLike | None,
+        eval_workflow_kwargs,
+    ) -> bool:
+        if (
+            self.eval_rollout is None
+            or self.valid_dataloader is None
+            or eval_workflow is None
+        ):
+            return self.evaluator.evaluate_before_train(None)
+
+        def evaluate_fn() -> None:
+            if self._should_offload_rollout:
+                self._onload_rollout(is_eval=True)
+            try:
+                with (
+                    stats_tracker.record_timing("eval"),
+                    perf_tracer.trace_scope(
+                        "train.eval",
+                        category=Category.COMPUTE,
+                        args={"global_step": -1},
+                    ),
+                ):
+                    self._evaluate_fn(
+                        eval_workflow=eval_workflow,
+                        eval_workflow_kwargs=eval_workflow_kwargs,
+                    )
+            finally:
+                if self._should_offload_rollout:
+                    self._offload_rollout(is_eval=True)
+
+        evaluated = self.evaluator.evaluate_before_train(evaluate_fn)
+        if evaluated and not is_single_controller():
+            dist.barrier(group=self.actor.cpu_group)
+            current_platform.synchronize()
+        return evaluated
 
     def _evaluate(
         self,

--- a/areal/trainer/rw_trainer.py
+++ b/areal/trainer/rw_trainer.py
@@ -192,6 +192,12 @@ class RWTrainer:
 
         global_step = 0
         data_generator = cycle_dataloader(self.train_dataloader)
+        if self.recover_info is None and self._evaluate_before_train():
+            self._export_and_commit_stats(
+                epoch=-1,
+                epoch_step=-1,
+                global_step=-1,
+            )
         for global_step in range(start_step, max_steps):
             if (
                 config.total_train_steps is not None
@@ -449,6 +455,27 @@ class RWTrainer:
 
         dist.barrier(group=self.actor.cpu_group)
         current_platform.synchronize()
+
+    def _evaluate_before_train(self) -> bool:
+        if self.valid_dataloader is None:
+            return self.evaluator.evaluate_before_train(None)
+
+        def evaluate_fn() -> None:
+            with (
+                stats_tracker.record_timing("eval"),
+                perf_tracer.trace_scope(
+                    "train.eval",
+                    category=Category.COMPUTE,
+                    args={"global_step": -1},
+                ),
+            ):
+                self._evaluate_fn()
+
+        evaluated = self.evaluator.evaluate_before_train(evaluate_fn)
+        if evaluated:
+            dist.barrier(group=self.actor.cpu_group)
+            current_platform.synchronize()
+        return evaluated
 
     def _evaluate(
         self,

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -170,6 +170,12 @@ class SFTTrainer:
 
         global_step = 0
         data_generator = cycle_dataloader(self.train_dataloader)
+        if self.recover_info is None and self._evaluate_before_train():
+            self._export_and_commit_stats(
+                epoch=-1,
+                epoch_step=-1,
+                global_step=-1,
+            )
         for global_step in range(start_step, max_steps):
             if (
                 config.total_train_steps is not None
@@ -430,6 +436,27 @@ class SFTTrainer:
 
         dist.barrier(group=self.actor.cpu_group)
         current_platform.synchronize()
+
+    def _evaluate_before_train(self) -> bool:
+        if self.valid_dataloader is None:
+            return self.evaluator.evaluate_before_train(None)
+
+        def evaluate_fn() -> None:
+            with (
+                stats_tracker.record_timing("eval"),
+                perf_tracer.trace_scope(
+                    "train.eval",
+                    category=Category.COMPUTE,
+                    args={"global_step": -1},
+                ),
+            ):
+                self._evaluate_fn()
+
+        evaluated = self.evaluator.evaluate_before_train(evaluate_fn)
+        if evaluated:
+            dist.barrier(group=self.actor.cpu_group)
+            current_platform.synchronize()
+        return evaluated
 
     def _evaluate(
         self,

--- a/areal/utils/evaluator.py
+++ b/areal/utils/evaluator.py
@@ -11,18 +11,42 @@ class Evaluator:
     def __init__(self, config: EvaluatorConfig, ft_spec: FinetuneSpec):
         self.config = config
         self.ft_sepc = ft_spec
+        self._eval_before_train_pending = config.eval_before_train
         self.freq_ctl = timeutil.EpochStepTimeFreqCtl(
             freq_epoch=config.freq_epochs,
             freq_step=config.freq_steps,
             freq_sec=config.freq_secs,
-            initial_epoch_value=config.eval_before_train,
         )
 
     def state_dict(self):
         return self.freq_ctl.state_dict()
 
     def load_state_dict(self, state_dict):
+        # Checkpoints written by the original eval_before_train implementation may
+        # still carry a deferred initial trigger. Loading a checkpoint is a resume,
+        # so that trigger must not be interpreted as a version-zero evaluation.
+        state_dict = {
+            **state_dict,
+            "epoch": {**state_dict["epoch"], "initial_value": False},
+        }
         self.freq_ctl.load_state_dict(state_dict)
+        self._eval_before_train_pending = False
+
+    def evaluate_before_train(self, evaluate_fn: Callable[[], None] | None) -> bool:
+        """Run the configured initial evaluation without advancing its cadence.
+
+        Passing ``None`` consumes the one-shot opportunity when evaluation inputs
+        are unavailable, preventing a later trained model from being mislabeled as
+        the initial baseline. A callback failure leaves the opportunity pending.
+        """
+        if not self._eval_before_train_pending:
+            return False
+        if evaluate_fn is None:
+            self._eval_before_train_pending = False
+            return False
+        evaluate_fn()
+        self._eval_before_train_pending = False
+        return True
 
     def evaluate(
         self,

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from areal.api import FinetuneSpec
+from areal.api.cli_args import EvaluatorConfig
+from areal.utils.evaluator import Evaluator
+
+
+def _make_evaluator(
+    *,
+    eval_before_train: bool,
+    freq_steps: int | None = None,
+) -> Evaluator:
+    config = EvaluatorConfig(
+        experiment_name="test",
+        trial_name="eval-before-train",
+        fileroot="/tmp",
+        eval_before_train=eval_before_train,
+        freq_steps=freq_steps,
+    )
+    ft_spec = FinetuneSpec(
+        total_train_epochs=1,
+        dataset_size=4,
+        train_batch_size=1,
+    )
+    return Evaluator(config, ft_spec)
+
+
+def test_evaluate_before_train_runs_once_when_enabled():
+    """The initial evaluation should run exactly once on a fresh evaluator."""
+    evaluator = _make_evaluator(eval_before_train=True)
+    calls: list[str] = []
+
+    first_ran = evaluator.evaluate_before_train(lambda: calls.append("initial"))
+    second_ran = evaluator.evaluate_before_train(lambda: calls.append("duplicate"))
+
+    assert first_ran is True
+    assert second_ran is False
+    assert calls == ["initial"]
+
+
+def test_evaluate_before_train_is_disabled_by_default():
+    """A disabled initial evaluation should remain a no-op."""
+    evaluator = _make_evaluator(eval_before_train=False)
+    calls: list[str] = []
+
+    ran = evaluator.evaluate_before_train(lambda: calls.append("initial"))
+
+    assert ran is False
+    assert calls == []
+
+
+def test_evaluate_before_train_without_callback_consumes_initial_opportunity():
+    """Missing evaluation inputs must not defer a baseline until after updates."""
+    evaluator = _make_evaluator(eval_before_train=True)
+    calls: list[str] = []
+
+    missing_inputs_ran = evaluator.evaluate_before_train(None)
+    later_ran = evaluator.evaluate_before_train(lambda: calls.append("late"))
+
+    assert missing_inputs_ran is False
+    assert later_ran is False
+    assert calls == []
+
+
+def test_evaluate_before_train_retries_after_callback_failure():
+    """A failed callback should leave the one-shot evaluation pending."""
+    evaluator = _make_evaluator(eval_before_train=True)
+    calls: list[str] = []
+
+    def fail_initial_evaluation() -> None:
+        calls.append("failed")
+        raise RuntimeError("evaluation failed")
+
+    with pytest.raises(RuntimeError, match="evaluation failed"):
+        evaluator.evaluate_before_train(fail_initial_evaluation)
+
+    retry_ran = evaluator.evaluate_before_train(lambda: calls.append("retried"))
+    duplicate_ran = evaluator.evaluate_before_train(lambda: calls.append("duplicate"))
+
+    assert retry_ran is True
+    assert duplicate_ran is False
+    assert calls == ["failed", "retried"]
+
+
+def test_evaluate_before_train_does_not_advance_step_frequency():
+    """The initial evaluation must not advance any periodic cadence."""
+    evaluator = _make_evaluator(eval_before_train=True, freq_steps=2)
+    calls: list[str] = []
+    state_before = evaluator.state_dict()
+
+    evaluator.evaluate_before_train(lambda: calls.append("initial"))
+    assert evaluator.state_dict() == state_before
+
+    evaluator.evaluate(
+        lambda: calls.append("scheduled"),
+        epoch=0,
+        step=0,
+        global_step=0,
+    )
+    assert calls == ["initial"]
+
+    evaluator.evaluate(
+        lambda: calls.append("scheduled"),
+        epoch=0,
+        step=1,
+        global_step=1,
+    )
+    assert calls == ["initial", "scheduled"]
+
+
+def test_load_legacy_state_does_not_rearm_initial_evaluation():
+    """Recovery should ignore the legacy deferred initial-trigger state."""
+    evaluator = _make_evaluator(eval_before_train=True)
+    legacy_state = evaluator.state_dict()
+    legacy_state["epoch"]["initial_value"] = True
+
+    recovered = _make_evaluator(eval_before_train=True)
+    recovered.load_state_dict(legacy_state)
+    calls: list[str] = []
+
+    initial_ran = recovered.evaluate_before_train(lambda: calls.append("initial"))
+    recovered.evaluate(
+        lambda: calls.append("scheduled"),
+        epoch=0,
+        step=0,
+        global_step=1,
+    )
+
+    assert initial_ran is False
+    assert calls == []
+    assert legacy_state["epoch"]["initial_value"] is True

--- a/tests/test_trainer_eval_before_train.py
+++ b/tests/test_trainer_eval_before_train.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from areal.trainer import dpo_trainer, rl_trainer, rw_trainer, sft_trainer
+from areal.trainer.dpo_trainer import DPOTrainer
+from areal.trainer.rl_trainer import PPOTrainer
+from areal.trainer.rw_trainer import RWTrainer
+from areal.trainer.sft_trainer import SFTTrainer
+from areal.utils import stats_logger as stats_logger_module
+from areal.utils.stats_logger import StatsLogger
+
+
+class _StopAfterFirstUpdate(Exception):
+    pass
+
+
+class _FakeSaver:
+    def maybe_wait_for_staging(self) -> None:
+        pass
+
+
+class _FakeLastStepInfo:
+    def next(self):
+        return SimpleNamespace(global_step=1)
+
+
+class _FakeDeviceStats:
+    def log(self, _message: str) -> None:
+        pass
+
+
+class _FakeLogprobs:
+    ndim = 1
+
+    def unsqueeze(self, _dim: int):
+        return self
+
+
+class _FakeRef:
+    def compute_logp(self, batch):
+        return [_FakeLogprobs() for _ in batch]
+
+    def get_device_stats(self) -> _FakeDeviceStats:
+        return _FakeDeviceStats()
+
+
+class _CallbackEvaluator:
+    def evaluate_before_train(self, evaluate_fn) -> bool:
+        evaluate_fn()
+        return True
+
+
+class _RecordingEvaluator:
+    def __init__(self):
+        self.callbacks = []
+
+    def evaluate_before_train(self, evaluate_fn) -> bool:
+        self.callbacks.append(evaluate_fn)
+        return False
+
+
+class _FailingUpdateActor:
+    def __init__(self, update_method: str, events: list[tuple]):
+        self.update_method = update_method
+        self.events = events
+
+    def __getattr__(self, name: str):
+        if name == self.update_method:
+            return self._update
+        raise AttributeError(name)
+
+    def _update(self, _batch) -> None:
+        self.events.append(("update", {}))
+        raise _StopAfterFirstUpdate
+
+
+class _FailingPPOActor:
+    def __init__(self, events: list[tuple]):
+        self.events = events
+
+    def prepare_batch(self, *_args, **_kwargs):
+        return [{}]
+
+    def compute_advantages(self, _rollout_batch):
+        return [{}]
+
+    def get_device_stats(self) -> _FakeDeviceStats:
+        return _FakeDeviceStats()
+
+    def ppo_update(self, _adv_batch) -> None:
+        self.events.append(("update", {}))
+        raise _StopAfterFirstUpdate
+
+
+def _disable_timing_contexts(monkeypatch, module) -> None:
+    monkeypatch.setattr(
+        module.stats_tracker,
+        "record_timing",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+    monkeypatch.setattr(
+        module.perf_tracer,
+        "trace_scope",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+
+
+def _record_initial_eval(events: list[tuple], *_args, **_kwargs) -> bool:
+    events.append(("initial_eval", {}))
+    return True
+
+
+def _record_commit(events: list[tuple], **kwargs) -> None:
+    events.append(("commit", kwargs))
+
+
+def _build_supervised_trainer(
+    trainer_cls,
+    update_method: str,
+    events: list[tuple],
+    *,
+    recovered: bool = False,
+):
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = SimpleNamespace(
+        total_train_epochs=1,
+        total_train_steps=None,
+        memory_profiler=None,
+    )
+    trainer.recover_info = (
+        SimpleNamespace(last_step_info=_FakeLastStepInfo()) if recovered else None
+    )
+    trainer.train_dataloader = [[{}], [{}]] if recovered else [[{}]]
+    trainer.saver = _FakeSaver()
+    trainer.actor = _FailingUpdateActor(update_method, events)
+    trainer._load_bcast_from = lambda data_generator: next(data_generator)
+    trainer._evaluate_before_train = lambda: _record_initial_eval(events)
+    trainer._export_and_commit_stats = lambda **kwargs: _record_commit(events, **kwargs)
+    if trainer_cls is DPOTrainer:
+        trainer.ref = _FakeRef()
+    return trainer
+
+
+def _build_ppo_trainer(events: list[tuple], *, recovered: bool = False):
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.config = SimpleNamespace(
+        total_train_epochs=1,
+        total_train_steps=None,
+        rollout=SimpleNamespace(agent=None),
+        gconfig=SimpleNamespace(
+            n_samples=1,
+            reward_normalization=False,
+            drop_incomplete_group=False,
+        ),
+        dynamic_bs=False,
+        actor=SimpleNamespace(
+            _version="v1",
+            weight_update_mode="xccl",
+            should_compute_prox_logp=lambda: False,
+        ),
+        memory_profiler=None,
+    )
+    trainer.recover_info = (
+        SimpleNamespace(last_step_info=_FakeLastStepInfo()) if recovered else None
+    )
+    trainer.train_dataloader = [[{}], [{}]] if recovered else [[{}]]
+    trainer.saver = _FakeSaver()
+    trainer.actor = _FailingPPOActor(events)
+    trainer.critic = None
+    trainer.ref = None
+    trainer.teacher = None
+    trainer._should_offload_rollout = False
+    trainer._should_offload_actor = False
+    trainer._requires_proxy_workflow = lambda _workflow: False
+    trainer._evaluate_before_train = lambda *_args, **_kwargs: _record_initial_eval(
+        events
+    )
+    trainer._export_and_commit_stats = lambda **kwargs: _record_commit(events, **kwargs)
+    return trainer
+
+
+@pytest.mark.parametrize(
+    ("module", "trainer_cls", "update_method"),
+    [
+        (sft_trainer, SFTTrainer, "train_lm"),
+        (dpo_trainer, DPOTrainer, "train_dpo"),
+        (rw_trainer, RWTrainer, "train_rw"),
+    ],
+    ids=["sft", "dpo", "rw"],
+)
+@pytest.mark.parametrize("recovered", [False, True], ids=["fresh", "recovered"])
+def test_supervised_trainers_order_initial_eval_around_recovery(
+    monkeypatch,
+    module,
+    trainer_cls,
+    update_method: str,
+    recovered: bool,
+):
+    """Trainer call sites should run a baseline only before a fresh update."""
+    _disable_timing_contexts(monkeypatch, module)
+    events: list[tuple] = []
+    trainer = _build_supervised_trainer(
+        trainer_cls,
+        update_method,
+        events,
+        recovered=recovered,
+    )
+
+    with pytest.raises(_StopAfterFirstUpdate):
+        trainer.train()
+
+    if recovered:
+        assert [event for event, _ in events] == ["update"]
+    else:
+        assert [event for event, _ in events] == ["initial_eval", "commit", "update"]
+        assert events[1][1] == {
+            "epoch": -1,
+            "epoch_step": -1,
+            "global_step": -1,
+        }
+
+
+@pytest.mark.parametrize("recovered", [False, True], ids=["fresh", "recovered"])
+def test_ppo_trainer_orders_initial_eval_around_recovery(monkeypatch, recovered: bool):
+    """PPO should record a version-zero baseline only on a fresh run."""
+    _disable_timing_contexts(monkeypatch, rl_trainer)
+    events: list[tuple] = []
+    trainer = _build_ppo_trainer(events, recovered=recovered)
+
+    with pytest.raises(_StopAfterFirstUpdate):
+        trainer.train(workflow=object())
+
+    if recovered:
+        assert [event for event, _ in events] == ["update"]
+    else:
+        assert [event for event, _ in events] == ["initial_eval", "commit", "update"]
+        assert events[1][1] == {
+            "epoch": -1,
+            "epoch_step": -1,
+            "global_step": -1,
+        }
+
+
+def test_ppo_initial_eval_offloads_rollout_when_evaluation_fails(monkeypatch):
+    """A failed colocated baseline must still restore the offloaded state."""
+    _disable_timing_contexts(monkeypatch, rl_trainer)
+    events: list[str] = []
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.eval_rollout = object()
+    trainer.valid_dataloader = object()
+    trainer.evaluator = _CallbackEvaluator()
+    trainer._should_offload_rollout = True
+    trainer._onload_rollout = lambda *, is_eval: events.append(f"onload:{is_eval}")
+    trainer._offload_rollout = lambda *, is_eval: events.append(f"offload:{is_eval}")
+
+    def fail_evaluation(**_kwargs):
+        events.append("evaluate")
+        raise RuntimeError("evaluation failed")
+
+    trainer._evaluate_fn = fail_evaluation
+
+    with pytest.raises(RuntimeError, match="evaluation failed"):
+        trainer._evaluate_before_train(
+            eval_workflow=object(),
+            eval_workflow_kwargs=None,
+        )
+
+    assert events == ["onload:True", "evaluate", "offload:True"]
+
+
+def test_ppo_consumes_initial_eval_without_complete_evaluation_inputs():
+    """PPO should consume the baseline when no evaluation workflow is provided."""
+    evaluator = _RecordingEvaluator()
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.eval_rollout = object()
+    trainer.valid_dataloader = object()
+    trainer.evaluator = evaluator
+
+    ran = trainer._evaluate_before_train(
+        eval_workflow=None,
+        eval_workflow_kwargs=None,
+    )
+
+    assert ran is False
+    assert evaluator.callbacks == [None]
+
+
+def test_initial_eval_stats_use_step_zero_before_first_update(monkeypatch):
+    """Baseline and first-update metrics should occupy distinct log steps."""
+    stats_logger = StatsLogger.__new__(StatsLogger)
+    stats_logger.ft_spec = SimpleNamespace(
+        total_train_epochs=1,
+        steps_per_epoch=1,
+        total_train_steps=1,
+    )
+    stats_logger._last_commit_step = -1
+    stats_logger._trackio_enabled = False
+    stats_logger.summary_writer = None
+    stats_logger.print_stats = lambda _stats: None
+    logged_steps: list[int] = []
+
+    monkeypatch.setattr(stats_logger_module.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(
+        stats_logger_module.wandb,
+        "log",
+        lambda _data, *, step: logged_steps.append(step),
+    )
+    monkeypatch.setattr(
+        stats_logger_module.swanlab,
+        "log",
+        lambda _data, *, step: None,
+    )
+
+    stats_logger.commit(
+        epoch=-1,
+        step=-1,
+        global_step=-1,
+        data={"eval/reward": 0.5},
+    )
+    stats_logger.commit(
+        epoch=0,
+        step=0,
+        global_step=0,
+        data={"train/loss": 0.1},
+    )
+
+    assert logged_steps == [0, 1]
+    assert stats_logger.state_dict() == {"last_commit_step": 1}


### PR DESCRIPTION
## Description

`eval_before_train`, introduced in #1232, currently relies on the evaluator's
first scheduled check. Trainers do not perform that check until after their
first optimization step, so the reported baseline can already contain updated
weights.

This change runs the one-shot baseline before the first update in PPO, SFT,
DPO, and reward-model training. It commits the baseline at log step 0 without
advancing periodic evaluation cadence, skips it during checkpoint recovery,
and safely restores PPO rollout offload state if evaluation fails.

## Related Issue

Correctness follow-up to #1232, addressing
[this reported behavior](https://github.com/areal-project/AReaL/pull/1232#issuecomment-4687149208).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable; existing documentation already
      describes the intended behavior)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

Not applicable.

## Additional Context

Risk areas reviewed by the regression suite include trainer startup ordering,
checkpoint recovery, periodic evaluation cadence, log-step separation, and PPO
rollout offload cleanup.

Validation:

- `python -m pytest -q tests/test_evaluator.py tests/test_trainer_eval_before_train.py tests/test_recover.py tests/test_trackio_backend.py` — 72 passed
- `pre-commit run --all-files`
- `git diff --check`

A GPU end-to-end training run was not performed because this defect is a
lifecycle-ordering issue covered deterministically by CPU tests; the change
does not modify trainer update or numerical paths.
