### PR TITLE
fix(ppo): track trajectory truncation explicitly

### DIFF
--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -22,6 +22,11 @@ class RolloutWorkflow(ABC):
         ----
         Returning `None` implies that this trajectory is rejected and will not be used for training.
 
+        Tensor trajectories should include an ``is_truncated`` boolean tensor with
+        one value per trajectory when the workflow can determine whether the final
+        model response stopped because it reached a length limit. PPO uses this
+        metadata for reward masking, value bootstrapping, and truncation metrics.
+
         See concrete example implementations under the `areal/workflow` directory.
 
         Parameters

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -2044,6 +2044,7 @@ class FSDPEngine(TrainEngine):
             ulysses_pad_size = 0
 
         inputs.pop("turn_ids", None)
+        inputs.pop("is_truncated", None)
 
         ctx = FSDPTrainContext(
             model_inputs=inputs,

--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -979,6 +979,7 @@ class ArchonEngine(TrainEngine):
         # Extract trie_node for tree training (if present)
         trie_node = inputs.pop("trie_node", None)
         inputs.pop("turn_ids", None)
+        inputs.pop("is_truncated", None)
 
         # Tree training: labels are derived from trie structure, not torch.roll.
         # (Tree input_ids is 1D packed format, so roll would be wrong anyway.)

--- a/areal/experimental/openai/types.py
+++ b/areal/experimental/openai/types.py
@@ -222,6 +222,7 @@ class InteractionWithTokenLogpReward:
             # reward
             rewards=torch.tensor([float(reward)]),
             original_rewards=torch.tensor([float(original_reward)]),
+            is_truncated=torch.tensor([resp.stop_reason == "length"], dtype=torch.bool),
         )
         self._cache = result
         return result

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -64,6 +64,22 @@ def _infer_prompt_lens(
     return torch.where(has_gen, first_gen_idx, attention_mask.long().sum(-1))
 
 
+def _get_truncated_mask(data: dict[str, Any], seqlens: torch.Tensor) -> torch.Tensor:
+    is_truncated = data.get("is_truncated")
+    if is_truncated is None:
+        # Preserve compatibility with custom tensor workflows that predate the
+        # explicit per-trajectory termination metadata.
+        return seqlens == data["attention_mask"].shape[-1]
+    if not torch.is_tensor(is_truncated):
+        raise TypeError("`is_truncated` must be a tensor")
+    if is_truncated.shape != seqlens.shape:
+        raise ValueError(
+            "`is_truncated` must have one value per trajectory, got "
+            f"shape {tuple(is_truncated.shape)} for batch shape {tuple(seqlens.shape)}"
+        )
+    return is_truncated.to(device=seqlens.device, dtype=torch.bool)
+
+
 class PPOActor:
     def __init__(self, config: PPOActorConfig, engine: TrainEngine):
         self.config = config
@@ -249,7 +265,8 @@ class PPOActor:
         # Compute KL-regularized rewards.
         attn_mask = data["attention_mask"]
         seqlens = attn_mask.sum(-1).long()
-        seq_no_eos_mask = seqlens == attn_mask.shape[1]
+        seq_truncated_mask = _get_truncated_mask(data, seqlens)
+        data["is_truncated"] = seq_truncated_mask
         rewards = -self.kl_ctl * self.kl_estimator(old_logp, ref_logp)
         kl_rewards = rewards.clone()
         # KL rewards at the next token after eos is zero.
@@ -259,7 +276,7 @@ class PPOActor:
         gae_outcome_rewards = torch.zeros_like(rewards)
         if self.mask_no_eos_with_zero:
             gae_outcome_rewards[batch_indices, indices] = torch.where(
-                seq_no_eos_mask, 0, reward_score
+                seq_truncated_mask, 0, reward_score
             )
         else:
             gae_outcome_rewards[batch_indices, indices] = reward_score
@@ -277,6 +294,7 @@ class PPOActor:
             values = torch.zeros_like(rewards)
         else:
             values = data["values"]
+        bootstrap_values = values[batch_indices, seqlens - 1]
         if self._gae_lambda_is_custom:
             gae_lambda = self._compute_gae_lambda(loss_mask, turn_ids)
         else:
@@ -290,7 +308,8 @@ class PPOActor:
                 values=values,
                 loss_mask=loss_mask,
                 turn_ids=turn_ids,
-                seq_no_eos_mask=seq_no_eos_mask,
+                seq_no_eos_mask=seq_truncated_mask,
+                bootstrap_values=bootstrap_values,
                 discount=self.discount,
                 gae_lambda=gae_lambda,
             )
@@ -300,7 +319,8 @@ class PPOActor:
                 rewards=rewards,
                 values=values,
                 loss_mask=loss_mask,
-                seq_no_eos_mask=seq_no_eos_mask,
+                seq_no_eos_mask=seq_truncated_mask,
+                bootstrap_values=bootstrap_values,
                 discount=self.discount,
                 gae_lambda=gae_lambda,
             )
@@ -415,8 +435,9 @@ class PPOActor:
         stats_tracker.stat(**stats, denominator="n_valid_tokens")
 
         prompt_lens = _infer_prompt_lens(data["attention_mask"], data["loss_mask"])
+        seq_truncated_mask = _get_truncated_mask(data, seqlens)
         seq_stats = dict(
-            no_eos_ratios=(seqlens == attn_mask.shape[-1]).float(),
+            no_eos_ratios=seq_truncated_mask.float(),
             task_reward=task_reward,
             prompt_len=prompt_lens.float(),
             seq_len=seqlens.float(),
@@ -447,7 +468,7 @@ class PPOActor:
 
         # Pop keys that are no longer needed after advantage computation
         # Note: "versions" is kept if needed for approximation/metrics in loss function
-        for key in ["rewards", "tot_rewards", "kl_rewards"]:
+        for key in ["rewards", "tot_rewards", "kl_rewards", "is_truncated"]:
             data.pop(key, None)
         # NOTE: calling engine.train() is critical to enabling gradient checkpointing
         self.engine.train()

--- a/areal/trainer/ppo/critic.py
+++ b/areal/trainer/ppo/critic.py
@@ -53,7 +53,13 @@ class PPOCritic:
         stats_tracker.scalar(**scalars)
         ########## Logging code ends ##########
 
-        for key in ["rewards", "tot_rewards", "kl_rewards", "versions"]:
+        for key in [
+            "rewards",
+            "tot_rewards",
+            "kl_rewards",
+            "versions",
+            "is_truncated",
+        ]:
             data.pop(key, None)
 
         # NOTE: calling engine.train() is critical to enabling gradient checkpointing

--- a/areal/trainer/ppo/gae.py
+++ b/areal/trainer/ppo/gae.py
@@ -12,14 +12,19 @@ def _compute_token_level_gae(
     values: torch.Tensor,
     loss_mask: torch.Tensor,
     seq_no_eos_mask: torch.Tensor,
+    bootstrap_values: torch.Tensor,
     discount: float,
     gae_lambda: float | torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute GAE with each generated token treated as one timestep."""
+    """Compute GAE with each generated token treated as one timestep.
+
+    ``bootstrap_values`` contains each trajectory's value at its final valid token,
+    independent of the padded batch width.
+    """
     bs, max_seqlen = rewards.shape
     advantages_reversed = [torch.zeros(bs, dtype=torch.float32, device=values.device)]
     lastgaelam = torch.zeros(bs, dtype=torch.float32, device=values.device)
-    nextvalues = values[:, max_seqlen - 1] * seq_no_eos_mask
+    nextvalues = bootstrap_values * seq_no_eos_mask
     discounted_lambda = discount * gae_lambda
     for t in reversed(range(max_seqlen - 1)):
         delta = rewards[:, t] + discount * nextvalues - values[:, t]
@@ -85,10 +90,15 @@ def _compute_turn_level_gae(
     loss_mask: torch.Tensor,
     turn_ids: torch.Tensor,
     seq_no_eos_mask: torch.Tensor,
+    bootstrap_values: torch.Tensor,
     discount: float,
     gae_lambda: float | torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute GAE with each generated turn treated as one timestep."""
+    """Compute GAE with each generated turn treated as one timestep.
+
+    ``bootstrap_values`` contains each trajectory's value at its final valid token,
+    independent of the padded batch width.
+    """
     _validate_turn_ids(loss_mask, turn_ids)
     bs, max_seqlen = rewards.shape
     valid_token_mask = loss_mask.bool()
@@ -130,7 +140,7 @@ def _compute_turn_level_gae(
     )
     lastgaelam = torch.zeros(bs, dtype=torch.float32, device=values.device)
     zero_advantages = torch.zeros_like(lastgaelam)
-    nextvalues = values[:, max_seqlen - 1] * seq_no_eos_mask
+    nextvalues = bootstrap_values * seq_no_eos_mask
     discounted_lambda = discount * gae_lambda
     # Advantage calculation normally runs over CPU rollout tensors. Avoid
     # iterating over every token slot there when trajectories contain only a

--- a/areal/workflow/multi_turn.py
+++ b/areal/workflow/multi_turn.py
@@ -73,6 +73,7 @@ class MultiTurnWorkflow(RolloutWorkflow):
         discount = 1.0
         prompt_str = ""
         completions_str = ""
+        is_truncated = False
         while reward == 0.0 and t < self.max_turns:
             # Send generate request to get the response.
             req = ModelRequest(
@@ -82,6 +83,9 @@ class MultiTurnWorkflow(RolloutWorkflow):
                 tokenizer=self.tokenizer,
             )
             resp = await engine.agenerate(req)
+            # Only the final turn determines whether the trajectory itself was
+            # truncated; a later turn supersedes an earlier length stop.
+            is_truncated = resp.stop_reason == "length"
             # compute reward: 1 for correct and 0 otherwise
             prompt_str = self.tokenizer.decode(input_ids)
             completions_str = self.tokenizer.decode(resp.output_tokens)
@@ -133,5 +137,6 @@ class MultiTurnWorkflow(RolloutWorkflow):
             turn_ids=torch.tensor(turn_ids, dtype=torch.int32),
             rewards=torch.tensor(reward, dtype=torch.float32),
             attention_mask=torch.ones(len(seq), dtype=torch.bool),
+            is_truncated=torch.tensor(is_truncated, dtype=torch.bool),
         )
         return {k: v.unsqueeze(0) for k, v in res.items()}

--- a/areal/workflow/rlvr.py
+++ b/areal/workflow/rlvr.py
@@ -176,5 +176,8 @@ class RLVRWorkflow(RolloutWorkflow):
             "turn_ids": torch.tensor(turn_ids, dtype=torch.int32),
             "attention_mask": torch.ones(len(seq), dtype=torch.bool),
             "rewards": torch.tensor(reward, dtype=torch.float32),
+            "is_truncated": torch.tensor(
+                resp.stop_reason == "length", dtype=torch.bool
+            ),
         }
         return {k: v.unsqueeze(0) for k, v in res.items()}

--- a/areal/workflow/vision_rlvr.py
+++ b/areal/workflow/vision_rlvr.py
@@ -166,4 +166,7 @@ class VisionRLVRWorkflow(RLVRWorkflow):
             "turn_ids": torch.tensor(turn_ids, dtype=torch.int32).unsqueeze(0),
             "attention_mask": torch.ones(len(seq), dtype=torch.bool).unsqueeze(0),
             "rewards": torch.tensor(reward, dtype=torch.float32).unsqueeze(0),
+            "is_truncated": torch.tensor(
+                [resp.stop_reason == "length"], dtype=torch.bool
+            ),
         }

--- a/tests/test_ppo_actor_truncation.py
+++ b/tests/test_ppo_actor_truncation.py
@@ -1,0 +1,301 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import torch
+
+from areal.api import ModelResponse
+from areal.api.cli_args import (
+    GenerationHyperparameters,
+    PPOActorConfig,
+    PPOCriticConfig,
+)
+from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.trainer.ppo.actor import PPOActor
+from areal.trainer.ppo.critic import PPOCritic
+from areal.utils.data import concat_padded_tensors
+from areal.workflow.multi_turn import MultiTurnWorkflow
+from areal.workflow.rlvr import RLVRWorkflow
+
+
+def _make_trajectory(
+    *,
+    prompt_len: int,
+    completion_len: int,
+    reward: float,
+    bootstrap_value: float,
+    is_truncated: bool,
+) -> dict[str, torch.Tensor]:
+    seq_len = prompt_len + completion_len
+    values = torch.zeros((1, seq_len), dtype=torch.float32)
+    values[0, -1] = bootstrap_value
+
+    return {
+        "input_ids": torch.arange(seq_len, dtype=torch.long).unsqueeze(0),
+        "attention_mask": torch.ones((1, seq_len), dtype=torch.bool),
+        "loss_mask": torch.tensor(
+            [[0] * prompt_len + [1] * completion_len], dtype=torch.bool
+        ),
+        "logprobs": torch.zeros((1, seq_len), dtype=torch.float32),
+        "turn_ids": torch.tensor(
+            [[-1] * prompt_len + [0] * completion_len], dtype=torch.int32
+        ),
+        "values": values,
+        "rewards": torch.tensor([reward], dtype=torch.float32),
+        "is_truncated": torch.tensor([is_truncated], dtype=torch.bool),
+    }
+
+
+def _assert_action_advantages(output: dict[str, torch.Tensor], expected: float) -> None:
+    action_advantages = output["advantages"][output["loss_mask"].bool()]
+    torch.testing.assert_close(
+        action_advantages,
+        torch.full_like(action_advantages, expected),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_interaction_tensor_dict_preserves_length_termination():
+    """Export the inference stop reason as per-trajectory training metadata."""
+    for stop_reason, expected in (("length", True), ("stop", False)):
+        response = ModelResponse(
+            input_tokens=[1, 2],
+            output_tokens=[3],
+            output_logprobs=[0.0],
+            output_versions=[0],
+            stop_reason=stop_reason,
+        )
+        interaction = InteractionWithTokenLogpReward(model_response=response)
+
+        is_truncated = interaction.to_tensor_dict()["is_truncated"]
+
+        torch.testing.assert_close(
+            is_truncated,
+            torch.tensor([expected], dtype=torch.bool),
+            rtol=0,
+            atol=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_rlvr_workflow_preserves_length_termination():
+    """Export the response stop reason from the built-in RLVR workflow."""
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "decoded"
+
+    workflow = object.__new__(RLVRWorkflow)
+    workflow.reward_fn = MagicMock()
+    workflow.tokenizer = tokenizer
+    workflow.enable_thinking = False
+    workflow.gconfig = GenerationHyperparameters(max_new_tokens=3)
+    workflow.get_input_ids_fn = lambda *_args: [1, 2]
+    workflow.data_extract_prompt_fn = lambda data: data["messages"]
+
+    for stop_reason, expected in (("length", True), ("stop", False)):
+        response = ModelResponse(
+            input_tokens=[1, 2],
+            output_tokens=[3],
+            output_logprobs=[0.0],
+            output_versions=[0],
+            stop_reason=stop_reason,
+        )
+        workflow._collect_samples = AsyncMock(return_value=(response, 1.0))
+
+        trajectory = await workflow.arun_episode(
+            MagicMock(), {"messages": [{"role": "user", "content": "test"}]}
+        )
+
+        torch.testing.assert_close(
+            trajectory["is_truncated"],
+            torch.tensor([expected], dtype=torch.bool),
+            rtol=0,
+            atol=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_uses_final_response_termination():
+    """Let a later successful turn supersede an earlier length stop."""
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "decoded"
+    tokenizer.eos_token_id = 0
+
+    workflow = object.__new__(MultiTurnWorkflow)
+    workflow.tokenizer = tokenizer
+    workflow.gconfig = GenerationHyperparameters(max_new_tokens=3)
+    workflow.max_turns = 2
+    workflow.turn_discount = 1.0
+    workflow.multi_turn_prompt_ids = [9]
+    workflow.async_reward_fn = AsyncMock(side_effect=[0.0, 1.0])
+
+    engine = MagicMock()
+    engine.agenerate = AsyncMock(
+        side_effect=[
+            ModelResponse(
+                input_tokens=[1, 2],
+                output_tokens=[3],
+                output_logprobs=[0.0],
+                output_versions=[0],
+                stop_reason="length",
+            ),
+            ModelResponse(
+                input_tokens=[1, 2, 3, 0, 9],
+                output_tokens=[4],
+                output_logprobs=[0.0],
+                output_versions=[0],
+                stop_reason="stop",
+            ),
+        ]
+    )
+
+    with (
+        patch("areal.workflow.multi_turn.apply_chat_template", return_value=[1, 2]),
+        patch("areal.workflow.multi_turn.stats_tracker"),
+        patch("areal.workflow.multi_turn.workflow_context"),
+    ):
+        trajectory = await workflow.arun_episode(
+            engine, {"messages": [{"role": "user", "content": "test"}]}
+        )
+
+    assert engine.agenerate.await_count == 2
+    torch.testing.assert_close(
+        trajectory["is_truncated"],
+        torch.tensor([False], dtype=torch.bool),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_critic_update_does_not_forward_truncation_metadata():
+    """Remove trajectory metadata before constructing critic microbatches."""
+    engine = MagicMock()
+    engine.train_batch.return_value = {}
+    critic = PPOCritic(PPOCriticConfig(backend="fsdp:d1", ppo_n_minibatches=1), engine)
+    data = {
+        "input_ids": torch.tensor([[1, 2, 3], [4, 5, 0]], dtype=torch.long),
+        "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 0]], dtype=torch.bool),
+        "loss_mask": torch.tensor([[0, 1, 1], [0, 1, 0]], dtype=torch.bool),
+        "values": torch.zeros((2, 3), dtype=torch.float32),
+        "returns": torch.zeros((2, 3), dtype=torch.float32),
+        "is_truncated": torch.tensor([False, True], dtype=torch.bool),
+    }
+
+    critic._ppo_update(data)
+
+    assert "is_truncated" not in data
+    engine.train_batch.assert_called()
+    for call in engine.train_batch.call_args_list:
+        assert "is_truncated" not in call.args[0]
+
+
+def test_ppo_update_logs_explicit_truncation_metadata():
+    """Report the same per-trajectory truncation state used for advantages."""
+    engine = MagicMock()
+    engine.train_batch.return_value = {}
+    actor = PPOActor(
+        PPOActorConfig(
+            backend="fsdp:d1",
+            ppo_n_minibatches=1,
+            mask_no_eos_with_zero=True,
+            kl_ctl=0.0,
+        ),
+        engine,
+    )
+    outputs = actor.compute_advantages(
+        [
+            _make_trajectory(
+                prompt_len=2,
+                completion_len=3,
+                reward=1.0,
+                bootstrap_value=0.0,
+                is_truncated=True,
+            ),
+            _make_trajectory(
+                prompt_len=4,
+                completion_len=3,
+                reward=1.0,
+                bootstrap_value=0.0,
+                is_truncated=False,
+            ),
+        ]
+    )
+    batch = concat_padded_tensors(outputs)
+
+    with patch("areal.trainer.ppo.actor.stats_tracker") as tracker:
+        actor._ppo_update(batch)
+
+    truncation_call = next(
+        call for call in tracker.stat.call_args_list if "no_eos_ratios" in call.kwargs
+    )
+    torch.testing.assert_close(
+        truncation_call.kwargs["no_eos_ratios"],
+        torch.tensor([1.0, 0.0]),
+        rtol=0,
+        atol=0,
+    )
+    engine.train_batch.assert_called()
+    for call in engine.train_batch.call_args_list:
+        assert "is_truncated" not in call.args[0]
+
+
+@pytest.mark.parametrize("gae_timestep_unit", ["token", "turn"])
+def test_compute_advantages_uses_termination_reason_across_variable_padding(
+    gae_timestep_unit: str,
+):
+    """Use explicit termination state, not the batch's padded sequence width."""
+    actor = PPOActor(
+        PPOActorConfig(
+            backend="fsdp:d1",
+            max_new_tokens=3,
+            mask_no_eos_with_zero=True,
+            kl_ctl=0.0,
+            discount=1.0,
+            gae_lambda=1.0,
+            gae_timestep_unit=gae_timestep_unit,
+        ),
+        MagicMock(),
+    )
+
+    # The shorter trajectory was truncated, while the longest trajectory stopped
+    # normally. Padding width therefore gives exactly the opposite classification.
+    outputs = actor.compute_advantages(
+        [
+            _make_trajectory(
+                prompt_len=2,
+                completion_len=3,
+                reward=3.0,
+                bootstrap_value=10.0,
+                is_truncated=True,
+            ),
+            _make_trajectory(
+                prompt_len=4,
+                completion_len=3,
+                reward=3.0,
+                bootstrap_value=20.0,
+                is_truncated=False,
+            ),
+        ]
+    )
+
+    truncated, stopped = outputs
+
+    # A truncated trajectory receives no task reward and bootstraps from its own
+    # last valid token, even when it is shorter than the padded batch width.
+    torch.testing.assert_close(
+        truncated["tot_rewards"],
+        torch.zeros_like(truncated["tot_rewards"]),
+        rtol=0,
+        atol=0,
+    )
+    _assert_action_advantages(truncated, expected=10.0)
+
+    # A normally stopped trajectory keeps its task reward and must not bootstrap,
+    # even when it happens to be the longest sequence in the batch.
+    assert torch.count_nonzero(stopped["tot_rewards"]) == 1
+    torch.testing.assert_close(
+        stopped["tot_rewards"].sum(),
+        torch.tensor(3.0),
+        rtol=0,
+        atol=0,
+    )
+    _assert_action_advantages(stopped, expected=3.0)

--- a/tests/test_ppo_gae.py
+++ b/tests/test_ppo_gae.py
@@ -67,6 +67,7 @@ def _make_interaction(
         output_len=len(output_tokens),
         output_logprobs=[-0.1] * len(output_tokens),
         output_versions=[1] * len(output_tokens),
+        stop_reason="stop",
     )
     return InteractionWithTokenLogpReward(
         model_response=response,
@@ -88,6 +89,7 @@ def test_turn_level_gae_broadcasts_advantage_and_steps_once_per_turn():
         loss_mask=torch.ones_like(rewards),
         turn_ids=torch.tensor([[0, 0, 1, 1]], dtype=torch.int32),
         seq_no_eos_mask=torch.tensor([False]),
+        bootstrap_values=torch.zeros(1),
         discount=1.0,
         gae_lambda=0.5,
     )
@@ -108,6 +110,7 @@ def test_turn_level_gae_skips_gaps_and_uses_first_value_with_bootstrap():
         loss_mask=torch.tensor([[1.0, 1.0, 0.0, 1.0, 1.0]]),
         turn_ids=torch.tensor([[0, 0, -1, 2, 2]], dtype=torch.int64),
         seq_no_eos_mask=torch.tensor([True]),
+        bootstrap_values=values[:, -1],
         discount=0.5,
         gae_lambda=0.25,
     )
@@ -139,6 +142,7 @@ def test_turn_level_gae_applies_one_lambda_per_sample():
         loss_mask=torch.ones_like(rewards),
         turn_ids=torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]], dtype=torch.int32),
         seq_no_eos_mask=torch.tensor([False, False]),
+        bootstrap_values=torch.zeros(2),
         discount=1.0,
         gae_lambda=torch.tensor([0.5, 0.0]),
     )
@@ -183,6 +187,7 @@ def test_token_level_gae_matches_legacy_recurrence():
         values=values,
         loss_mask=loss_mask,
         seq_no_eos_mask=seq_no_eos_mask,
+        bootstrap_values=values[:, -1],
         discount=discount,
         gae_lambda=gae_lambda,
     )
@@ -209,6 +214,7 @@ def test_token_level_gae_applies_one_lambda_per_sample():
         values=torch.zeros_like(rewards),
         loss_mask=loss_mask,
         seq_no_eos_mask=torch.tensor([False, False]),
+        bootstrap_values=torch.zeros(2),
         discount=1.0,
         gae_lambda=torch.tensor([0.5, 0.0]),
     )
@@ -527,6 +533,7 @@ def test_turn_level_gae_rejects_malformed_active_turn_ids(turn_ids, message):
             loss_mask=torch.ones_like(rewards),
             turn_ids=torch.tensor([turn_ids]),
             seq_no_eos_mask=torch.tensor([False]),
+            bootstrap_values=torch.zeros(1),
             discount=1.0,
             gae_lambda=1.0,
         )
@@ -543,6 +550,7 @@ def test_turn_level_gae_rejects_non_integral_ids():
             loss_mask=torch.ones_like(rewards),
             turn_ids=torch.tensor([[0.0, 0.0]]),
             seq_no_eos_mask=torch.tensor([False]),
+            bootstrap_values=torch.zeros(1),
             discount=1.0,
             gae_lambda=1.0,
         )

--- a/tests/test_turn_ids_engine_inputs.py
+++ b/tests/test_turn_ids_engine_inputs.py
@@ -12,6 +12,7 @@ def _make_microbatch() -> MicroBatchItem:
         "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
         "attention_mask": torch.ones(1, 3, dtype=torch.bool),
         "turn_ids": torch.tensor([[-1, 0, 0]], dtype=torch.int32),
+        "is_truncated": torch.tensor([True]),
     }
     return MicroBatchItem(
         orig_mb=data,
@@ -21,7 +22,7 @@ def _make_microbatch() -> MicroBatchItem:
     )
 
 
-def test_fsdp_prepare_inputs_strips_turn_ids_without_mutating_context():
+def test_fsdp_prepare_inputs_strips_algorithm_metadata_without_mutating_context():
     """FSDP forwards model fields only while retaining algorithm metadata."""
     engine = FSDPEngine.__new__(FSDPEngine)
     engine.parallel_helper = SimpleNamespace(sp_size=1)
@@ -29,10 +30,12 @@ def test_fsdp_prepare_inputs_strips_turn_ids_without_mutating_context():
     inputs, context = engine._prepare_mb_inputs(_make_microbatch())
 
     assert "turn_ids" not in inputs
+    assert "is_truncated" not in inputs
     assert "turn_ids" in context.mb_input
+    assert "is_truncated" in context.mb_input
 
 
-def test_archon_prepare_inputs_strips_turn_ids_without_mutating_context():
+def test_archon_prepare_inputs_strips_algorithm_metadata_without_mutating_context():
     """Archon forwards model fields only while retaining algorithm metadata."""
     pytest.importorskip("triton", reason="Archon import requires Triton")
     from areal.experimental.engine.archon_engine import ArchonEngine
@@ -44,4 +47,6 @@ def test_archon_prepare_inputs_strips_turn_ids_without_mutating_context():
     inputs, context = engine._prepare_mb_inputs(_make_microbatch())
 
     assert "turn_ids" not in inputs
+    assert "is_truncated" not in inputs
     assert "turn_ids" in context.mb_input
+    assert "is_truncated" in context.mb_input


### PR DESCRIPTION
## Description

`PPOActor` currently infers truncation by checking whether a trajectory reaches the
dynamically padded batch width. This can invert the actual termination state: a shorter
response stopped by a length limit may be treated as complete, while the longest
response that stopped normally may be treated as truncated.

This PR propagates `stop_reason == "length"` as per-trajectory `is_truncated` metadata
and uses it for outcome-reward masking, GAE bootstrapping, and truncation metrics. The
metadata is removed before model forwards, while the existing heuristic is retained as
a compatibility fallback for custom workflows that do not provide it.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable to user-facing documentation; the tensor
  contract is documented inline)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

A deterministic variable-padding regression reproduces the issue on the current
`main` for both token-level and turn-level GAE. Both variants pass with this change.

Validation:

- Focused regression: `2 passed`
- Relevant regression suite: `163 passed, 4 skipped`
- `pre-commit run --all-files`: passed
- Full GPU training was not run; the affected workflow, trainer, GAE, and engine-input
  boundaries are covered by deterministic CPU tests.
