### PR TITLE
chore: bump v2.1.0

### DIFF
--- a/.github/workflows/tag-release-image.yml
+++ b/.github/workflows/tag-release-image.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to build (e.g., v2.0.0-sglang)'
+        description: 'Release tag to build (e.g., v2.1.0-sglang)'
         required: true
         type: string
 

--- a/docs/en/tutorial/installation.md
+++ b/docs/en/tutorial/installation.md
@@ -24,7 +24,7 @@ The following hardware configuration has been extensively tested:
 | Git LFS                  | Required for downloading models, datasets, and AReaL code. See [installation guide](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) |
 | Docker                   |                                                                                                 27.5.1                                                                                                 |
 | NVIDIA Container Toolkit |                                         See [installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)                                          |
-| AReaL Image              |                                   `ghcr.io/areal-project/areal-runtime:v2.0.0-sglang` (default) or `v2.0.0-vllm`. Includes runtime dependencies and Ray components.                                    |
+| AReaL Image              |                                   `ghcr.io/areal-project/areal-runtime:v2.1.0-sglang` (default) or `v2.1.0-vllm`. Includes runtime dependencies and Ray components.                                    |
 
 **Note**: This tutorial does not cover the installation of NVIDIA Drivers, CUDA, or
 shared storage mounting, as these depend on your specific node configuration and system
@@ -42,11 +42,11 @@ We recommend using Docker with our provided image. The Dockerfile is available i
 top-level directory of the AReaL repository.
 
 ```bash
-docker pull ghcr.io/areal-project/areal-runtime:v2.0.0-sglang
+docker pull ghcr.io/areal-project/areal-runtime:v2.1.0-sglang
 docker run -it --name areal-node1 \
    --privileged --gpus all --network host \
    --shm-size 700g -v /path/to/mount:/path/to/mount \
-   ghcr.io/areal-project/areal-runtime:v2.0.0-sglang \
+   ghcr.io/areal-project/areal-runtime:v2.1.0-sglang \
    /bin/bash
 git clone https://github.com/areal-project/AReaL /path/to/mount/AReaL
 cd /path/to/mount/AReaL
@@ -54,7 +54,7 @@ uv pip install -e . --no-deps
 ```
 
 A vLLM variant of the Docker image is also available at
-`ghcr.io/areal-project/areal-runtime:v2.0.0-vllm`. Replace the image tag in the commands
+`ghcr.io/areal-project/areal-runtime:v2.1.0-vllm`. Replace the image tag in the commands
 above if you prefer vLLM as the inference backend.
 
 ### Option 2: Custom Environment Installation

--- a/docs/zh/tutorial/installation.md
+++ b/docs/zh/tutorial/installation.md
@@ -24,7 +24,7 @@
 | Git LFS                  | 用于下载模型、数据集和 AReaL 代码。请参阅[安装指南](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) |
 | Docker                   |                                                                                 27.5.1                                                                                 |
 | NVIDIA Container Toolkit |                             请参阅[安装指南](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)                              |
-| AReaL 镜像               |                                `ghcr.io/areal-project/areal-runtime:v2.0.0-sglang`（默认）或 `v2.0.0-vllm`。包含运行时依赖和 Ray 组件。                                |
+| AReaL 镜像               |                                `ghcr.io/areal-project/areal-runtime:v2.1.0-sglang`（默认）或 `v2.1.0-vllm`。包含运行时依赖和 Ray 组件。                                |
 
 **注意**：本教程不涵盖 NVIDIA 驱动、CUDA 或共享存储挂载的安装，因为这些取决于您具体的节点配置和系统版本。请独立完成这些安装。
 
@@ -37,18 +37,18 @@
 我们推荐使用 Docker 和提供的镜像。Dockerfile 位于 AReaL 仓库的顶级目录。
 
 ```bash
-docker pull ghcr.io/areal-project/areal-runtime:v2.0.0-sglang
+docker pull ghcr.io/areal-project/areal-runtime:v2.1.0-sglang
 docker run -it --name areal-node1 \
    --privileged --gpus all --network host \
    --shm-size 700g -v /path/to/mount:/path/to/mount \
-   ghcr.io/areal-project/areal-runtime:v2.0.0-sglang \
+   ghcr.io/areal-project/areal-runtime:v2.1.0-sglang \
    /bin/bash
 git clone https://github.com/areal-project/AReaL /path/to/mount/AReaL
 cd /path/to/mount/AReaL
 uv pip install -e . --no-deps
 ```
 
-vLLM 变体的 Docker 镜像也可使用： `ghcr.io/areal-project/areal-runtime:v2.0.0-vllm`。如果您偏好使用 vLLM
+vLLM 变体的 Docker 镜像也可使用： `ghcr.io/areal-project/areal-runtime:v2.1.0-vllm`。如果您偏好使用 vLLM
 作为推理后端，请将上述命令中的镜像标签替换为该变体。
 
 ### 方式 2：自定义环境安装

--- a/examples/skypilot/README.md
+++ b/examples/skypilot/README.md
@@ -25,7 +25,7 @@ resources:
   cpus: 8+
   memory: 32GB+
   disk_size: 256GB
-  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.0.0-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.1.0-sglang
 
 num_nodes: 1
 
@@ -78,7 +78,7 @@ Specify the resources and image used to run the experiment.
 ```yaml
 resources:
   accelerators: A100:8
-  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.0.0-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.1.0-sglang
   memory: 256+
   cpus: 32+
 

--- a/examples/skypilot/ray_cluster.sky.yaml
+++ b/examples/skypilot/ray_cluster.sky.yaml
@@ -1,7 +1,7 @@
 
 resources:
   accelerators: A100:8
-  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.0.0-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.1.0-sglang
   memory: 32+
   cpus: 8+
 

--- a/examples/skypilot/single_node.sky.yaml
+++ b/examples/skypilot/single_node.sky.yaml
@@ -8,7 +8,7 @@ resources:
   cpus: 8+
   memory: 32GB+
   disk_size: 256GB
-  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.0.0-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v2.1.0-sglang
 
 num_nodes: 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "AReaL: A Large-Scale Asynchronous Reinforcement Learning System"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11,<3.13"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     {name = "AReaL Team"},
 ]

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -24,7 +24,7 @@ description = "AReaL: A Large-Scale Asynchronous Reinforcement Learning System"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11,<3.13"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     {name = "AReaL Team"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "areal"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.vllm.lock
+++ b/uv.vllm.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "areal"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
Version bump for v2.1.0 release.

- ``pyproject.toml`` / ``pyproject.vllm.toml``: ``2.0.0`` → ``2.1.0``
- ``uv.lock`` / ``uv.vllm.lock``: auto-regenerated via pre-commit
- ``docs/{en,zh}/tutorial/installation.md``, ``examples/skypilot/*``: ``v2.0.0-{sglang,vllm}`` → ``v2.1.0-{sglang,vllm}``
- ``.github/workflows/tag-release-image.yml``: workflow_dispatch example bumped

Release notes will be attached to the ``v2.1.0`` tag after merge.