### PR TITLE
ci: move Docker builder to us-central1-a

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       was_running: ${{ steps.start-instance.outputs.was_running }}
     env:
       INSTANCE_NAME: areal-docker-builder
-      INSTANCE_ZONE: us-central1-f
+      INSTANCE_ZONE: us-central1-a
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INSTANCE_NAME: areal-docker-builder
-      INSTANCE_ZONE: us-central1-f
+      INSTANCE_ZONE: us-central1-a
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INSTANCE_NAME: areal-docker-builder
-      INSTANCE_ZONE: us-central1-f
+      INSTANCE_ZONE: us-central1-a
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INSTANCE_NAME: areal-docker-builder
-      INSTANCE_ZONE: us-central1-f
+      INSTANCE_ZONE: us-central1-a
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3

--- a/.github/workflows/tag-release-image.yml
+++ b/.github/workflows/tag-release-image.yml
@@ -30,7 +30,7 @@ jobs:
       was_running: ${{ steps.start-instance.outputs.was_running }}
     env:
       INSTANCE_NAME: areal-docker-builder
-      INSTANCE_ZONE: us-central1-f
+      INSTANCE_ZONE: us-central1-a
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INSTANCE_NAME: areal-docker-builder
-      INSTANCE_ZONE: us-central1-f
+      INSTANCE_ZONE: us-central1-a
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3


### PR DESCRIPTION
## Description
Point all Docker builder lifecycle workflows at the migrated VM so release, development, and heartbeat jobs use the same zone.
<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
