### PR TITLE
ci: add PR-based Ascend image build probe

### DIFF
--- a/.github/workflows/ascend-image-build-probe.yml
+++ b/.github/workflows/ascend-image-build-probe.yml
@@ -1,0 +1,96 @@
+name: Ascend Image Build Probe
+
+on:
+  pull_request:
+    branches:
+      - ascend
+    paths:
+      - Dockerfile.a2
+      - Dockerfile.a3
+      - .github/workflows/ascend-image-build-probe.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ascend-image-build-probe-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  probe-docker-build:
+    name: probe-docker-build
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == 'Adiactive/AReaL' &&
+      github.event.pull_request.user.login == 'Adiactive')
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Inspect runner and Docker access
+        run: |
+          set -euo pipefail
+
+          echo "Runner: ${RUNNER_NAME:-unknown}"
+          echo "Architecture: $(uname -m)"
+          echo "Online CPUs: $(getconf _NPROCESSORS_ONLN)"
+          echo "Available CPUs: $(nproc)"
+          lscpu
+          grep '^Cpus_allowed_list:' /proc/self/status
+          for file in \
+            /sys/fs/cgroup/cpu.max \
+            /sys/fs/cgroup/cpuset.cpus.effective \
+            /sys/fs/cgroup/cpuset/cpuset.cpus \
+            /sys/fs/cgroup/cpu/cpu.cfs_quota_us \
+            /sys/fs/cgroup/cpu/cpu.cfs_period_us; do
+            if [[ -r "${file}" ]]; then
+              echo "${file}: $(<"${file}")"
+            fi
+          done
+          free -h
+          df -h
+
+          echo "Docker client: $(command -v docker)"
+          echo "DOCKER_HOST: ${DOCKER_HOST:-<unset>}"
+          if [[ -S /var/run/docker.sock ]]; then
+            stat /var/run/docker.sock
+          else
+            echo "/var/run/docker.sock is not mounted"
+          fi
+
+          docker version
+          docker buildx version
+          docker info --format \
+            'Server={{.ServerVersion}} Driver={{.Driver}} Root={{.DockerRootDir}} CPUs={{.NCPU}} Memory={{.MemTotal}}'
+          docker system df
+
+      - name: Build Dockerfile.a3 without publishing
+        env:
+          PROBE_IMAGE: areal_npu:ci-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          SECONDS=0
+          docker build \
+            --file Dockerfile.a3 \
+            --progress=plain \
+            --tag "${PROBE_IMAGE}" \
+            .
+          echo "Build duration: ${SECONDS}s"
+
+          docker image inspect "${PROBE_IMAGE}" \
+            --format 'Image={{.Id}} Architecture={{.Architecture}} OS={{.Os}}'
+
+      - name: Report final storage usage
+        if: always()
+        run: |
+          docker system df || true
+          df -h / /var/lib/docker || true

--- a/.github/workflows/ascend-pr-tests.yml
+++ b/.github/workflows/ascend-pr-tests.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - ascend
+    paths-ignore:
+      - .github/workflows/ascend-image-build-probe.yml
   push:
     branches:
       - ascend
+    paths-ignore:
+      - .github/workflows/ascend-image-build-probe.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

Add a PR-only, non-publishing Dockerfile.a3 build probe on GitHub's hosted ARM64 runner. The workflow reports CPU, memory, disk, Docker, and Buildx details before performing a full image build, and always reports final storage usage.

The expensive job is limited to pull requests from the Adiactive fork and manual dispatch. Probe-only workflow updates are excluded from the existing full Ascend CPU/NPU test workflow so image-build iteration does not consume unrelated runners.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant validation passes
- [x] Documentation updated (not applicable)
- [x] Branch is up to date with `ascend`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

The preceding direct-push probe established that `ubuntu-24.04-arm` provides four ARM64 CPU cores, approximately 15 GiB RAM, approximately 109 GB initially free disk, Docker Engine 28.0.4, and Buildx 0.36.1. The minimal ARM build passed; this PR exercises the full Dockerfile.a3 build without registry authentication or publication.
