### PR TITLE
ci: discover CPU tests by capability

### DIFF
--- a/.github/workflows/ascend-pr-tests.yml
+++ b/.github/workflows/ascend-pr-tests.yml
@@ -148,57 +148,17 @@ jobs:
 
       - name: Run CPU unit tests
         run: |
-          uv run pytest -q \
-            tests/test_adv_norm_config.py \
-            tests/test_allocation_mode.py \
-            tests/test_async_reward_wrapper.py \
-            tests/test_async_task_runner.py \
-            tests/test_attn_impl_validation.py \
-            tests/test_awex_runtime.py \
-            tests/test_clevr_reward.py \
-            tests/test_code_agent.py \
-            tests/test_dataset_mixture.py \
-            tests/test_domain_router_workflow.py \
-            tests/test_dpo.py \
-            tests/test_dynamic_import.py \
-            tests/test_eval_dispatch.py \
-            tests/test_functional.py \
-            tests/test_geometry3k_sft_dataset.py \
-            tests/test_math_verify_reward.py \
-            tests/test_mopd_loss.py \
-            tests/test_perf_trace_converter.py \
-            tests/test_ppo_stats.py \
-            tests/test_prox_approx.py \
-            tests/test_ray_scheduler.py \
-            tests/test_rejection_sampling.py \
-            tests/test_requires_padded_seq.py \
-            tests/test_seqpack.py \
-            tests/test_split_trajectory_for_dump.py \
-            tests/test_staleness_manager.py \
-            tests/test_teacher_domain_routing.py \
-            tests/test_utils.py \
-            tests/test_vllm_generation_request.py \
-            tests/test_vllm_pp_mismatch.py \
-            tests/test_workflow_detection.py
+          set -euo pipefail
 
-      - name: Run qualified slow CPU tests
-        run: |
-          uv run pytest -q -m slow \
-            tests/infra/data_service/test_epoch_crossing.py \
-            tests/infra/data_service/test_data_service_e2e.py
-
-      - name: Run additional CPU-compatible tests
-        run: |
+          uv run python scripts/select_cpu_tests.py \
+            --ignore tests/experimental/archon \
+            > /tmp/cpu-test-files.txt
+          mapfile -t cpu_test_files < /tmp/cpu-test-files.txt
+          test "${#cpu_test_files[@]}" -gt 0
+          printf 'Selected %s CPU test modules\n' "${#cpu_test_files[@]}"
           uv run pytest -q \
-            -m "not skip and not skipif" \
-            -k "not torchrun_multi_rank" \
-            tests/test_perf_tracer.py \
-            tests/test_megatron_async_save.py \
-            tests/test_megatron_engine_vlm.py::TestVisionModelDetection \
-            tests/test_mindspeed_gdn_patch.py \
-            tests/test_reassemble_cp_logprobs.py \
-            tests/test_vision_sp_shard.py \
-            tests/test_warmup_process_groups.py
+            -m "not npu and not multi_npu and not cuda and not nccl and not sglang and not vllm and not integration" \
+            "${cpu_test_files[@]}"
 
   npu-pr-tests:
     name: npu-pr-tests

--- a/areal/infra/__init__.py
+++ b/areal/infra/__init__.py
@@ -2,7 +2,26 @@
 
 """Core components for AREAL."""
 
-import importlib
+from . import workflow_context
+from .controller import RolloutController, TrainController
+from .launcher import (
+    LocalLauncher,
+    RayLauncher,
+    SGLangServerWrapper,
+    SlurmLauncher,
+    vLLMServerWrapper,
+)
+from .platforms import Platform, current_platform, is_npu_available
+from .remote_inf_engine import (
+    RemoteInfBackendProtocol,
+    RemoteInfEngine,
+)
+from .scheduler import LocalScheduler, RayScheduler, SlurmScheduler
+from .staleness_manager import StalenessManager
+from .workflow_executor import (
+    WorkflowExecutor,
+    check_trajectory_format,
+)
 
 __all__ = [
     "RemoteInfBackendProtocol",
@@ -25,41 +44,3 @@ __all__ = [
     "SGLangServerWrapper",
     "vLLMServerWrapper",
 ]
-
-_LAZY_IMPORTS = {
-    "LocalLauncher": "areal.infra.launcher",
-    "LocalScheduler": "areal.infra.scheduler",
-    "Platform": "areal.infra.platforms",
-    "RayLauncher": "areal.infra.launcher",
-    "RayScheduler": "areal.infra.scheduler",
-    "RemoteInfBackendProtocol": "areal.infra.remote_inf_engine",
-    "RemoteInfEngine": "areal.infra.remote_inf_engine",
-    "RolloutController": "areal.infra.controller",
-    "SGLangServerWrapper": "areal.infra.launcher",
-    "SlurmLauncher": "areal.infra.launcher",
-    "SlurmScheduler": "areal.infra.scheduler",
-    "StalenessManager": "areal.infra.staleness_manager",
-    "TrainController": "areal.infra.controller",
-    "WorkflowExecutor": "areal.infra.workflow_executor",
-    "check_trajectory_format": "areal.infra.workflow_executor",
-    "current_platform": "areal.infra.platforms",
-    "is_npu_available": "areal.infra.platforms",
-    "vLLMServerWrapper": "areal.infra.launcher",
-}
-
-
-def __getattr__(name: str):
-    if name == "workflow_context":
-        module = importlib.import_module("areal.infra.workflow_context")
-        globals()[name] = module
-        return module
-    if name in _LAZY_IMPORTS:
-        module = importlib.import_module(_LAZY_IMPORTS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return list(__all__)

--- a/areal/infra/__init__.py
+++ b/areal/infra/__init__.py
@@ -2,26 +2,7 @@
 
 """Core components for AREAL."""
 
-from . import workflow_context
-from .controller import RolloutController, TrainController
-from .launcher import (
-    LocalLauncher,
-    RayLauncher,
-    SGLangServerWrapper,
-    SlurmLauncher,
-    vLLMServerWrapper,
-)
-from .platforms import Platform, current_platform, is_npu_available
-from .remote_inf_engine import (
-    RemoteInfBackendProtocol,
-    RemoteInfEngine,
-)
-from .scheduler import LocalScheduler, RayScheduler, SlurmScheduler
-from .staleness_manager import StalenessManager
-from .workflow_executor import (
-    WorkflowExecutor,
-    check_trajectory_format,
-)
+import importlib
 
 __all__ = [
     "RemoteInfBackendProtocol",
@@ -44,3 +25,41 @@ __all__ = [
     "SGLangServerWrapper",
     "vLLMServerWrapper",
 ]
+
+_LAZY_IMPORTS = {
+    "LocalLauncher": "areal.infra.launcher",
+    "LocalScheduler": "areal.infra.scheduler",
+    "Platform": "areal.infra.platforms",
+    "RayLauncher": "areal.infra.launcher",
+    "RayScheduler": "areal.infra.scheduler",
+    "RemoteInfBackendProtocol": "areal.infra.remote_inf_engine",
+    "RemoteInfEngine": "areal.infra.remote_inf_engine",
+    "RolloutController": "areal.infra.controller",
+    "SGLangServerWrapper": "areal.infra.launcher",
+    "SlurmLauncher": "areal.infra.launcher",
+    "SlurmScheduler": "areal.infra.scheduler",
+    "StalenessManager": "areal.infra.staleness_manager",
+    "TrainController": "areal.infra.controller",
+    "WorkflowExecutor": "areal.infra.workflow_executor",
+    "check_trajectory_format": "areal.infra.workflow_executor",
+    "current_platform": "areal.infra.platforms",
+    "is_npu_available": "areal.infra.platforms",
+    "vLLMServerWrapper": "areal.infra.launcher",
+}
+
+
+def __getattr__(name: str):
+    if name == "workflow_context":
+        module = importlib.import_module("areal.infra.workflow_context")
+        globals()[name] = module
+        return module
+    if name in _LAZY_IMPORTS:
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(__all__)

--- a/areal/utils/testing_utils.py
+++ b/areal/utils/testing_utils.py
@@ -8,6 +8,7 @@ This module provides utilities that are shared between tests and profiling tools
 import asyncio
 import os
 import random
+from collections.abc import Iterator, Mapping
 from typing import Any
 
 import torch
@@ -21,6 +22,26 @@ from areal.utils import logging
 from areal.utils.save_load import get_state_dict_from_repo_id_or_path
 
 logger = logging.getLogger("TestingUtils")
+
+
+class _LazyModelPaths(Mapping[str, str]):
+    """Resolve model paths when a test actually requests them."""
+
+    def __init__(self, specs: Mapping[str, tuple[str, str]]):
+        self._specs = dict(specs)
+        self._resolved: dict[str, str] = {}
+
+    def __getitem__(self, key: str) -> str:
+        if key not in self._resolved:
+            local_path, hf_id = self._specs[key]
+            self._resolved[key] = get_model_path(local_path, hf_id)
+        return self._resolved[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._specs)
+
+    def __len__(self) -> int:
+        return len(self._specs)
 
 
 def get_model_path(local_path: str, hf_id: str) -> str:
@@ -85,48 +106,49 @@ def get_dataset_path(local_path: str, hf_id: str) -> str:
 
 
 # Model paths for testing (keyed by HF model_type)
-# Dense models (fast to instantiate even on meta device)
-DENSE_MODEL_PATHS = {
-    "qwen2": get_model_path(
+_DENSE_MODEL_SPECS = {
+    "qwen2": (
         "/storage/openpsi/models/Qwen__Qwen2.5-0.5B-Instruct/",
         "Qwen/Qwen2.5-0.5B-Instruct",
     ),
-    "qwen3": get_model_path(
+    "qwen3": (
         "/storage/openpsi/models/Qwen__Qwen3-0.6B/",
         "Qwen/Qwen3-0.6B",
     ),
-    "qwen3_5": get_model_path(
+    "qwen3_5": (
         "/storage/openpsi/models/Qwen__Qwen3.5-0.8B/",
         "Qwen/Qwen3.5-0.8B",
     ),
-    "qwen2_5_vl": get_model_path(
+    "qwen2_5_vl": (
         "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
         "Qwen/Qwen2.5-VL-3B-Instruct",
     ),
-    "qwen3_vl": get_model_path(
+    "qwen3_vl": (
         "/storage/openpsi/models/Qwen__Qwen3-VL-2B-Instruct/",
         "Qwen/Qwen3-VL-2B-Instruct",
     ),
 }
 
-# MoE models (slow to instantiate due to large number of experts)
-MOE_MODEL_PATHS = {
-    "qwen3_moe": get_model_path(
+_MOE_MODEL_SPECS = {
+    "qwen3_moe": (
         "/storage/openpsi/models/Qwen__Qwen3-30B-A3B/",
         "Qwen/Qwen3-30B-A3B",
     ),
-    "qwen3_5_moe": get_model_path(
+    "qwen3_5_moe": (
         "/storage/openpsi/models/Qwen__Qwen3.5-35B-A3B",
         "Qwen/Qwen3.5-35B-A3B",
     ),
-    "qwen3_vl_moe": get_model_path(
+    "qwen3_vl_moe": (
         "/storage/openpsi/models/Qwen__Qwen3-VL-30B-A3B-Instruct/",
         "Qwen/Qwen3-VL-30B-A3B-Instruct",
     ),
 }
 
-# Combined for backward compatibility
-MODEL_PATHS = {**DENSE_MODEL_PATHS, **MOE_MODEL_PATHS}
+DENSE_MODEL_PATHS: Mapping[str, str] = _LazyModelPaths(_DENSE_MODEL_SPECS)
+MOE_MODEL_PATHS: Mapping[str, str] = _LazyModelPaths(_MOE_MODEL_SPECS)
+MODEL_PATHS: Mapping[str, str] = _LazyModelPaths(
+    {**_DENSE_MODEL_SPECS, **_MOE_MODEL_SPECS}
+)
 
 
 def load_archon_model(

--- a/pyproject.npu.toml
+++ b/pyproject.npu.toml
@@ -226,13 +226,19 @@ filterwarnings = [
     "ignore::UserWarning:torch.*",
     "ignore::UserWarning:transformers.*",
 ]
+# Unmarked tests run in CPU CI. Add capability markers only when required.
 markers = [
     "slow: mark test as slow, expected to cost more than 30 seconds and will not run in CI by default.",
     "ci: mark test as must-run in CI (only marked for slow tests).",
     "gpu: mark test that uses a single GPU",
     "multi_gpu: mark test that uses more than one GPU",
+    "npu: mark test that requires a single Ascend NPU",
+    "multi_npu: mark test that requires multiple Ascend NPUs",
+    "cuda: mark test that requires CUDA-specific APIs or kernels",
+    "nccl: mark test with a hard-coded NVIDIA NCCL backend",
     "sglang: mark test that requires the SGLang inference backend",
     "vllm: mark test that requires the vLLM inference backend",
+    "integration: requires external services or credentials",
 ]
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,11 +286,16 @@ filterwarnings = [
     "ignore::UserWarning:torch.*",
     "ignore::UserWarning:transformers.*",
 ]
+# Unmarked tests run in CPU CI. Add capability markers only when required.
 markers = [
     "slow: mark test as slow, expected to cost more than 30 seconds and will not run in CI by default.",
     "ci: mark test as must-run in CI (only marked for slow tests).",
     "gpu: mark test that uses a single GPU",
     "multi_gpu: mark test that uses more than one GPU",
+    "npu: mark test that requires a single Ascend NPU",
+    "multi_npu: mark test that requires multiple Ascend NPUs",
+    "cuda: mark test that requires CUDA-specific APIs or kernels",
+    "nccl: mark test with a hard-coded NVIDIA NCCL backend",
     "sglang: mark test that requires the SGLang inference backend",
     "vllm: mark test that requires the vLLM inference backend",
     "integration: requires external services or credentials",

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -317,11 +317,16 @@ filterwarnings = [
     "ignore::UserWarning:torch.*",
     "ignore::UserWarning:transformers.*",
 ]
+# Unmarked tests run in CPU CI. Add capability markers only when required.
 markers = [
     "slow: mark test as slow, expected to cost more than 30 seconds and will not run in CI by default.",
     "ci: mark test as must-run in CI (only marked for slow tests).",
     "gpu: mark test that uses a single GPU",
     "multi_gpu: mark test that uses more than one GPU",
+    "npu: mark test that requires a single Ascend NPU",
+    "multi_npu: mark test that requires multiple Ascend NPUs",
+    "cuda: mark test that requires CUDA-specific APIs or kernels",
+    "nccl: mark test with a hard-coded NVIDIA NCCL backend",
     "sglang: mark test that requires the SGLang inference backend",
     "vllm: mark test that requires the vLLM inference backend",
     "integration: requires external services or credentials",

--- a/scripts/select_cpu_tests.py
+++ b/scripts/select_cpu_tests.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""List test modules that are safe to import in the CPU CI environment."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+NON_CPU_MARKERS = frozenset(
+    {
+        "cuda",
+        "integration",
+        "multi_npu",
+        "nccl",
+        "npu",
+        "sglang",
+        "vllm",
+    }
+)
+
+
+def _pytest_markers(node: ast.AST) -> set[str]:
+    markers: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Attribute):
+            continue
+        mark = child.value
+        if not isinstance(mark, ast.Attribute) or mark.attr != "mark":
+            continue
+        if isinstance(mark.value, ast.Name) and mark.value.id == "pytest":
+            markers.add(child.attr)
+    return markers
+
+
+def module_markers(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    markers: set[str] = set()
+    for statement in tree.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        if not any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in targets
+        ):
+            continue
+        markers.update(_pytest_markers(statement.value))
+    return markers
+
+
+def select_cpu_test_files(
+    tests_root: Path, ignored_paths: tuple[Path, ...] = ()
+) -> list[Path]:
+    ignored_paths = tuple(path.resolve() for path in ignored_paths)
+    selected: list[Path] = []
+    for path in sorted(tests_root.rglob("test_*.py")):
+        resolved_path = path.resolve()
+        if any(resolved_path.is_relative_to(ignored) for ignored in ignored_paths):
+            continue
+        if module_markers(path).isdisjoint(NON_CPU_MARKERS):
+            selected.append(path)
+    return selected
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests-root", type=Path, default=Path("tests"))
+    parser.add_argument("--ignore", action="append", type=Path, default=[])
+    args = parser.parse_args()
+
+    for path in select_cpu_test_files(args.tests_root, tuple(args.ignore)):
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/experimental/awex/test_awex_megatron_vllm_integration.py
+++ b/tests/experimental/awex/test_awex_megatron_vllm_integration.py
@@ -34,6 +34,13 @@ from areal.infra.utils.proc import kill_process_tree
 from areal.utils import network
 from areal.utils.pkg_version import is_available
 
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.multi_npu,
+    pytest.mark.npu,
+    pytest.mark.vllm,
+]
+
 IS_VLLM_INSTALLED = is_available("vllm")
 IS_AWEX_INSTALLED = is_available("awex")
 

--- a/tests/experimental/inference_service/test_controller_integration.py
+++ b/tests/experimental/inference_service/test_controller_integration.py
@@ -39,6 +39,7 @@ from tests.experimental.inference_service.integration_utils import (
 )
 
 SERVER_STARTUP_TIMEOUT = 180  # seconds
+pytestmark = pytest.mark.npu
 
 
 # =============================================================================

--- a/tests/experimental/inference_service/test_data_proxy_integration.py
+++ b/tests/experimental/inference_service/test_data_proxy_integration.py
@@ -24,6 +24,8 @@ from tests.utils import get_model_path
 from areal.api.cli_args import SGLangConfig
 from areal.utils import network
 
+pytestmark = pytest.mark.npu
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------

--- a/tests/experimental/inference_service/test_exact_token_contract_integration.py
+++ b/tests/experimental/inference_service/test_exact_token_contract_integration.py
@@ -31,6 +31,7 @@ from areal.utils.vision_canary import EXACT_TOKEN_REFUSAL
 LOCAL_MODEL_PATH = "/storage/openpsi/models/Qwen__Qwen3-VL-2B-Instruct/"
 HF_MODEL_ID = "Qwen/Qwen3-VL-2B-Instruct"
 SERVER_STARTUP_TIMEOUT = 300
+pytestmark = [pytest.mark.integration, pytest.mark.npu, pytest.mark.vllm]
 
 
 def _model_path() -> str:

--- a/tests/experimental/inference_service/test_examples.py
+++ b/tests/experimental/inference_service/test_examples.py
@@ -15,7 +15,12 @@ from areal.utils import logging
 
 logger = logging.getLogger("InferenceServiceExamples")
 
-pytestmark = pytest.mark.slow
+pytestmark = [
+    pytest.mark.multi_npu,
+    pytest.mark.npu,
+    pytest.mark.sglang,
+    pytest.mark.slow,
+]
 
 
 @pytest.mark.sglang

--- a/tests/experimental/inference_service/test_gateway_integration.py
+++ b/tests/experimental/inference_service/test_gateway_integration.py
@@ -31,6 +31,8 @@ from tests.utils import get_model_path
 from areal.api.cli_args import SGLangConfig
 from areal.utils import network
 
+pytestmark = pytest.mark.npu
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------

--- a/tests/experimental/openai/test_proxy_integration.py
+++ b/tests/experimental/openai/test_proxy_integration.py
@@ -23,7 +23,7 @@ from areal.infra.scheduler.local import LocalScheduler
 from areal.infra.utils.proc import kill_process_tree
 from areal.utils import network, seeding
 
-pytestmark = pytest.mark.sglang
+pytestmark = [pytest.mark.cuda, pytest.mark.sglang]
 # =============================================================================
 # Test Configuration
 # =============================================================================

--- a/tests/experimental/training_service/test_controller_integration.py
+++ b/tests/experimental/training_service/test_controller_integration.py
@@ -25,10 +25,10 @@ from areal.infra.scheduler.local import LocalScheduler
 LOCAL_MODEL_PATH = "/storage/openpsi/models/Qwen__Qwen3-0.6B/"
 LOCAL_MOE_MODEL_PATH = "/storage/openpsi/models/Qwen__Qwen3-30B-A3B/"
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="CUDA not available",
-)
+pytestmark = [
+    pytest.mark.cuda,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),
+]
 
 
 def _resolve_model_path_or_skip() -> str:

--- a/tests/experimental/weight_update/conftest.py
+++ b/tests/experimental/weight_update/conftest.py
@@ -1,48 +1,6 @@
-"""Pre-import hook for Python < 3.12 compatibility.
+"""Package marker for the weight-update tests.
 
-The top-level ``areal/__init__.py`` imports from modules that use PEP 695 syntax
-(``def func[T](...)``) which is only valid on Python 3.12+. When running tests on
-Python 3.10/3.11 we register lightweight stubs for the ``areal`` namespace packages
-so that importing ``areal.experimental.weight_update.*`` never triggers the
-problematic top-level init.
+This previously registered namespace stubs on Python 3.11 to avoid PEP 695
+syntax that has since been removed. Loading the real package keeps shared test
+sessions consistent with production imports.
 """
-
-from __future__ import annotations
-
-import os
-import sys
-import types
-
-_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-
-_STUB_PACKAGES = [
-    ("areal", os.path.join(_REPO_ROOT, "areal")),
-    ("areal.experimental", os.path.join(_REPO_ROOT, "areal", "experimental")),
-    (
-        "areal.experimental.weight_update",
-        os.path.join(_REPO_ROOT, "areal", "experimental", "weight_update"),
-    ),
-]
-
-
-def _ensure_namespace_stubs():
-    """Insert namespace-style modules for ``areal`` ancestors with real paths."""
-    for name, path in _STUB_PACKAGES:
-        if name not in sys.modules:
-            mod = types.ModuleType(name)
-            mod.__path__ = [path]
-            mod.__package__ = name
-            sys.modules[name] = mod
-
-    for name, _path in _STUB_PACKAGES:
-        parts = name.rsplit(".", 1)
-        if len(parts) == 2:
-            parent_name, child_attr = parts
-            parent = sys.modules.get(parent_name)
-            child = sys.modules.get(name)
-            if parent is not None and child is not None:
-                setattr(parent, child_attr, child)
-
-
-if sys.version_info < (3, 12):
-    _ensure_namespace_stubs()

--- a/tests/experimental/weight_update/test_disk_integration.py
+++ b/tests/experimental/weight_update/test_disk_integration.py
@@ -286,6 +286,7 @@ class TestDiskDisconnect:
 
 
 @pytest.mark.multi_gpu
+@pytest.mark.cuda
 @pytest.mark.slow
 @pytest.mark.sglang
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/experimental/weight_update/test_nccl_integration.py
+++ b/tests/experimental/weight_update/test_nccl_integration.py
@@ -12,9 +12,11 @@ from areal.infra.platforms import current_platform
 from areal.infra.utils.proc import kill_process_tree
 from areal.utils.network import find_free_ports
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA not available"
-)
+pytestmark = [
+    pytest.mark.cuda,
+    pytest.mark.nccl,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),
+]
 
 # Project root so that torchrun workers can resolve `from tests.*` imports.
 # pytest adds "." via pyproject.toml `pythonpath`, but subprocesses don't inherit that.

--- a/tests/experimental/weight_update/test_sglang_integration.py
+++ b/tests/experimental/weight_update/test_sglang_integration.py
@@ -22,6 +22,7 @@ import torch
 from areal.utils.network import find_free_ports
 
 pytestmark = [
+    pytest.mark.cuda,
     pytest.mark.slow,
     pytest.mark.sglang,
     pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),

--- a/tests/fp8/test_fp8_bf16_comparison.py
+++ b/tests/fp8/test_fp8_bf16_comparison.py
@@ -36,6 +36,8 @@ from tests.utils import get_model_path
 from areal.infra.platforms import current_platform
 from areal.utils import logging
 
+pytestmark = pytest.mark.cuda
+
 MODEL_PATH_BF16 = get_model_path(
     "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"
 )

--- a/tests/fp8/test_fp8_conversion.py
+++ b/tests/fp8/test_fp8_conversion.py
@@ -12,6 +12,7 @@ from areal.infra.platforms import current_platform
 from areal.utils import logging
 
 logger = logging.getLogger("Test FP8 Conversion")
+pytestmark = pytest.mark.cuda
 
 try:
     import transformer_engine.pytorch as te

--- a/tests/fp8/test_fp8_rmsnorm.py
+++ b/tests/fp8/test_fp8_rmsnorm.py
@@ -26,6 +26,7 @@ from areal.engine import MegatronEngine
 from areal.utils import logging
 
 logger = logging.getLogger("FP8 BF16 RMSNorm Test")
+pytestmark = pytest.mark.cuda
 
 MODEL_PATH_BF16 = get_model_path(
     "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"

--- a/tests/fp8/test_fp8_tensor.py
+++ b/tests/fp8/test_fp8_tensor.py
@@ -3,6 +3,8 @@ import torch
 
 from areal.engine.megatron_utils.fp8 import FP8BlockwiseTensorHelper
 
+pytestmark = pytest.mark.npu
+
 
 @pytest.fixture(scope="module")
 def device():

--- a/tests/grpo/test_grpo.py
+++ b/tests/grpo/test_grpo.py
@@ -12,6 +12,8 @@ from tests.utils import get_dataset_path, get_model_path
 
 from areal.api.cli_args import GRPOConfig, load_expr_config
 
+pytestmark = pytest.mark.npu
+
 # Each (training_backend, inference_backend) pair and its pytest mark.
 _SGLANG_CASES = [
     pytest.param("fsdp", "sglang", id="fsdp-sglang", marks=pytest.mark.sglang),

--- a/tests/sft/test_sft.py
+++ b/tests/sft/test_sft.py
@@ -11,6 +11,8 @@ from tests.utils import get_dataset_path, get_model_path
 
 from areal.api.cli_args import SFTConfig, load_expr_config
 
+pytestmark = pytest.mark.npu
+
 
 @pytest.mark.parametrize(
     ("backend", "v2"),

--- a/tests/test_cuda_deterministic.py
+++ b/tests/test_cuda_deterministic.py
@@ -15,6 +15,8 @@ import pytest
 import torch
 import torch.nn as nn
 
+pytestmark = pytest.mark.cuda
+
 CUDA_AVAILABLE = torch.cuda.is_available()
 GROUPED_MM_AVAILABLE = hasattr(torch, "_grouped_mm")
 

--- a/tests/test_data_redistribution.py
+++ b/tests/test_data_redistribution.py
@@ -10,6 +10,8 @@ from areal.infra.platforms import current_platform
 from areal.utils.environ import is_in_ci
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.nccl
+
 
 def assert_tensor_container_close(x1, x2):
     assert type(x1) is type(x2), (type(x1), type(x2))

--- a/tests/test_dynamic_import.py
+++ b/tests/test_dynamic_import.py
@@ -1,32 +1,8 @@
-import subprocess
-import sys
 from unittest.mock import patch
 
 import pytest
 
 from areal.utils.dynamic_import import import_from_string
-
-
-def test_importing_infra_platforms_does_not_load_controllers():
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import importlib, sys, areal; "
-                "[sys.modules.pop(name) for name in tuple(sys.modules) "
-                "if name == 'areal.infra' or name.startswith('areal.infra.')]; "
-                "areal.__dict__.pop('infra', None); "
-                "importlib.import_module('areal.infra.platforms'); "
-                "assert 'areal.infra.controller' not in sys.modules"
-            ),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stderr
 
 
 class TestImportFromString:

--- a/tests/test_dynamic_import.py
+++ b/tests/test_dynamic_import.py
@@ -1,8 +1,32 @@
+import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
 
 from areal.utils.dynamic_import import import_from_string
+
+
+def test_importing_infra_platforms_does_not_load_controllers():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib, sys, areal; "
+                "[sys.modules.pop(name) for name in tuple(sys.modules) "
+                "if name == 'areal.infra' or name.startswith('areal.infra.')]; "
+                "areal.__dict__.pop('infra', None); "
+                "importlib.import_module('areal.infra.platforms'); "
+                "assert 'areal.infra.controller' not in sys.modules"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 class TestImportFromString:

--- a/tests/test_estimate_num_params.py
+++ b/tests/test_estimate_num_params.py
@@ -14,6 +14,8 @@ from areal.engine.megatron_utils.pipeline_parallel import (
 from areal.models.mcore.registry import make_hf_and_mcore_config
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.npu
+
 
 @pytest.mark.parametrize(
     "model_name_or_path",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("TestExamples")
 
 SUCCESS_PATTERN = re.compile(r"Epoch 1/\d+ Step 1/\d+ Train step 1/\d+ done\.")
 
-pytestmark = pytest.mark.slow
+pytestmark = [pytest.mark.npu, pytest.mark.slow]
 
 
 async def run_example(

--- a/tests/test_fsdp_dcp.py
+++ b/tests/test_fsdp_dcp.py
@@ -6,6 +6,8 @@ from areal.api.alloc_mode import ModelAllocation
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = [pytest.mark.npu, pytest.mark.multi_npu]
+
 
 def _run_test_with_torchrun(test_type: str, alloc_mode: str, output: str):
     port = find_free_ports(1)[0]

--- a/tests/test_fsdp_engine_nccl.py
+++ b/tests/test_fsdp_engine_nccl.py
@@ -15,7 +15,7 @@ from areal.api.cli_args import (
 from areal.engine import FSDPEngine, RemoteSGLangEngine
 from areal.utils import network
 
-pytestmark = pytest.mark.sglang
+pytestmark = [pytest.mark.nccl, pytest.mark.sglang]
 EXPR_NAME = "test_fsdp_engine_nccl"
 TRIAL_NAME = "trial_nccl"
 MODEL_PATH = get_model_path(

--- a/tests/test_fsdp_grad.py
+++ b/tests/test_fsdp_grad.py
@@ -147,6 +147,7 @@ class TestGetGradNormFp32:
             f"norm_type={norm_type}: {result} != {expected}"
         )
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     @pytest.mark.parametrize("norm_type", [1.0, 2.0, 3.0, float("inf")])
     def test_norm_types_gpu_no_offload(self, mock_process_groups, norm_type):
@@ -170,6 +171,7 @@ class TestGetGradNormFp32:
             f"norm_type={norm_type}: {result} != {expected}"
         )
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_offload_vs_non_offload_consistency_l2(self, mock_process_groups):
         """Test that offload and non-offload paths produce consistent L2 norm results."""
@@ -190,6 +192,7 @@ class TestGetGradNormFp32:
 
         assert abs(result_offload - result_no_offload) < 1e-4
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_offload_vs_non_offload_consistency_inf(self, mock_process_groups):
         """Test that offload and non-offload paths produce consistent inf norm results."""
@@ -292,6 +295,7 @@ class TestClipGradByTotalNormFp32:
         new_norm = compute_expected_grad_norm(list(model.parameters()), norm_type=2.0)
         assert new_norm < original_norm
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_clipping_reduces_grad_magnitude_gpu(self):
         """Test that clipping reduces gradient magnitude when norm exceeds max (GPU)."""
@@ -338,6 +342,7 @@ class TestClipGradByTotalNormFp32:
                 expected = original_grads[name] * expected_scale
                 assert torch.allclose(param.grad, expected, atol=1e-6)
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_clip_coefficient_applied_correctly_gpu(self):
         """Test that the clip coefficient is applied correctly (GPU)."""
@@ -382,6 +387,7 @@ class TestClipGradByTotalNormFp32:
             offload_params=True,
         )
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_offload_vs_non_offload_clipping_consistency(self):
         """Test that CPU and GPU paths produce same clipping results."""
@@ -454,6 +460,7 @@ class TestIntegration:
             expected_ratio = max_norm / (total_norm + 1e-6)
             assert abs(new_norm - total_norm * expected_ratio) < 1e-4
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_compute_and_clip_workflow_gpu(self):
         """Test the complete workflow of computing norm and clipping (GPU)."""
@@ -485,6 +492,7 @@ class TestIntegration:
             expected_ratio = max_norm / (total_norm + 1e-6)
             assert abs(new_norm - total_norm * expected_ratio) < 1e-4
 
+    @pytest.mark.cuda
     @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
     def test_cpu_gpu_consistency_end_to_end(self):
         """Test that CPU and GPU paths produce consistent results end-to-end."""

--- a/tests/test_fsdp_memory_efficient_lora.py
+++ b/tests/test_fsdp_memory_efficient_lora.py
@@ -6,6 +6,8 @@ from areal.api.alloc_mode import ModelAllocation
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.npu
+
 
 def _run_test_with_torchrun(alloc_mode: str, output: str):
     port = find_free_ports(1)[0]

--- a/tests/test_fsdp_optimizer_dtype.py
+++ b/tests/test_fsdp_optimizer_dtype.py
@@ -17,6 +17,8 @@ import pytest
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.nccl
+
 
 def _run_with_torchrun(n_gpus: int, dtype: str, optimizer_dtype: str) -> None:
     port = find_free_ports(1)[0]

--- a/tests/test_fsdp_ulysses_forward.py
+++ b/tests/test_fsdp_ulysses_forward.py
@@ -5,6 +5,8 @@ import pytest
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.nccl
+
 
 def _run_test_with_torchrun(n_gpus: int):
     port = find_free_ports(1)[0]

--- a/tests/test_fsdp_ulysses_train_batch.py
+++ b/tests/test_fsdp_ulysses_train_batch.py
@@ -5,6 +5,8 @@ import pytest
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.nccl
+
 
 def _run_test_with_torchrun(n_gpus: int):
     port = find_free_ports(1)[0]

--- a/tests/test_inference_engines.py
+++ b/tests/test_inference_engines.py
@@ -19,6 +19,8 @@ from areal.utils.data import concat_padded_tensors, get_batch_size
 from areal.utils.hf_utils import load_hf_tokenizer
 from areal.utils.pkg_version import is_available
 
+pytestmark = pytest.mark.npu
+
 MODEL_PATH = get_model_path(
     "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"
 )
@@ -38,11 +40,11 @@ def _dummy_reward_fn(*args, **kwargs):
         pytest.param({"backend": "sglang", "method": "init"}, marks=pytest.mark.sglang),
         pytest.param(
             {"backend": "vllm", "method": "from_pretrained"},
-            marks=pytest.mark.vllm_from_pretrained,
+            marks=pytest.mark.vllm,
         ),
         pytest.param(
             {"backend": "sglang", "method": "from_pretrained"},
-            marks=pytest.mark.sglang_from_pretrained,
+            marks=pytest.mark.sglang,
         ),
     ],
     scope="module",

--- a/tests/test_kk_e2e.py
+++ b/tests/test_kk_e2e.py
@@ -21,6 +21,8 @@ import pytest
 
 from areal.infra.platforms import current_platform
 
+pytestmark = pytest.mark.nccl
+
 # Path to the torchrun worker script
 WORKER_SCRIPT = os.path.join(os.path.dirname(__file__), "torchrun", "run_kk_vs_ffd.py")
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -49,6 +49,7 @@ def test_distributed_lock_single_rank(world_size):
 
 
 @pytest.mark.multi_gpu
+@pytest.mark.multi_npu
 @pytest.mark.parametrize("world_size", [2])
 def test_distributed_lock_multi_rank(world_size):
     _run_lock_test(world_size)

--- a/tests/test_megatron_engine.py
+++ b/tests/test_megatron_engine.py
@@ -22,6 +22,7 @@ from areal.infra.platforms import current_platform
 from areal.utils import logging
 
 logger = logging.getLogger("TestMegatronEngine")
+pytestmark = pytest.mark.npu
 
 VOCAB_SIZE = 100
 MODEL_PATH = get_model_path(

--- a/tests/test_megatron_engine_distributed.py
+++ b/tests/test_megatron_engine_distributed.py
@@ -7,6 +7,8 @@ from areal.api.alloc_mode import ModelAllocation
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = [pytest.mark.npu, pytest.mark.multi_npu]
+
 
 def _run_test_with_torchrun(
     model_type: str, alloc_mode: str, test_type: str, output: str, vpp_size: int = 1

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -15,6 +15,8 @@ import torch
 class TestUnwrapToGptModel:
     """Test unwrap_to_gpt_model with VLM model structures."""
 
+    pytestmark = pytest.mark.npu
+
     def test_plain_gpt_model_unwraps(self):
         """Plain GPTModel (no wrapping) should return itself."""
         from megatron.core.models.gpt.gpt_model import GPTModel
@@ -94,6 +96,8 @@ class TestUnwrapToGptModel:
 
 class TestExtractVisionFromMultiModal:
     """Test _extract_vision_from_multi_modal helper."""
+
+    pytestmark = pytest.mark.npu
 
     def test_extracts_pixel_values_and_grid(self):
         """Vision tensors should land on padded_mb only, not duplicated on mb."""
@@ -215,6 +219,8 @@ class TestPrepareMbListRebindCallerSafety:
     instead — this test pins that contract.
     """
 
+    pytestmark = pytest.mark.npu
+
     def test_rebind_does_not_mutate_caller_input(self):
         from areal.engine.megatron_utils.packed_context_parallel import (
             _is_multi_modal_payload_key,
@@ -300,6 +306,8 @@ class TestVisionModelDetection:
 
 class TestConvertQwen25VLToHF:
     """Test mcore→HF weight name conversion for Qwen2.5-VL."""
+
+    pytestmark = pytest.mark.npu
 
     @pytest.fixture()
     def tf_config(self):
@@ -526,6 +534,8 @@ class TestConvertQwen25VLToHF:
 
 class TestConvertQwen3VLToHF:
     """Test mcore→HF weight name conversion for Qwen3-VL (dense)."""
+
+    pytestmark = pytest.mark.npu
 
     @pytest.fixture()
     def tf_config(self):
@@ -958,6 +968,8 @@ class TestConvertQwen3VLMoEToHF:
     regression guards.
     """
 
+    pytestmark = pytest.mark.npu
+
     @pytest.fixture()
     def tf_config(self):
         """Mock TransformerConfig matching Qwen/Qwen3-VL-30B-A3B-Instruct text_config:
@@ -1224,6 +1236,8 @@ class TestConvertQwen3VLMoEToHF:
 
 class TestRemovePaddingVLM:
     """Test remove_padding handles VLM language_model prefixed params."""
+
+    pytestmark = pytest.mark.npu
 
     def test_vlm_embedding_padding_removed(self):
         """VLM language_model embedding should be trimmed to vocab_size."""

--- a/tests/test_megatron_engine_vlm_distributed.py
+++ b/tests/test_megatron_engine_vlm_distributed.py
@@ -28,6 +28,8 @@ from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 from areal.utils.testing_utils import DENSE_MODEL_PATHS, MOE_MODEL_PATHS
 
+pytestmark = [pytest.mark.npu, pytest.mark.multi_npu]
+
 _TORCHRUN_SCRIPT = (
     pathlib.Path(__file__).parent
     / "torchrun"

--- a/tests/test_mixed_multimodal_batch_megatron.py
+++ b/tests/test_mixed_multimodal_batch_megatron.py
@@ -21,6 +21,8 @@ import torch
 
 from areal.utils.data import concat_padded_tensors
 
+pytestmark = pytest.mark.npu
+
 
 def _vision_row(seq_len: int = 5, n_patches: int = 4) -> dict:
     return {

--- a/tests/test_model_packed_seq_cp.py
+++ b/tests/test_model_packed_seq_cp.py
@@ -30,6 +30,8 @@ from areal.engine.core.model import (
 )
 from areal.engine.megatron_utils import packed_context_parallel as packed_cp
 
+pytestmark = pytest.mark.npu
+
 
 class _RecordingModel(torch.nn.Module):
     def __init__(self, output: torch.Tensor):

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -19,6 +19,8 @@ from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 from areal.utils.offload import get_tms_env_vars
 
+pytestmark = pytest.mark.npu
+
 MODEL_PATH = get_model_path(
     "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"
 )

--- a/tests/test_packed_vs_padded_consistency.py
+++ b/tests/test_packed_vs_padded_consistency.py
@@ -16,6 +16,8 @@ from areal.utils.hf_utils import load_hf_processor_and_tokenizer
 from areal.utils.network import find_free_ports
 from areal.utils.seeding import set_random_seed
 
+pytestmark = pytest.mark.npu
+
 BS = 4
 MAX_ANSWER_LEN = 16
 MAX_PROMPT_LEN = 8

--- a/tests/test_per_layer_optim_step.py
+++ b/tests/test_per_layer_optim_step.py
@@ -16,6 +16,8 @@ from areal.engine.fsdp_utils import PerLayerOptimWrapper, apply_fsdp2
 from areal.engine.fsdp_utils.grad import fsdp2_clip_grad_norm
 from areal.engine.fsdp_utils.optimizer import _get_local_tensor
 
+pytestmark = [pytest.mark.cuda, pytest.mark.nccl]
+
 CUDA_AVAILABLE = torch.cuda.is_available()
 
 

--- a/tests/test_perf_tracer.py
+++ b/tests/test_perf_tracer.py
@@ -581,6 +581,7 @@ def _run_perf_tracer_torchrun(tmp_path: Path, world_size: int) -> None:
 
 
 @pytest.mark.multi_gpu
+@pytest.mark.multi_npu
 @pytest.mark.parametrize("world_size", [2])
 def test_perf_tracer_torchrun_multi_rank(tmp_path, world_size):
     device_count_fn = getattr(current_platform, "device_count", None)

--- a/tests/test_select_cpu_tests.py
+++ b/tests/test_select_cpu_tests.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.select_cpu_tests import module_markers, select_cpu_test_files
+
+
+def _write_test(path: Path, source: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_module_markers_reads_single_and_list_assignments(tmp_path: Path):
+    test_file = _write_test(
+        tmp_path / "test_markers.py",
+        """
+import pytest
+
+pytestmark = [pytest.mark.slow, pytest.mark.multi_npu]
+pytestmark = pytest.mark.vllm
+""",
+    )
+
+    assert module_markers(test_file) == {"multi_npu", "slow", "vllm"}
+
+
+def test_select_cpu_test_files_keeps_unmarked_and_slow_modules(tmp_path: Path):
+    unmarked = _write_test(tmp_path / "test_unmarked.py", "def test_cpu(): pass\n")
+    slow = _write_test(
+        tmp_path / "test_slow.py",
+        "import pytest\npytestmark = pytest.mark.slow\ndef test_cpu(): pass\n",
+    )
+
+    assert select_cpu_test_files(tmp_path) == [slow, unmarked]
+
+
+@pytest.mark.parametrize("marker", ["npu", "multi_npu", "cuda", "nccl"])
+def test_select_cpu_test_files_excludes_hardware_modules(tmp_path: Path, marker: str):
+    _write_test(
+        tmp_path / f"test_{marker}.py",
+        f"import pytest\npytestmark = pytest.mark.{marker}\ndef test_device(): pass\n",
+    )
+
+    assert select_cpu_test_files(tmp_path) == []
+
+
+def test_select_cpu_test_files_does_not_use_function_markers_for_import_filtering(
+    tmp_path: Path,
+):
+    mixed = _write_test(
+        tmp_path / "test_mixed.py",
+        """
+import pytest
+
+def test_cpu(): pass
+
+@pytest.mark.npu
+def test_npu(): pass
+""",
+    )
+
+    assert select_cpu_test_files(tmp_path) == [mixed]
+
+
+def test_select_cpu_test_files_does_not_route_legacy_gpu_marker(tmp_path: Path):
+    legacy = _write_test(
+        tmp_path / "test_legacy.py",
+        "import pytest\npytestmark = pytest.mark.multi_gpu\ndef test_device(): pass\n",
+    )
+
+    assert select_cpu_test_files(tmp_path) == [legacy]
+
+
+def test_select_cpu_test_files_ignores_requested_tree(tmp_path: Path):
+    ignored = tmp_path / "ignored"
+    _write_test(ignored / "test_archon.py", "def test_archon(): pass\n")
+    selected = _write_test(tmp_path / "test_selected.py", "def test_cpu(): pass\n")
+
+    assert select_cpu_test_files(tmp_path, (ignored,)) == [selected]

--- a/tests/test_sglang_lora_unload.py
+++ b/tests/test_sglang_lora_unload.py
@@ -6,8 +6,12 @@ never unloads old versions, so sglang accumulates adapters until it hangs
 version that falls outside the retention window (kept for off-policy rollouts).
 """
 
+import pytest
+
 from areal.api.io_struct import WeightUpdateMeta
 from areal.engine.sglang_remote import SGLangBackend
+
+pytestmark = pytest.mark.sglang
 
 
 def _lora_meta(version, keep, lora_name="lora-gsm8k", path="/tmp/wu"):

--- a/tests/test_sglang_pp_distributed.py
+++ b/tests/test_sglang_pp_distributed.py
@@ -36,6 +36,7 @@ from areal.utils import logging
 from areal.utils.network import find_free_ports
 
 logger = logging.getLogger("TestSglangPPDistributed")
+pytestmark = [pytest.mark.nccl, pytest.mark.sglang]
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/tests/test_sglang_pp_unit.py
+++ b/tests/test_sglang_pp_unit.py
@@ -20,6 +20,8 @@ from areal.api.alloc_mode import (
 from areal.api.io_struct import WeightUpdateMeta
 from areal.engine.sglang_remote import SGLangBackend
 
+pytestmark = pytest.mark.sglang
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -1,0 +1,25 @@
+from areal.utils import testing_utils
+
+
+def test_lazy_model_paths_resolve_only_requested_key(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def resolve(local_path: str, hf_id: str) -> str:
+        calls.append((local_path, hf_id))
+        return f"resolved/{hf_id}"
+
+    monkeypatch.setattr(testing_utils, "get_model_path", resolve)
+    paths = testing_utils._LazyModelPaths(
+        {
+            "first": ("local/first", "org/first"),
+            "second": ("local/second", "org/second"),
+        }
+    )
+
+    assert list(paths) == ["first", "second"]
+    assert len(paths) == 2
+    assert calls == []
+
+    assert paths["second"] == "resolved/org/second"
+    assert paths["second"] == "resolved/org/second"
+    assert calls == [("local/second", "org/second")]

--- a/tests/test_train_engine.py
+++ b/tests/test_train_engine.py
@@ -22,6 +22,8 @@ from areal.api.cli_args import (
 from areal.engine.fsdp_utils.attn_impl import BUILTIN_ATTN_IMPLS
 from areal.infra.platforms import current_platform
 
+pytestmark = pytest.mark.npu
+
 VOCAB_SIZE = 100
 MODEL_PATH = get_model_path(
     "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"

--- a/tests/test_tree_training.py
+++ b/tests/test_tree_training.py
@@ -21,6 +21,7 @@ from areal.models.tree_attn.triton_kernel import TRITON_AVAILABLE
 from areal.utils import logging
 
 logger = logging.getLogger("TreeTraining Test")
+pytestmark = pytest.mark.npu
 
 
 MODEL_PATH = get_model_path(

--- a/tests/test_ulysses.py
+++ b/tests/test_ulysses.py
@@ -5,6 +5,8 @@ import pytest
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = [pytest.mark.npu, pytest.mark.multi_npu]
+
 
 def _run_test_with_torchrun(world_size):
     port = find_free_ports(1)[0]

--- a/tests/test_ulysses_all_to_all.py
+++ b/tests/test_ulysses_all_to_all.py
@@ -13,6 +13,8 @@ import pytest
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = pytest.mark.nccl
+
 
 def _run_test_with_torchrun(world_size: int, test_name: str):
     port = find_free_ports(1)[0]
@@ -55,6 +57,7 @@ def test_ulysses_all_to_all_backward(world_size):
 
 
 @pytest.mark.multi_gpu
+@pytest.mark.cuda
 @pytest.mark.parametrize("world_size", [2])
 def test_ulysses_all_to_all_compile(world_size):
     """Test torch.compile compatibility (no graph breaks)."""

--- a/tests/test_vocab_parallel.py
+++ b/tests/test_vocab_parallel.py
@@ -5,6 +5,8 @@ import pytest
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 
+pytestmark = [pytest.mark.npu, pytest.mark.multi_npu]
+
 
 def _run_test_with_torchrun(world_size: int):
     """Run tensor parallel tests with torchrun."""


### PR DESCRIPTION
## Description

Replace the hard-coded CPU test lists in Ascend PR CI with automatic module discovery. Unmarked tests run in CPU CI by default, while modules requiring NPU, CUDA/NCCL, vLLM/SGLang, or external integration systems are classified by capability markers. Model test paths are resolved lazily so CPU collection does not trigger artifact downloads.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable)
- [x] Branch is up to date with `ascend`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

The generated selection was qualified on node09 with AReaL forced to `CpuPlatform`: 2,299 passed, 112 skipped, and 104 capability-marked tests deselected in 4m34.93s. This validates the selected CPU paths inside the Ascend image but is not a substitute for the clean Ubuntu CPU job that this PR will trigger. `tests/experimental/archon` remains outside this gate.

______________________________________________________________________

**Need help?** Check the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md) or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
