### PR TITLE
fix(infra): prevent leaks after RTensor delete failures

### DIFF
--- a/.github/workflows/ascend-pr-tests.yml
+++ b/.github/workflows/ascend-pr-tests.yml
@@ -224,9 +224,12 @@ jobs:
             --step-summary "${GITHUB_STEP_SUMMARY}"
           )
           if [[ -d /tmp/base-cpu-test-reports ]]; then
+            git diff --name-only "${CPU_TEST_BASE_SHA}" HEAD -- tests \
+              > /tmp/changed-cpu-test-files.txt
             report_args+=(
               --base /tmp/base-cpu-test-reports
               --base-sha "${CPU_TEST_BASE_SHA}"
+              --changed-test-files /tmp/changed-cpu-test-files.txt
             )
           fi
           uv run python scripts/ci_test_report.py summarize "${report_args[@]}"
@@ -279,41 +282,54 @@ jobs:
           trap cleanup EXIT
 
           cp scripts/ci_test_report.py "${plugin_dir}/ci_test_report.py"
-          git archive "${NPU_TEST_BASE_SHA}" | tar -x -C "${base_dir}"
+          git -c safe.directory="${GITHUB_WORKSPACE}" \
+            archive "${NPU_TEST_BASE_SHA}" | tar -x -C "${base_dir}"
+          : > /tmp/unavailable-base-npu-test-files.txt
 
-          npu_test_files=(
-            tests/test_lock.py
-            tests/test_megatron_engine_distributed.py
-            tests/test_megatron_engine_vlm.py
-            tests/test_model_packed_seq_cp.py
-            tests/test_perf_tracer.py
-            tests/test_reassemble_cp_logprobs.py
-            tests/test_ulysses.py
-            tests/test_vocab_parallel.py
-          )
-          base_test_files=()
-          for test_file in "${npu_test_files[@]}"; do
-            if [[ -f "${base_dir}/${test_file}" ]]; then
-              base_test_files+=("${test_file}")
+          collect_base_tests() {
+            local name="$1"
+            local status
+            local test_file="${!#}"
+            shift
+
+            if [[ ! -f "${base_dir}/${test_file}" ]]; then
+              echo "Base test file does not exist: ${test_file}"
+              return 0
             fi
-          done
 
-          if [[ "${#base_test_files[@]}" -eq 0 ]]; then
-            echo "No NPU test files exist at the base commit"
-            exit 0
-          fi
+            set +e
+            (
+              cd "${base_dir}"
+              PYTHONPATH="${plugin_dir}:${base_dir}" \
+                python -m pytest -q \
+                --collect-only \
+                -p ci_test_report \
+                "$@"
+            ) > "/tmp/base-npu-${name}.log" 2>&1
+            status=$?
+            set -e
 
-          (
-            cd "${base_dir}"
-            PYTHONPATH="${plugin_dir}:${base_dir}" \
-              python -m pytest -q \
-              --collect-only \
-              -p ci_test_report \
-              "${base_test_files[@]}"
-          ) > /tmp/base-npu-collection.log 2>&1 || {
-            cat /tmp/base-npu-collection.log
-            exit 1
+            if [[ "${status}" -ne 0 ]]; then
+              printf '%s\n' "${test_file}" \
+                >> /tmp/unavailable-base-npu-test-files.txt
+              echo "::warning title=Base NPU inventory unavailable::${test_file} exited with status ${status}"
+              tail -n 40 "/tmp/base-npu-${name}.log"
+            fi
           }
+
+          collect_base_tests megatron-vlm \
+            --deselect tests/test_megatron_engine_vlm.py::TestVisionModelDetection \
+            tests/test_megatron_engine_vlm.py
+          collect_base_tests model-packed-seq-cp \
+            tests/test_model_packed_seq_cp.py
+          collect_base_tests reassemble-cp-logprobs \
+            -m skipif tests/test_reassemble_cp_logprobs.py
+          collect_base_tests megatron-distributed \
+            tests/test_megatron_engine_distributed.py
+          collect_base_tests lock tests/test_lock.py
+          collect_base_tests perf-tracer tests/test_perf_tracer.py
+          collect_base_tests ulysses tests/test_ulysses.py
+          collect_base_tests vocab-parallel tests/test_vocab_parallel.py
 
       - name: Verify NPU runtime
         run: |
@@ -672,10 +688,15 @@ jobs:
             --step-summary "${GITHUB_STEP_SUMMARY}"
           )
           if [[ -d /tmp/base-npu-test-reports ]]; then
+            git -c safe.directory="${GITHUB_WORKSPACE}" \
+              diff --name-only "${NPU_TEST_BASE_SHA}" HEAD -- tests \
+              > /tmp/changed-npu-test-files.txt
             report_args+=(
               --base /tmp/base-npu-test-reports
               --base-sha "${NPU_TEST_BASE_SHA}"
               --base-is-inventory
+              --changed-test-files /tmp/changed-npu-test-files.txt
+              --unavailable-base-test-files /tmp/unavailable-base-npu-test-files.txt
             )
           fi
           python scripts/ci_test_report.py summarize "${report_args[@]}"

--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+from threading import Lock
 from typing import Any
 
 import torch
@@ -20,7 +21,7 @@ from areal.api import (
 )
 from areal.api.alloc_mode import ModelAllocation
 from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
-from areal.infra.rpc.rtensor import RTensor, flatten_shard_ids
+from areal.infra.rpc.rtensor import RTensor
 from areal.infra.utils.concurrent import run_async_task
 from areal.utils import logging, stats_tracker
 from areal.utils.data import make_dummy_eval_item
@@ -31,6 +32,8 @@ from .rollout_callback import RolloutCallback
 from .rollout_controller import RolloutController
 
 logger = logging.getLogger("TrainController")
+
+_MAX_CLEAR_STEP_FAILURES = 2
 
 
 def _find_in_structure(obj: Any, type_: type) -> Any | None:
@@ -206,6 +209,9 @@ class TrainController:
 
         self._worker_role: str = "default"
         self._own_process_group = False
+        self._pending_clear_shards: dict[Any, dict[Any, int]] = {}
+        self._clear_shards_lock = Lock()
+        self._clear_batches_lock = Lock()
 
         self.rollout: RolloutController = None
 
@@ -792,23 +798,113 @@ class TrainController:
                 " before using rollout/update_weight methods."
             )
 
-    async def _async_clear_batches(self, *targets: dict[str, RTensor]):
-        """Extract shard IDs and clear tensors on each worker.
+    async def _async_clear_batches(
+        self, *targets: dict[str, RTensor]
+    ) -> tuple[list[Any], dict[Any, list[Any]]]:
+        """Extract shard IDs and stage storage cleanup results.
 
         HTTP DELETEs to each storage node's ``/data/clear`` — this evicts
         ``_storage`` (mandatory, otherwise HTTP storage grows unboundedly)
         and, via :func:`rtensor.remove`, also pops the storage owner's own
-        ``_fetch_buffer`` (covers storage-owner-as-consumer). See #1209.
+        ``_fetch_buffer`` (covers storage-owner-as-consumer). Failed shards
+        remain pending for one cross-step retry. Exhausted shards stay pending
+        until consumer-worker buffers are drained, so a worker RPC failure
+        cannot lose the storage-leak state. See #1209 and #1581.
         """
         shards_by_node = RTensor.collect_shards(targets)
+        with self._clear_shards_lock:
+            for addr, sids in shards_by_node.items():
+                pending = self._pending_clear_shards.setdefault(addr, {})
+                for sid in sids:
+                    pending.setdefault(sid, 0)
+            clear_requests = [
+                (addr, list(pending))
+                for addr, pending in self._pending_clear_shards.items()
+                if pending
+            ]
 
-        if not shards_by_node:
-            return
+        if not clear_requests:
+            return [], {}
 
-        await asyncio.gather(
-            *[RTensor.clear_node(addr, sids) for addr, sids in shards_by_node.items()],
+        results = await asyncio.gather(
+            *[RTensor.clear_node(addr, sids) for addr, sids in clear_requests],
             return_exceptions=True,
         )
+        fatal_error = next(
+            (
+                result
+                for result in results
+                if isinstance(result, BaseException)
+                and not isinstance(result, Exception)
+            ),
+            None,
+        )
+        if fatal_error is not None:
+            raise fatal_error
+
+        exhausted: dict[Any, list[Any]] = {}
+        for (addr, sids), result in zip(clear_requests, results, strict=True):
+            if isinstance(result, Exception):
+                with self._clear_shards_lock:
+                    pending = self._pending_clear_shards.get(addr, {})
+                    exhausted_sids = []
+                    for sid in sids:
+                        if sid not in pending:
+                            continue
+                        failures = min(pending[sid] + 1, _MAX_CLEAR_STEP_FAILURES)
+                        pending[sid] = failures
+                        if failures >= _MAX_CLEAR_STEP_FAILURES:
+                            exhausted_sids.append(sid)
+                    pending_count = sum(
+                        failures < _MAX_CLEAR_STEP_FAILURES
+                        for failures in pending.values()
+                    )
+                if exhausted_sids:
+                    exhausted[addr] = exhausted_sids
+                logger.warning(
+                    "Failed to clear %d RTensor shards on storage node %s: "
+                    "%s: %s (%d pending, %d retries exhausted)",
+                    len(sids),
+                    addr,
+                    type(result).__name__,
+                    result,
+                    pending_count,
+                    len(exhausted_sids),
+                )
+                continue
+            with self._clear_shards_lock:
+                pending = self._pending_clear_shards.get(addr)
+                if pending is not None:
+                    for sid in sids:
+                        pending.pop(sid, None)
+                    if not pending:
+                        self._pending_clear_shards.pop(addr, None)
+            if isinstance(result, dict):
+                logger.debug(
+                    "Cleared RTensor shards on storage node %s "
+                    "(requested=%d, cleared=%s, remaining_tensors=%s, "
+                    "remaining_bytes=%s)",
+                    addr,
+                    len(sids),
+                    result.get("cleared_count", "unknown"),
+                    result.get("num_tensors", "unknown"),
+                    result.get("total_bytes", "unknown"),
+                )
+
+        attempted_sids = [sid for _, sids in clear_requests for sid in sids]
+        return attempted_sids, exhausted
+
+    def _commit_exhausted_clear_shards(self, exhausted: dict[Any, list[Any]]) -> None:
+        """Remove exhausted shards after every consumer worker is drained."""
+        with self._clear_shards_lock:
+            for addr, sids in exhausted.items():
+                pending = self._pending_clear_shards.get(addr)
+                if pending is None:
+                    continue
+                for sid in sids:
+                    pending.pop(sid, None)
+                if not pending:
+                    self._pending_clear_shards.pop(addr, None)
 
     def clear_batches(self, *targets: dict[str, RTensor]):
         """Clear distributed batch shards from workers to free memory.
@@ -827,16 +923,25 @@ class TrainController:
            full sid set.
 
         After the second fan-out, a ``fetch_buffer_stats`` RPC logs the
-        drain result — WARNING on leak, DEBUG when clean.
+        drain result — WARNING on leak, DEBUG when clean. A shard that also
+        fails on the next call raises after worker buffers have been drained,
+        preventing training from silently accumulating remote storage.
         """
-        run_async_task(self._async_clear_batches, *targets)
-        sids = flatten_shard_ids(targets)
+        with self._clear_batches_lock:
+            self._clear_batches_locked(*targets)
+
+    def _clear_batches_locked(self, *targets: dict[str, RTensor]) -> None:
+        sids, exhausted = run_async_task(self._async_clear_batches, *targets)
         if not sids:
             return
         # broadcast=False → purely local per-head op (no NCCL collective).
         # list[str] is not tensor-like → _replicate_inputs copies the full
         # sid set to every DP head.
         self._custom_function_call("clear_batches", sids, rpc_meta={"broadcast": False})
+        # Commit retry exhaustion only after every consumer worker accepted the
+        # buffer drain. If that RPC raises, exhausted shards remain pending so
+        # the next call can retry or report the remote storage leak.
+        self._commit_exhausted_clear_shards(exhausted)
         # Always observe post-drain state. _custom_function_call returns
         # the first DP head's stats (scalar dispatch collapses via
         # _collect_results[0]); all heads are symmetric in steady state,
@@ -852,19 +957,31 @@ class TrainController:
                 self._worker_role,
                 e,
             )
-            return
-        n_entries = stats.get("num_entries", 0) if isinstance(stats, dict) else 0
-        if n_entries > 0:
-            logger.warning(
-                "clear_batches: _fetch_buffer non-empty on DP head 0 "
-                "(role=%s, num_entries=%d) — possible leak, see #1209",
-                self._worker_role,
-                n_entries,
-            )
         else:
-            logger.debug(
-                "clear_batches: _fetch_buffer drained on DP head 0 (role=%s)",
-                self._worker_role,
+            n_entries = stats.get("num_entries", 0) if isinstance(stats, dict) else 0
+            if n_entries > 0:
+                logger.warning(
+                    "clear_batches: _fetch_buffer non-empty on DP head 0 "
+                    "(role=%s, num_entries=%d) — possible leak, see #1209",
+                    self._worker_role,
+                    n_entries,
+                )
+            else:
+                logger.debug(
+                    "clear_batches: _fetch_buffer drained on DP head 0 (role=%s)",
+                    self._worker_role,
+                )
+
+        if exhausted:
+            summary = ", ".join(
+                f"{addr}: {len(sids)}"
+                for addr, sids in sorted(
+                    exhausted.items(), key=lambda item: str(item[0])
+                )
+            )
+            raise RuntimeError(
+                "RTensor storage cleanup failed across two clear_batches calls "
+                f"({summary})"
             )
 
     def clear_all_local_rtensors(self):

--- a/areal/infra/data_service/controller/controller.py
+++ b/areal/infra/data_service/controller/controller.py
@@ -413,20 +413,28 @@ class DataController:
 
     async def _async_clear_batches(self) -> None:
         async def _clear_one(session: aiohttp.ClientSession, addr: str) -> None:
-            try:
-                async with session.delete(
-                    f"{addr}/data/clear",
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as resp:
-                    resp.raise_for_status()
-            except Exception:
-                logger.debug("Failed to clear batches on %s", addr)
+            async with session.delete(
+                f"{addr}/data/clear",
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                resp.raise_for_status()
 
         async with aiohttp.ClientSession(trust_env=False) as session:
-            await asyncio.gather(
-                *(_clear_one(session, addr) for addr in self._worker_addrs),
+            clear_requests = list(self._worker_addrs)
+            results = await asyncio.gather(
+                *(_clear_one(session, addr) for addr in clear_requests),
                 return_exceptions=True,
             )
+            for addr, result in zip(clear_requests, results, strict=True):
+                if isinstance(result, asyncio.CancelledError):
+                    raise result
+                if isinstance(result, BaseException):
+                    logger.warning(
+                        "Failed to clear batches on data worker %s: %s: %s",
+                        addr,
+                        type(result).__name__,
+                        result,
+                    )
 
     # -- Destroy -----------------------------------------------------------
 

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -15,7 +15,11 @@ import orjson
 import torch
 
 from areal.infra.utils.concurrent import run_async_task
-from areal.infra.utils.http import DEFAULT_REQUEST_TIMEOUT, get_default_connector
+from areal.infra.utils.http import (
+    DEFAULT_REQUEST_TIMEOUT,
+    arequest_with_retry,
+    get_default_connector,
+)
 from areal.utils import logging
 
 logger = logging.getLogger("HttpRTensor")
@@ -52,7 +56,9 @@ class RTensorBackend(Protocol):
         """
         ...
 
-    async def delete(self, node_addr: Any, shard_ids: list[Any]) -> None:
+    async def delete(
+        self, node_addr: Any, shard_ids: list[Any]
+    ) -> dict[str, Any] | None:
         """Delete shards from storage.
 
         Parameters
@@ -61,6 +67,11 @@ class RTensorBackend(Protocol):
             The node address where shards are stored
         shard_ids : list[Any]
             List of shard IDs to delete
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Storage-node cleanup statistics when provided by the backend.
         """
         ...
 
@@ -252,21 +263,24 @@ class HttpRTensorBackend:
         _store_local(shard_id, tensor)
         return shard_id
 
-    async def delete(self, node_addr: str, shard_ids: list[str]) -> None:
-        """Delete shards via HTTP DELETE request."""
-        from areal.utils.network import format_hostport, split_hostport
-
-        try:
-            host, port = split_hostport(node_addr)
-            base = format_hostport(host, port)
-        except ValueError:
-            base = node_addr
+    async def delete(self, node_addr: str, shard_ids: list[str]) -> dict[str, Any]:
+        """Delete shards with retries and return storage-node cleanup statistics."""
         async with self._create_session() as session:
-            async with session.delete(
-                f"http://{base}/data/clear", json={"shard_ids": shard_ids}
-            ) as resp:
-                if resp.status == 200:
-                    await resp.json()
+            result = await arequest_with_retry(
+                node_addr,
+                "/data/clear",
+                payload={"shard_ids": shard_ids},
+                session=session,
+                method="DELETE",
+                max_retries=3,
+                timeout=10,
+            )
+        if not isinstance(result, dict) or result.get("status") != "ok":
+            raise RuntimeError(
+                f"Invalid response while clearing RTensor shards on {node_addr}: "
+                f"{result!r}"
+            )
+        return result
 
 
 _backend: RTensorBackend | None = None
@@ -528,7 +542,7 @@ class RTensor:
         return shards_by_node
 
     @staticmethod
-    async def clear_node(node_addr: Any, shard_ids: list[Any]) -> None:
+    async def clear_node(node_addr: Any, shard_ids: list[Any]) -> dict[str, Any] | None:
         """Clear shards from a node and evict them from the fetch buffer.
 
         Parameters
@@ -537,11 +551,16 @@ class RTensor:
             The node address
         shard_ids : list[Any]
             List of shard IDs to delete
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Storage-node cleanup statistics when provided by the backend.
         """
         with _fetch_buffer_lock:
             for sid in shard_ids:
                 _fetch_buffer.pop(sid, None)
-        await get_backend().delete(node_addr, shard_ids)
+        return await get_backend().delete(node_addr, shard_ids)
 
     @property
     def shape(self) -> torch.Size:

--- a/areal/infra/utils/http.py
+++ b/areal/infra/utils/http.py
@@ -179,7 +179,7 @@ async def arequest_with_retry(
             elif method.upper() == "PUT":
                 ctx = _session.put(url, json=payload, timeout=timeo)
             elif method.upper() == "DELETE":
-                ctx = _session.delete(url, timeout=timeo)
+                ctx = _session.delete(url, json=payload, timeout=timeo)
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
             async with ctx as response:

--- a/areal/trainer/dpo_trainer.py
+++ b/areal/trainer/dpo_trainer.py
@@ -27,6 +27,7 @@ from areal.infra.data_service import DataController
 from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.data import (
     broadcast_tensor_container,
     cycle_dataloader,
@@ -300,14 +301,17 @@ class DPOTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(batch)
+                    cleanups = [("actor", lambda: self.actor.clear_batches(batch))]
                     # ref DP heads also localized `batch` in compute_logp —
                     # drain their per-process fetch buffers. See
                     # areal-project/AReaL#1209.
                     if self.ref is not None:
-                        self.ref.clear_batches(batch)
+                        cleanups.append(("ref", lambda: self.ref.clear_batches(batch)))
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -55,6 +55,7 @@ from areal.infra.rpc.rtensor import RTensor
 from areal.infra.utils.concurrent import call_maybe_async
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
 from areal.utils.awex_runtime import prepare_awex_runtime
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.dataloader import create_dataloader
 from areal.utils.environ import is_single_controller
 from areal.utils.evaluator import Evaluator
@@ -1010,21 +1011,44 @@ class PPOTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(rollout_batch, adv_batch)
+                    cleanups = [
+                        (
+                            "actor",
+                            lambda: self.actor.clear_batches(rollout_batch, adv_batch),
+                        )
+                    ]
                     if self.critic is not None:
-                        self.critic.clear_batches(rollout_batch, adv_batch)
+                        cleanups.append(
+                            (
+                                "critic",
+                                lambda: self.critic.clear_batches(
+                                    rollout_batch, adv_batch
+                                ),
+                            )
+                        )
                     if self.ref is not None:
-                        self.ref.clear_batches(rollout_batch)
+                        cleanups.append(
+                            ("ref", lambda: self.ref.clear_batches(rollout_batch))
+                        )
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
                     # Defensive sweep: drain RTensors created by auxiliary RPC
                     # returns (stats dicts, etc.) that aren't tracked by the
                     # standard batch lifecycle above. See #1209.
-                    self.actor.clear_all_local_rtensors()
+                    cleanups.append(
+                        ("actor sweep", self.actor.clear_all_local_rtensors)
+                    )
                     if self.critic is not None:
-                        self.critic.clear_all_local_rtensors()
+                        cleanups.append(
+                            ("critic sweep", self.critic.clear_all_local_rtensors)
+                        )
                     if self.ref is not None:
-                        self.ref.clear_all_local_rtensors()
+                        cleanups.append(
+                            ("ref sweep", self.ref.clear_all_local_rtensors)
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/trainer/rw_trainer.py
+++ b/areal/trainer/rw_trainer.py
@@ -27,6 +27,7 @@ from areal.infra.data_service import DataController
 from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.data import (
     broadcast_tensor_container,
     cycle_dataloader,
@@ -293,9 +294,12 @@ class RWTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(batch)
+                    cleanups = [("actor", lambda: self.actor.clear_batches(batch))]
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -26,6 +26,7 @@ from areal.infra.data_service import DataController
 from areal.infra.data_service.controller.config import DataServiceConfig
 from areal.infra.data_service.rdataset import RDataset
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.cleanup import run_batch_cleanups
 from areal.utils.data import (
     broadcast_tensor_container,
     collate_samples_to_list,
@@ -259,9 +260,12 @@ class SFTTrainer:
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():
-                    self.actor.clear_batches(batch)
+                    cleanups = [("actor", lambda: self.actor.clear_batches(batch))]
                     if self.data_controller is not None:
-                        self.data_controller.clear_batches()
+                        cleanups.append(
+                            ("data", lambda: self.data_controller.clear_batches())
+                        )
+                    run_batch_cleanups(cleanups)
 
             with perf_tracer.trace_scope(
                 "train.log_stats",

--- a/areal/utils/cleanup.py
+++ b/areal/utils/cleanup.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable, Iterable
+
+
+def run_batch_cleanups(
+    cleanups: Iterable[tuple[str, Callable[[], None]]],
+) -> None:
+    """Run every batch cleanup before propagating any ordinary failures."""
+    failures: list[tuple[str, Exception]] = []
+    for role, cleanup in cleanups:
+        try:
+            cleanup()
+        except Exception as error:
+            failures.append((role, error))
+
+    if failures:
+        first_role, first_error = failures[0]
+        first_error.add_note(f"clear_batches failed first for role: {first_role}")
+        for role, error in failures[1:]:
+            first_error.add_note(
+                "Additional clear_batches failure for "
+                f"{role}: {type(error).__name__}: {error}"
+            )
+        raise first_error

--- a/scripts/ci_test_report.py
+++ b/scripts/ci_test_report.py
@@ -80,6 +80,8 @@ def summarize_reports(
     base: dict[str, Any] | None = None,
     *,
     base_is_inventory: bool = False,
+    changed_test_files: set[str] | None = None,
+    unavailable_base_test_files: set[str] | None = None,
 ) -> dict[str, int]:
     selected = set(current.get("selected_nodeids", []))
     outcomes = current.get("outcomes", {})
@@ -101,7 +103,22 @@ def summarize_reports(
         return counts
 
     base_selected = set(base.get("selected_nodeids", []))
-    new_selected = selected - base_selected
+    unmatched_selected = selected - base_selected
+    unavailable_selected: set[str] = set()
+    if unavailable_base_test_files is not None:
+        unavailable_selected = {
+            nodeid
+            for nodeid in selected
+            if nodeid.split("::", maxsplit=1)[0] in unavailable_base_test_files
+        }
+    comparable_unmatched = unmatched_selected - unavailable_selected
+    new_selected = comparable_unmatched
+    if changed_test_files is not None:
+        new_selected = {
+            nodeid
+            for nodeid in comparable_unmatched
+            if nodeid.split("::", maxsplit=1)[0] in changed_test_files
+        }
     counts.update(
         {
             "base_selected": len(selected & base_selected)
@@ -113,6 +130,10 @@ def summarize_reports(
             "new_incomplete": len(new_selected & incomplete),
         }
     )
+    if changed_test_files is not None:
+        counts["unchanged_unmatched"] = len(comparable_unmatched - new_selected)
+    if unavailable_base_test_files is not None:
+        counts["uncompared_selected"] = len(unavailable_selected)
     return counts
 
 
@@ -140,12 +161,23 @@ def render_summary(
         rows.extend(
             [
                 (previous_label, counts["base_selected"]),
-                ("New selected cases", counts["new_selected"]),
-                ("New cases executed", counts["new_executed"]),
-                ("New cases skipped", counts["new_skipped"]),
-                ("New cases incomplete", counts["new_incomplete"]),
+                ("New test cases selected", counts["new_selected"]),
+                ("New test cases executed", counts["new_executed"]),
+                ("New test cases skipped", counts["new_skipped"]),
+                ("New test cases incomplete", counts["new_incomplete"]),
             ]
         )
+        if "unchanged_unmatched" in counts:
+            rows.append(
+                (
+                    "Unmatched cases from unchanged test files",
+                    counts["unchanged_unmatched"],
+                )
+            )
+        if "uncompared_selected" in counts:
+            rows.append(
+                ("Cases without a base inventory", counts["uncompared_selected"])
+            )
 
     lines = [f"## {suite} test summary", "", "| Metric | Count |", "| --- | ---: |"]
     lines.extend(f"| {label} | {value} |" for label, value in rows)
@@ -159,6 +191,14 @@ def _load_reports(path: Path) -> dict[str, Any]:
     )
 
 
+def _load_changed_test_files(path: Path) -> set[str]:
+    return {
+        line.strip().removeprefix("./")
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -167,17 +207,31 @@ def main() -> None:
     summary_parser.add_argument("--base", type=Path)
     summary_parser.add_argument("--base-sha")
     summary_parser.add_argument("--base-is-inventory", action="store_true")
+    summary_parser.add_argument("--changed-test-files", type=Path)
+    summary_parser.add_argument("--unavailable-base-test-files", type=Path)
     summary_parser.add_argument("--suite", required=True)
     summary_parser.add_argument("--step-summary", type=Path)
     args = parser.parse_args()
 
     current = _load_reports(args.current)
     base = _load_reports(args.base) if args.base else None
+    changed_test_files = (
+        _load_changed_test_files(args.changed_test_files)
+        if args.changed_test_files
+        else None
+    )
+    unavailable_base_test_files = (
+        _load_changed_test_files(args.unavailable_base_test_files)
+        if args.unavailable_base_test_files
+        else None
+    )
     summary = render_summary(
         summarize_reports(
             current,
             base,
             base_is_inventory=args.base_is_inventory,
+            changed_test_files=changed_test_files,
+            unavailable_base_test_files=unavailable_base_test_files,
         ),
         suite=args.suite,
         base_sha=args.base_sha,

--- a/tests/infra/data_service/test_controller.py
+++ b/tests/infra/data_service/test_controller.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from areal.api.cli_args import (
@@ -239,3 +240,59 @@ class TestDataControllerRegisterDataset:
 
         assert "key-1" not in controller._datasets
         assert "key-2" in controller._datasets
+
+
+class _FakeClearResponse:
+    def __init__(self, error=None):
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+
+class _FakeClearSession:
+    def __init__(self):
+        self.urls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def delete(self, url, *, timeout):
+        self.urls.append(url)
+        error = RuntimeError("clear failed") if "bad-worker" in url else None
+        return _FakeClearResponse(error)
+
+
+class TestDataControllerClearBatches:
+    def test_worker_failure_warns_without_stopping_other_clears(self):
+        controller = DataController(DataServiceConfig(), MagicMock())
+        controller._worker_addrs = ["http://good-worker", "http://bad-worker"]
+        session = _FakeClearSession()
+
+        with (
+            patch(
+                "areal.infra.data_service.controller.controller.aiohttp.ClientSession",
+                return_value=session,
+            ),
+            patch(
+                "areal.infra.data_service.controller.controller.logger.warning"
+            ) as mock_warning,
+        ):
+            asyncio.run(controller._async_clear_batches())
+
+        assert session.urls == [
+            "http://good-worker/data/clear",
+            "http://bad-worker/data/clear",
+        ]
+        mock_warning.assert_called_once()
+        assert "http://bad-worker" in str(mock_warning.call_args)

--- a/tests/test_ci_test_report.py
+++ b/tests/test_ci_test_report.py
@@ -70,6 +70,74 @@ def test_summarize_reports_uses_base_as_inventory():
     assert counts["new_executed"] == 1
 
 
+def test_summarize_reports_ignores_unmatched_cases_from_unchanged_files():
+    current = {
+        "selected_nodeids": [
+            "tests/test_npu.py::test_existing",
+            "tests/test_npu.py::test_import_sensitive",
+        ],
+        "outcomes": {
+            "tests/test_npu.py::test_existing": "passed",
+            "tests/test_npu.py::test_import_sensitive": "passed",
+        },
+    }
+    base = {
+        "selected_nodeids": ["tests/test_npu.py::test_existing"],
+        "outcomes": {},
+    }
+
+    counts = summarize_reports(
+        current,
+        base,
+        base_is_inventory=True,
+        changed_test_files={"tests/test_cpu.py"},
+    )
+
+    assert counts["new_selected"] == 0
+    assert counts["new_executed"] == 0
+    assert counts["unchanged_unmatched"] == 1
+
+
+def test_summarize_reports_counts_unmatched_cases_from_changed_files():
+    current = {
+        "selected_nodeids": ["tests/test_npu.py::test_new"],
+        "outcomes": {"tests/test_npu.py::test_new": "passed"},
+    }
+    base = {"selected_nodeids": [], "outcomes": {}}
+
+    counts = summarize_reports(
+        current,
+        base,
+        base_is_inventory=True,
+        changed_test_files={"tests/test_npu.py"},
+    )
+
+    assert counts["new_selected"] == 1
+    assert counts["new_executed"] == 1
+    assert counts["unchanged_unmatched"] == 0
+
+
+def test_summarize_reports_excludes_cases_without_base_inventory():
+    current = {
+        "selected_nodeids": ["tests/test_npu.py::test_import_sensitive"],
+        "outcomes": {"tests/test_npu.py::test_import_sensitive": "passed"},
+    }
+    base = {"selected_nodeids": [], "outcomes": {}}
+
+    counts = summarize_reports(
+        current,
+        base,
+        base_is_inventory=True,
+        changed_test_files={"tests/test_npu.py"},
+        unavailable_base_test_files={"tests/test_npu.py"},
+    )
+
+    assert counts["new_selected"] == 0
+    assert counts["new_executed"] == 0
+    assert counts["unchanged_unmatched"] == 0
+    assert counts["uncompared_selected"] == 1
+
+
 def test_render_summary_includes_suite_and_base_comparison():
     summary = render_summary(
         {
@@ -92,4 +160,4 @@ def test_render_summary_includes_suite_and_base_comparison():
     assert "## NPU test summary" in summary
     assert "| Selected NPU test cases | 10 |" in summary
     assert "| Base selected cases at `1234567890ab` | 9 |" in summary
-    assert "| New cases executed | 2 |" in summary
+    assert "| New test cases executed | 2 |" in summary

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -6,6 +6,7 @@ import sys
 import time
 import uuid
 
+import aiohttp
 import orjson
 import pytest
 import requests
@@ -19,6 +20,42 @@ from areal.infra.rpc.rtensor import (
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.utils.proc import kill_process_tree
 from areal.utils.network import find_free_ports
+
+
+class _FakeDeleteResponse:
+    content_type = "application/json"
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self.payload
+
+
+class _FakeDeleteSession:
+    def __init__(self, responses_or_errors):
+        self.responses_or_errors = list(responses_or_errors)
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def delete(self, url, *, json, timeout):
+        self.requests.append((url, json, timeout))
+        item = self.responses_or_errors.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return _FakeDeleteResponse(item)
 
 
 @pytest.fixture(scope="module")
@@ -262,6 +299,60 @@ class TestRTensorIntegration:
 
 class TestHttpRTensorBackendBatching:
     """Unit tests for HTTP batch fetching behavior."""
+
+    def test_delete_retries_with_payload_and_returns_storage_stats(self, monkeypatch):
+        async def no_sleep(_delay):
+            return None
+
+        result_payload = {
+            "status": "ok",
+            "cleared_count": 2,
+            "num_tensors": 3,
+            "total_bytes": 128,
+        }
+        session = _FakeDeleteSession(
+            [aiohttp.ClientConnectionError("temporary failure"), result_payload]
+        )
+        backend = HttpRTensorBackend()
+        monkeypatch.setattr(backend, "_create_session", lambda: session)
+        monkeypatch.setattr("areal.infra.utils.http.asyncio.sleep", no_sleep)
+
+        result = asyncio.run(backend.delete("node-a", ["s0", "s1"]))
+
+        assert result == result_payload
+        assert len(session.requests) == 2
+        for url, payload, timeout in session.requests:
+            assert url == "http://node-a/data/clear"
+            assert payload == {"shard_ids": ["s0", "s1"]}
+            assert timeout.total == 10
+
+    def test_delete_raises_after_three_failed_attempts(self, monkeypatch):
+        async def no_sleep(_delay):
+            return None
+
+        session = _FakeDeleteSession(
+            [aiohttp.ClientConnectionError("offline") for _ in range(3)]
+        )
+        backend = HttpRTensorBackend()
+        monkeypatch.setattr(backend, "_create_session", lambda: session)
+        monkeypatch.setattr("areal.infra.utils.http.asyncio.sleep", no_sleep)
+
+        with pytest.raises(RuntimeError, match="Failed after 3 retries"):
+            asyncio.run(backend.delete("node-a", ["s0"]))
+
+        assert len(session.requests) == 3
+
+    @pytest.mark.parametrize(
+        "payload",
+        ["not-a-dict", {"status": "error", "message": "clear failed"}],
+    )
+    def test_delete_rejects_invalid_success_payload(self, monkeypatch, payload):
+        session = _FakeDeleteSession([payload])
+        backend = HttpRTensorBackend()
+        monkeypatch.setattr(backend, "_create_session", lambda: session)
+
+        with pytest.raises(RuntimeError, match="Invalid response"):
+            asyncio.run(backend.delete("node-a", ["s0"]))
 
     def test_fetch_chunks_large_requests(self, monkeypatch):
         """Large same-node fetches are split into bounded batch requests."""
@@ -1023,6 +1114,25 @@ class TestFetchBuffer:
         # clear_node evicts from buffer
         asyncio.run(RTensor.clear_node(rpc_server, [shard_id]))
         assert shard_id not in _fetch_buffer
+
+    def test_clear_node_evicts_from_buffer_when_delete_fails(self):
+        """A failed remote delete must not regress local buffer cleanup."""
+        from areal.infra.rpc.rtensor import _fetch_buffer, set_backend
+
+        class _FailingBackend:
+            async def delete(self, _node_addr, _shard_ids):
+                raise RuntimeError("storage node unavailable")
+
+        shard_id = "failed-delete-shard"
+        _fetch_buffer[shard_id] = torch.tensor([1])
+        set_backend(_FailingBackend())
+        try:
+            with pytest.raises(RuntimeError, match="storage node unavailable"):
+                asyncio.run(RTensor.clear_node("node-a", [shard_id]))
+            assert shard_id not in _fetch_buffer
+        finally:
+            set_backend(None)
+            _fetch_buffer.pop(shard_id, None)
 
     def test_clear_fetch_buffer_selective(self):
         """clear_fetch_buffer(sids) pops only the listed entries, misses are no-ops."""

--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -5,7 +5,8 @@ RPC wrappers, PPO/SFT methods, weight management, and error handling.
 """
 
 import asyncio
-from unittest.mock import Mock
+from threading import Lock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -21,6 +22,7 @@ from areal.api import (
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
 from areal.infra import TrainController
 from areal.infra.controller.train_controller import _merge_tensors
+from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
 
 
 class MockTrainEngine(TrainEngine):
@@ -164,6 +166,13 @@ def create_mock_distributed_batch(size=4, seq_len=10):
         }
         for _ in range(size)
     ]
+
+
+def create_mock_rtensor(shard_id: str, node_addr: str) -> RTensor:
+    return RTensor(
+        shard=TensorShardInfo(shard_id=shard_id, node_addr=node_addr),
+        data=torch.empty(1, device="meta"),
+    )
 
 
 # ==================== TEST CLASSES ====================
@@ -752,3 +761,188 @@ class TestTrainControllerDispatchInputs:
         assert "learning_rate" in split_kwargs
         assert len(split_kwargs["input_"]) == train_controller.parallel_strategy.dp_size
         assert all(lr == 0.001 for lr in split_kwargs["learning_rate"])
+
+
+class TestTrainControllerClearBatches:
+    def test_storage_clear_surfaces_per_node_failures_and_stats(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        target = {
+            "good": create_mock_rtensor("s-good", "good-node"),
+            "bad": create_mock_rtensor("s-bad", "bad-node"),
+        }
+        calls = []
+
+        async def fake_clear_node(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if addr == "bad-node":
+                raise RuntimeError("delete failed")
+            return {
+                "status": "ok",
+                "cleared_count": 1,
+                "num_tensors": 2,
+                "total_bytes": 64,
+            }
+
+        with (
+            patch.object(RTensor, "clear_node", new=fake_clear_node),
+            patch(
+                "areal.infra.controller.train_controller.logger.warning"
+            ) as mock_warning,
+            patch("areal.infra.controller.train_controller.logger.debug") as mock_debug,
+        ):
+            asyncio.run(controller._async_clear_batches(target))
+
+        assert calls == [
+            ("good-node", ["s-good"]),
+            ("bad-node", ["s-bad"]),
+        ]
+        mock_warning.assert_called_once()
+        assert "bad-node" in str(mock_warning.call_args)
+        mock_debug.assert_called_once()
+        assert "good-node" in str(mock_debug.call_args)
+        assert "64" in str(mock_debug.call_args)
+        assert controller._pending_clear_shards == {"bad-node": {"s-bad": 1}}
+
+    def test_failed_storage_clear_is_retried_on_next_call(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+        next_target = {"batch": create_mock_rtensor("s1", "node-a")}
+        calls = []
+
+        async def fail_then_succeed(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if len(calls) == 1:
+                raise RuntimeError("delete failed")
+            return {"status": "ok", "cleared_count": 1}
+
+        with patch.object(RTensor, "clear_node", new=fail_then_succeed):
+            asyncio.run(controller._async_clear_batches(target))
+            asyncio.run(controller._async_clear_batches(next_target))
+
+        assert calls == [("node-a", ["s0"]), ("node-a", ["s0", "s1"])]
+        assert controller._pending_clear_shards == {}
+
+    def test_second_storage_clear_failure_cleans_workers_then_raises(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        controller._clear_batches_lock = Lock()
+        controller._worker_role = "test"
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+        calls = []
+
+        async def fail_clear(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            raise RuntimeError("delete failed")
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_clear),
+            patch.object(
+                controller,
+                "_custom_function_call",
+                return_value={"num_entries": 0},
+            ) as mock_worker_call,
+        ):
+            controller.clear_batches(target)
+            with pytest.raises(RuntimeError, match="two clear_batches calls"):
+                controller.clear_batches({})
+
+        assert calls == [("node-a", ["s0"]), ("node-a", ["s0"])]
+        assert controller._pending_clear_shards == {}
+        assert mock_worker_call.call_count == 4
+
+    def test_worker_cleanup_failure_preserves_exhausted_storage_state(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        controller._clear_batches_lock = Lock()
+        controller._worker_role = "test"
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+        storage_calls = []
+        worker_clear_calls = 0
+
+        async def fail_clear(addr, shard_ids):
+            storage_calls.append((addr, shard_ids))
+            raise RuntimeError("delete failed")
+
+        def fail_second_worker_clear(method, *_args, **_kwargs):
+            nonlocal worker_clear_calls
+            if method == "clear_batches":
+                worker_clear_calls += 1
+                if worker_clear_calls == 2:
+                    raise RuntimeError("worker cleanup failed")
+                return None
+            return {"num_entries": 0}
+
+        with (
+            patch.object(RTensor, "clear_node", new=fail_clear),
+            patch.object(
+                controller,
+                "_custom_function_call",
+                side_effect=fail_second_worker_clear,
+            ) as mock_worker_call,
+        ):
+            controller.clear_batches(target)
+            with pytest.raises(RuntimeError, match="worker cleanup failed"):
+                controller.clear_batches({})
+
+        assert storage_calls == [("node-a", ["s0"]), ("node-a", ["s0"])]
+        assert controller._pending_clear_shards == {"node-a": {"s0": 2}}
+        assert mock_worker_call.call_count == 3
+
+    def test_storage_clear_propagates_cancellation(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {}
+        controller._clear_shards_lock = Lock()
+        target = {"batch": create_mock_rtensor("s0", "node-a")}
+
+        async def cancel_clear(_addr, _shard_ids):
+            raise asyncio.CancelledError
+
+        with patch.object(RTensor, "clear_node", new=cancel_clear):
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(controller._async_clear_batches(target))
+
+        assert controller._pending_clear_shards == {"node-a": {"s0": 0}}
+
+    def test_storage_clear_cancellation_keeps_batch_state_atomic(self):
+        controller = TrainController.__new__(TrainController)
+        controller._pending_clear_shards = {"retry-node": {"s-retry": 1}}
+        controller._clear_shards_lock = Lock()
+        controller._clear_batches_lock = Lock()
+        target = {
+            "good": create_mock_rtensor("s-good", "good-node"),
+            "cancel": create_mock_rtensor("s-cancel", "cancel-node"),
+        }
+        calls = []
+
+        async def mixed_results(addr, shard_ids):
+            calls.append((addr, shard_ids))
+            if addr == "retry-node":
+                raise RuntimeError("second failure")
+            if addr == "cancel-node":
+                raise asyncio.CancelledError
+            return {"status": "ok", "cleared_count": 1}
+
+        with (
+            patch.object(RTensor, "clear_node", new=mixed_results),
+            patch.object(controller, "_custom_function_call") as mock_worker_call,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                controller.clear_batches(target)
+
+        assert {addr: sids for addr, sids in calls} == {
+            "retry-node": ["s-retry"],
+            "good-node": ["s-good"],
+            "cancel-node": ["s-cancel"],
+        }
+        assert controller._pending_clear_shards == {
+            "retry-node": {"s-retry": 1},
+            "good-node": {"s-good": 0},
+            "cancel-node": {"s-cancel": 0},
+        }
+        mock_worker_call.assert_not_called()

--- a/tests/test_trainer_utils.py
+++ b/tests/test_trainer_utils.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from areal.utils.cleanup import run_batch_cleanups
+
+
+def test_run_batch_cleanups_continues_after_one_role_fails():
+    calls = []
+    actor_error = RuntimeError("actor cleanup failed")
+
+    def fail_actor():
+        calls.append("actor")
+        raise actor_error
+
+    def record(role):
+        return lambda: calls.append(role)
+
+    with pytest.raises(RuntimeError, match="actor cleanup failed") as exc_info:
+        run_batch_cleanups(
+            [
+                ("actor", fail_actor),
+                ("critic", record("critic")),
+                ("ref", record("ref")),
+                ("data", record("data")),
+            ]
+        )
+
+    assert exc_info.value is actor_error
+    assert calls == ["actor", "critic", "ref", "data"]
+
+
+def test_run_batch_cleanups_preserves_first_of_multiple_failures():
+    calls = []
+
+    def fail(role):
+        def cleanup():
+            calls.append(role)
+            raise RuntimeError(f"{role} cleanup failed")
+
+        return cleanup
+
+    with pytest.raises(RuntimeError, match="actor cleanup failed") as exc_info:
+        run_batch_cleanups(
+            [
+                ("actor", fail("actor")),
+                ("critic", lambda: calls.append("critic")),
+                ("data", fail("data")),
+            ]
+        )
+
+    assert calls == ["actor", "critic", "data"]
+    assert exc_info.value.__notes__ == [
+        "clear_batches failed first for role: actor",
+        "Additional clear_batches failure for data: RuntimeError: data cleanup failed",
+    ]
+
+
+def test_run_batch_cleanups_runs_residual_sweeps_after_batch_failure():
+    calls = []
+
+    def fail_actor_batch():
+        calls.append("actor")
+        raise RuntimeError("actor cleanup failed")
+
+    with pytest.raises(RuntimeError, match="actor cleanup failed"):
+        run_batch_cleanups(
+            [
+                ("actor", fail_actor_batch),
+                ("critic", lambda: calls.append("critic")),
+                ("actor sweep", lambda: calls.append("actor sweep")),
+                ("critic sweep", lambda: calls.append("critic sweep")),
+            ]
+        )
+
+    assert calls == ["actor", "critic", "actor sweep", "critic sweep"]


### PR DESCRIPTION
<h2>Description</h2><p>Backports and adapts the complete RTensor delete-failure handling from areal-project/AReaL@6b1b6ddd3fd2b1ae8b40d652a30fc4a7441dde44 to the Ascend branch. Failed storage deletions are retried across one training step, persistent failures are surfaced only after all consumer buffers have been drained, cleanup continues across every role, and the Ascend residual RTensor sweep is retained for auxiliary tensors outside tracked batches. The accompanying regression tests cover HTTP DELETE payload retries, deferred shard cleanup, cancellation, multi-role cleanup continuation, and trainer cleanup behavior.</p><h2>Related Issue</h2><p>N/A; backport of areal-project/AReaL@6b1b6ddd3fd2b1ae8b40d652a30fc4a7441dde44.</p><h2>Type of Change</h2><ul><li>[x] 🐛 Bug fix</li><li>[ ] ✨ New feature</li><li>[ ] 💥 Breaking change</li><li>[ ] 📝 Documentation update</li><li>[ ] ♻️ Refactoring</li><li>[ ] ⚡ Performance improvement</li><li>[ ] ✅ Test coverage improvement</li></ul><h2>Checklist</h2><ul><li>[ ] I have read the Contributing Guide</li><li>[x] Pre-commit hooks pass (<code>pre-commit run --all-files</code>)</li><li>[x] Relevant tests pass; new tests added for new functionality</li><li>[ ] Documentation updated (not applicable; no documentation behavior changed)</li><li>[x] Branch is up to date with <code>ascend</code></li><li>[ ] Self-reviewed via <code>/review-pr</code> command</li><li>[x] This PR was created by a coding agent via <code>/create-pr</code></li><li>[ ] This PR is a breaking change</li></ul><p><strong>Breaking Change Details (if applicable):</strong> None.</p><h2>Additional Context</h2><p>Validation: <code>python -m pytest -q tests/infra/data_service/test_controller.py tests/test_rtensor.py tests/test_train_controller.py tests/test_trainer_utils.py</code> passed in the node09 <code>areal-node-rongzhi-dev</code> container (111 passed in 23.21s); the full pre-commit suite also passed in a clean disposable worktree. These are CPU/control-plane tests, and no NPU processes were left running before or after the node09 run.</p>
