### PR TITLE
docs: add OrcaRouter as an OpenAI-compatible provider example

### DIFF
--- a/docs/en/best_practices/debugging.md
+++ b/docs/en/best_practices/debugging.md
@@ -77,6 +77,9 @@ asyncio.run(MyAgent().run(data, base_url=f"http://127.0.0.1:{port}/v1", api_key=
 
 # If you use the official model provider
 asyncio.run(MyAgent().run(data, base_url="https://api.openai.com/v1", api_key="YOUR_API_KEY"))
+
+# Or route through OrcaRouter, an OpenAI-compatible AI gateway (https://www.orcarouter.ai)
+asyncio.run(MyAgent().run(data, base_url="https://api.orcarouter.ai/v1", api_key="YOUR_ORCAROUTER_API_KEY"))
 ```
 
 Test your code with random samples from the dataset. If it runs without errors, your

--- a/docs/zh/best_practices/debugging.md
+++ b/docs/zh/best_practices/debugging.md
@@ -70,6 +70,9 @@ asyncio.run(MyAgent().run(data, base_url=f"http://127.0.0.1:{port}/v1", api_key=
 
 # If you use the official model provider
 asyncio.run(MyAgent().run(data, base_url="https://api.openai.com/v1", api_key="YOUR_API_KEY"))
+
+# Or route through OrcaRouter, an OpenAI-compatible AI gateway (https://www.orcarouter.ai)
+asyncio.run(MyAgent().run(data, base_url="https://api.orcarouter.ai/v1", api_key="YOUR_ORCAROUTER_API_KEY"))
 ```
 
 使用数据集中的随机样本测试您的代码。如果它能无错误运行，则您的 Agent 逻辑是正确的。

--- a/examples/experimental/inference_service/README.md
+++ b/examples/experimental/inference_service/README.md
@@ -144,6 +144,16 @@ python3 examples/experimental/inference_service/human_in_the_loop_demo.py \
     --external-model gpt-4o
 ```
 
+You can also route the demo through [OrcaRouter](https://www.orcarouter.ai), an
+OpenAI-compatible AI gateway that aggregates many models behind one endpoint:
+
+```bash
+python3 examples/experimental/inference_service/human_in_the_loop_demo.py \
+    --external-url https://api.orcarouter.ai/v1 \
+    --external-api-key YOUR_ORCAROUTER_API_KEY \
+    --external-model <any-orcarouter-model>
+```
+
 When `--external-url` is set, the controller enables external model mode and routes chat
 traffic through the unified `/chat/completions` + `/export_trajectories` external flow.
 


### PR DESCRIPTION
Users of AReaL's agentic RL flows — like the HITL online RL demo and the standalone debugging guide — already connect their agents to external models by swapping `base_url` and `api_key`, and the docs point at `https://api.openai.com/v1` as the official-provider example. This PR adds [OrcaRouter](https://www.orcarouter.ai) as a named OpenAI-compatible provider in those spots, so anyone who wants to route a black-box agent through OrcaRouter can do it by copying a ready-made line instead of treating it as an anonymous custom endpoint.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The changes mirror the existing `api.openai.com` example lines already present in the docs:

- `docs/en/best_practices/debugging.md` — add an OrcaRouter `base_url` example next to the OpenAI one in the agent debug snippet.
- `docs/zh/best_practices/debugging.md` — same addition in the Chinese docs.
- `examples/experimental/inference_service/README.md` — add an OrcaRouter example to the External Model Mode section of the HITL demo.

Validation: mdformat (`--wrap=88`, the same hook AReaL's pre-commit uses) passes on all three files, and the new endpoint was live-tested with the documented `AsyncOpenAI(base_url=..., api_key=...)` pattern — it returns HTTP 200 with a valid completion.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
