### PR TITLE
fix(api): return float zero after async reward timeout

### DIFF
--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -158,7 +158,7 @@ class AsyncRewardWrapper:
                     f"{'Returning 0.' if is_last else 'Retrying...'}"
                 )
                 if is_last:
-                    return 0
+                    return 0.0
             except BrokenProcessPool:
                 logger.warning(
                     f"ProcessPoolExecutor broken (attempt {attempt + 1}/{self.max_retries + 1}). "
@@ -180,4 +180,4 @@ class AsyncRewardWrapper:
                 if is_last:
                     raise
 
-        return 0
+        return 0.0

--- a/tests/test_async_reward_wrapper.py
+++ b/tests/test_async_reward_wrapper.py
@@ -69,7 +69,8 @@ class TestAsyncRewardWrapperTimeout:
             _slow_reward, timeout_seconds=0.1, max_workers=1, max_retries=1
         )
         result = await wrapper(10.0)
-        assert result == 0
+        assert isinstance(result, float)
+        assert result == 0.0
 
     @pytest.mark.asyncio
     async def test_timeout_no_retries_returns_zero(self):
@@ -77,7 +78,8 @@ class TestAsyncRewardWrapperTimeout:
             _slow_reward, timeout_seconds=0.1, max_workers=1, max_retries=0
         )
         result = await wrapper(10.0)
-        assert result == 0
+        assert isinstance(result, float)
+        assert result == 0.0
 
 
 class TestAsyncRewardWrapperBrokenPool:


### PR DESCRIPTION
<h2>Description</h2><p>Backport upstream commit <code>6331a9488b0e3d937e36902435e8b14eb30f0010</code> so <code>AsyncRewardWrapper</code> returns <code>0.0</code> after reward-computation timeouts. This keeps the fallback consistent with its declared float result and prevents the v1 OpenAI proxy from rejecting a timed-out trajectory because it received an integer reward. The timeout tests now verify both the value and result type.</p><h2>Related Issue</h2><p>Backport of upstream PR #1541.</p><h2>Type of Change</h2><ul><li>☑ Bug fix</li><li>☐ New feature</li><li>☐ Breaking change</li><li>☐ Documentation update</li><li>☐ Refactoring</li><li>☐ Performance improvement</li><li>☐ Test coverage improvement</li></ul><h2>Checklist</h2><ul><li>☐ I have read the Contributing Guide</li><li>☑ Pre-commit hooks pass (<code>pre-commit run --all-files</code>; the sandbox-blocked <code>uv-lock</code> hook passed on an authorized rerun)</li><li>☑ Relevant tests pass; timeout type assertions are included</li><li>☐ Documentation updated (not applicable)</li><li>☑ Branch is up to date with the target branch (<code>origin/ascend</code>)</li><li>☐ Self-reviewed via <code>/review-pr</code></li><li>☑ This PR was created by a coding agent via <code>/create-pr</code></li><li>☐ This PR is a breaking change</li></ul><p><strong>Breaking Change Details:</strong> Not applicable.</p><h2>Additional Context</h2><p>Validation: <code>.venv/bin/pytest -q tests/test_async_reward_wrapper.py</code> — 15 passed. A direct timeout check returned <code>float 0.0</code>. No NPU hardware test was run because this is backend-neutral CPU control flow with no device-specific code or dependency changes.</p>
