### PR TITLE
ci: use A3-800I runner for Ascend tests

### DIFF
--- a/.github/workflows/ascend-pr-tests.yml
+++ b/.github/workflows/ascend-pr-tests.yml
@@ -249,7 +249,7 @@ jobs:
   npu-pr-tests:
     name: npu-pr-tests
     if: github.repository == 'areal-project/AReaL'
-    runs-on: linux-aarch64-a3-8
+    runs-on: linux-aarch64-a3-800i-8
     timeout-minutes: 90
     container:
       image: ghcr.io/hwvanici/areal_npu:a3-nightly
@@ -259,7 +259,7 @@ jobs:
       NPU_TEST_BASE_SHA: ""
       AREAL_TEST_QWEN3_PATH: "/root/.cache/modelscope/hub/models/Qwen/Qwen3-0.6B"
       AREAL_TEST_QWEN3_MOE_PATH: "/root/.cache/modelscope/hub/models/Qwen/Qwen3-30B-A3B"
-      AREAL_TEST_QWEN35_PATH: "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-0.8B"
+      AREAL_TEST_QWEN35_PATH: "/root/.cache/modelscope/hub/models/Qwen3.5-0.8B"
       AREAL_TEST_QWEN35_MOE_PATH: "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-35B-A3B"
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_DISABLE_XET: "1"
@@ -392,6 +392,26 @@ jobs:
 
           npu-smi info
 
+      - name: Verify cached NPU test models
+        run: |
+          set -euo pipefail
+
+          verify_model() {
+            local model_path="$1"
+            local weight_file
+
+            [[ -f "${model_path}/config.json" ]] || return 1
+            weight_file=$(find -L "${model_path}" -maxdepth 1 -type f \
+              \( -name '*.safetensors' -o -name '*.bin' \) -print -quit)
+            [[ -n "${weight_file}" ]]
+            echo "Using cached model: ${model_path}"
+          }
+
+          verify_model "${AREAL_TEST_QWEN3_PATH}"
+          verify_model "${AREAL_TEST_QWEN3_MOE_PATH}"
+          verify_model "${AREAL_TEST_QWEN35_PATH}"
+          verify_model "${AREAL_TEST_QWEN35_MOE_PATH}"
+
       - name: Run NPU-image dependency tests
         env:
           AREAL_TEST_REPORT_DIR: /tmp/current-npu-test-reports
@@ -405,26 +425,6 @@ jobs:
             tests/test_model_packed_seq_cp.py
           pytest -q -p scripts.ci_test_report \
             -m skipif tests/test_reassemble_cp_logprobs.py
-
-      - name: Verify cached NPU test models
-        run: |
-          set -euo pipefail
-
-          verify_model() {
-            local model_path="$1"
-            local weight_file
-
-            test -f "${model_path}/config.json"
-            weight_file=$(find -L "${model_path}" -maxdepth 1 -type f \
-              \( -name '*.safetensors' -o -name '*.bin' \) -print -quit)
-            test -n "${weight_file}"
-            echo "Using cached model: ${model_path}"
-          }
-
-          verify_model "${AREAL_TEST_QWEN3_PATH}"
-          verify_model "${AREAL_TEST_QWEN3_MOE_PATH}"
-          verify_model "${AREAL_TEST_QWEN35_PATH}"
-          verify_model "${AREAL_TEST_QWEN35_MOE_PATH}"
 
       - name: Run NPU test suites
         env:


### PR DESCRIPTION
## Description

Move the Ascend eight-NPU pull-request job to the higher-availability
`linux-aarch64-a3-800i-8` runner. Use the four ModelScope cache paths verified on that
runner and check each checkpoint before offline tests start. This avoids expensive NFS
enumeration while failing fast if the shared cache mount is incomplete.

## Related Issue

N/A — runner migration requested by the Ascend CI administrator.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable)
- [x] Branch is up to date with `ascend`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Local validation passed for YAML parsing, `bash -n` on the cache verification step,
`git diff --check`, and the changed-file pre-commit hooks. An A3-800I CI run resolved all
four direct ModelScope paths and passed 78 Megatron VLM tests. The next dependency test
was blocked during collection by the runner image's MindSpeed package lacking
`arguments_basic.get_full_args`; that failure is independent of model caching. The
repository-wide pre-commit run was attempted but was blocked by read-only tracked agent
files and the read-only default uv cache in the local execution environment.
