### PR TITLE
test: restore skipped CPU coverage

### DIFF
--- a/tests/experimental/inference_service/test_controller.py
+++ b/tests/experimental/inference_service/test_controller.py
@@ -513,10 +513,8 @@ class TestOnlineCallbackFlow:
 
 
 class TestInferenceServiceWorkflow:
-    @pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
     @pytest.mark.asyncio
     async def test_online_mode_waits_on_controller(self):
-        mock_interaction = MagicMock(reward=1.0)
         controller = MagicMock()
         controller.wait_for_online_trajectory = AsyncMock(
             return_value={"session_id": "sess-1", "trajectory_id": 7}
@@ -538,17 +536,17 @@ class TestInferenceServiceWorkflow:
                 "areal.experimental.inference_service.controller.workflow.stats_tracker"
             ) as mock_st,
             patch(
-                "areal.experimental.inference_service.controller.workflow.deserialize_interactions"
+                "areal.experimental.inference_service.controller.workflow.deserialize_value"
             ) as mock_deserialize,
         ):
-            mock_deserialize.return_value = {"chatcmpl-1": mock_interaction}
+            mock_deserialize.return_value = {"interactions": [{"reward": 1.0}]}
 
             # _run_online uses ``async with http_session.post(...)`` directly,
             # so the mock must support the async context-manager protocol.
             mock_response = MagicMock()
             mock_response.raise_for_status = MagicMock()
             mock_response.json = AsyncMock(
-                return_value={"interactions": {"chatcmpl-1": {}}}
+                return_value={"traj": {"serialized": "trajectory"}}
             )
 
             mock_cm = MagicMock()
@@ -565,10 +563,10 @@ class TestInferenceServiceWorkflow:
             result = await workflow.arun_episode(engine=MagicMock(), data={})
 
         assert result is not None
-        assert "chatcmpl-1" in result
+        assert result["interactions"][0]["reward"] == 1.0
         controller.wait_for_online_trajectory.assert_awaited_once_with(timeout=3.0)
         mock_http_session.post.assert_called_once()
-        mock_deserialize.assert_called_once_with({"chatcmpl-1": {}})
+        mock_deserialize.assert_called_once_with({"serialized": "trajectory"})
 
     @pytest.mark.asyncio
     async def test_offline_mode_runs_agent(self):

--- a/tests/experimental/inference_service/test_data_proxy_chat.py
+++ b/tests/experimental/inference_service/test_data_proxy_chat.py
@@ -18,6 +18,8 @@ from areal.experimental.inference_service.data_proxy.session import (
     SessionData,
     SessionStore,
 )
+from areal.infra.rpc.rtensor import RTensor, fetch
+from areal.infra.rpc.serialization import deserialize_value
 
 # =============================================================================
 # Fixtures
@@ -76,6 +78,7 @@ def mock_areal_client():
         import torch
 
         nonlocal call_index
+        interaction_index = call_index
 
         completion = ChatCompletion(
             id=f"chatcmpl-test{call_index}",
@@ -103,7 +106,9 @@ def mock_areal_client():
         )
         # Pre-populate _cache so to_tensor_dict() works without ModelResponse
         interaction._cache = {
-            "input_ids": torch.tensor([[100, 200, 300, 1234, 5678, 2]]),
+            "input_ids": torch.tensor(
+                [[100 + interaction_index, 200, 300, 1234, 5678, 2]]
+            ),
             "loss_mask": torch.tensor([[0, 0, 0, 1, 1, 1]]),
             "logprobs": torch.tensor([[0.0, 0.0, 0.0, -0.5, -0.3, -0.1]]),
             "versions": torch.tensor([[-1, -1, -1, 0, 0, 0]]),
@@ -156,6 +161,12 @@ def admin_headers():
 
 def session_headers(api_key: str):
     return {"Authorization": f"Bearer {api_key}"}
+
+
+def response_first_token(response: httpx.Response) -> int:
+    input_ids = deserialize_value(response.json()["traj"])["input_ids"]
+    assert isinstance(input_ids, RTensor)
+    return int(fetch(input_ids.shard.shard_id).reshape(-1)[0])
 
 
 # =============================================================================
@@ -1029,7 +1040,6 @@ async def test_online_set_reward_duplicate_is_idempotent(client):
     assert second.json()["ready_transition"] is False
 
 
-@pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
 @pytest.mark.asyncio
 async def test_online_export_latest_ready_without_trajectory_id(client):
     token = ADMIN_KEY
@@ -1071,11 +1081,9 @@ async def test_online_export_latest_ready_without_trajectory_id(client):
         headers=admin_headers(),
     )
     assert export_resp.status_code == 200
-    interactions = export_resp.json()["interactions"]
-    assert list(interactions) == ["chatcmpl-test1"]
+    assert response_first_token(export_resp) == 101
 
 
-@pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
 @pytest.mark.asyncio
 async def test_online_export_explicit_trajectory_id(client):
     token = ADMIN_KEY
@@ -1122,8 +1130,7 @@ async def test_online_export_explicit_trajectory_id(client):
         headers=admin_headers(),
     )
     assert export_resp.status_code == 200
-    interactions = export_resp.json()["interactions"]
-    assert list(interactions) == ["chatcmpl-test0"]
+    assert response_first_token(export_resp) == 100
 
     health = await client.get("/health")
     assert health.status_code == 200
@@ -1162,7 +1169,6 @@ async def test_health_sessions_count_after_start(client):
 # =============================================================================
 
 
-@pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
 @pytest.mark.asyncio
 async def test_full_session_lifecycle(client, mock_areal_client):
     """Test the complete flow: start → chat → set_reward → export."""
@@ -1205,5 +1211,4 @@ async def test_full_session_lifecycle(client, mock_areal_client):
         headers=admin_headers(),
     )
     assert resp.status_code == 200
-    data = resp.json()
-    assert "interactions" in data
+    assert response_first_token(resp) == 100

--- a/tests/experimental/inference_service/test_image_input.py
+++ b/tests/experimental/inference_service/test_image_input.py
@@ -27,6 +27,8 @@ from areal.experimental.openai.client import (
     _build_messages_list,
     _extract_images_from_messages,
 )
+from areal.infra.rpc.rtensor import RTensor, fetch
+from areal.infra.rpc.serialization import deserialize_value
 
 # ---------------------------------------------------------------------------
 # Real image fixtures
@@ -57,6 +59,12 @@ def _materialize(obj):
         return [_materialize(item) for item in obj]
     except TypeError:
         return obj
+
+
+def _response_first_token(response: httpx.Response) -> int:
+    input_ids = deserialize_value(response.json()["traj"])["input_ids"]
+    assert isinstance(input_ids, RTensor)
+    return int(fetch(input_ids.shard.shard_id).reshape(-1)[0])
 
 
 @pytest.fixture
@@ -679,7 +687,6 @@ class TestDataProxyImagePassthrough:
         assert messages[0]["content"][1]["type"] == "image_url"
         assert messages[0]["content"][1]["image_url"]["url"] == data_uri
 
-    @pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
     @pytest.mark.asyncio
     async def test_session_lifecycle_with_image_messages(self, image_test_client):
         """Full lifecycle: start → image chat → reward → end → export."""
@@ -737,9 +744,7 @@ class TestDataProxyImagePassthrough:
             headers={"Authorization": f"Bearer {ADMIN_KEY}"},
         )
         assert resp.status_code == 200
-        data = resp.json()
-        assert "interactions" in data
-        assert len(data["interactions"]) == 1
+        assert _response_first_token(resp) == 100
 
     @pytest.mark.asyncio
     async def test_mixed_text_and_image_messages(self, image_test_client):

--- a/tests/experimental/inference_service/test_online_stack.py
+++ b/tests/experimental/inference_service/test_online_stack.py
@@ -28,6 +28,8 @@ from areal.experimental.inference_service.router.app import (
     create_app as create_router_app,
 )
 from areal.experimental.inference_service.router.config import RouterConfig
+from areal.infra.rpc.rtensor import RTensor, fetch
+from areal.infra.rpc.serialization import deserialize_value
 
 ADMIN_KEY = "areal-admin-key"
 DATA_PROXY_ADDR = "http://data-proxy"
@@ -48,6 +50,7 @@ def _make_mock_areal_client():
         import torch
 
         nonlocal call_index
+        interaction_index = call_index
         completion = ChatCompletion(
             id=f"chatcmpl-test{call_index}",
             choices=[
@@ -71,7 +74,9 @@ def _make_mock_areal_client():
             output_message_list=[{"role": "assistant", "content": "Hello!"}],
         )
         interaction._cache = {
-            "input_ids": torch.tensor([[100, 200, 300, 1234, 5678, 2]]),
+            "input_ids": torch.tensor(
+                [[100 + interaction_index, 200, 300, 1234, 5678, 2]]
+            ),
             "loss_mask": torch.tensor([[0, 0, 0, 1, 1, 1]]),
             "logprobs": torch.tensor([[0.0, 0.0, 0.0, -0.5, -0.3, -0.1]]),
             "versions": torch.tensor([[-1, -1, -1, 0, 0, 0]]),
@@ -251,7 +256,12 @@ def _hitl_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {ADMIN_KEY}"}
 
 
-@pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
+def _response_first_token(response: httpx.Response) -> int:
+    input_ids = deserialize_value(response.json()["traj"])["input_ids"]
+    assert isinstance(input_ids, RTensor)
+    return int(fetch(input_ids.shard.shard_id).reshape(-1)[0])
+
+
 @pytest.mark.asyncio
 async def test_online_stack_latest_ready_export_keeps_session_pinned(online_stack):
     gw = online_stack["gateway_client"]
@@ -287,13 +297,12 @@ async def test_online_stack_latest_ready_export_keeps_session_pinned(online_stac
         headers=_admin_headers(),
     )
     assert export_resp.status_code == 200
-    assert list(export_resp.json()["interactions"]) == ["chatcmpl-test1"]
+    assert _response_first_token(export_resp) == 101
 
     session_registry = router_app.state.session_registry
     assert await session_registry.lookup_by_id("__hitl__") == DATA_PROXY_ADDR
 
 
-@pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
 @pytest.mark.asyncio
 async def test_online_stack_explicit_then_latest_export(online_stack):
     gw = online_stack["gateway_client"]
@@ -336,7 +345,7 @@ async def test_online_stack_explicit_then_latest_export(online_stack):
         headers=_admin_headers(),
     )
     assert explicit_resp.status_code == 200
-    assert list(explicit_resp.json()["interactions"]) == ["chatcmpl-test0"]
+    assert _response_first_token(explicit_resp) == 100
 
     latest_resp = await gw.post(
         "/export_trajectories",
@@ -349,7 +358,7 @@ async def test_online_stack_explicit_then_latest_export(online_stack):
         headers=_admin_headers(),
     )
     assert latest_resp.status_code == 200
-    assert list(latest_resp.json()["interactions"]) == ["chatcmpl-test1"]
+    assert _response_first_token(latest_resp) == 101
 
 
 @pytest.mark.asyncio

--- a/tests/test_local_scheduler.py
+++ b/tests/test_local_scheduler.py
@@ -30,12 +30,6 @@ from areal.infra.scheduler.exceptions import (
 from areal.infra.scheduler.local import LocalScheduler, WorkerInfo
 from areal.infra.utils.proc import kill_process_tree
 
-# Skip all tests in this module by default - run manually only
-pytestmark = pytest.mark.skip(
-    reason="LocalScheduler tests have unexpected behavior on GCP CI machines. "
-    "Run manually with: pytest tests/test_local_scheduler.py"
-)
-
 # ============================================================================
 # Fixtures and Helper Functions
 # ============================================================================
@@ -127,6 +121,10 @@ def create_scheduler(tmp_path, gpu_devices=None, **kwargs):
     }
     defaults.update(kwargs)
     return LocalScheduler(**defaults)
+
+
+def create_rpc_scheduling_spec():
+    return SchedulingSpec(cmd="python -m areal.infra.rpc.rpc_server")
 
 
 def create_worker_info(
@@ -397,7 +395,7 @@ class TestWorkerCreation:
         scheduler = create_scheduler(tmp_path, gpu_devices=[0, 1])
 
         with patch.object(scheduler, "_configure_worker", return_value=None):
-            job = Job(replicas=2, role="rollout")
+            job = Job(replicas=2, role="rollout", tasks=[create_rpc_scheduling_spec()])
             worker_ids = scheduler.create_workers(job)
 
             assert worker_ids == ["rollout/0", "rollout/1"]
@@ -703,7 +701,7 @@ class TestWorkerCreation:
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc
 
-            job = Job(replicas=1, role="test")
+            job = Job(replicas=1, role="test", tasks=[create_rpc_scheduling_spec()])
             with patch.object(scheduler, "_configure_worker", return_value=None):
                 scheduler.create_workers(job)
 
@@ -729,7 +727,7 @@ class TestWorkerCreation:
         assert "replicas must be greater than 0" in str(exc_info.value)
 
     def test_create_workers_invalid_specs_length(self, tmp_path):
-        """Should raise WorkerCreationError when tasks length is invalid."""
+        """Should reject a task count that cannot map to worker replicas."""
         scheduler = create_scheduler(tmp_path, gpu_devices=[0, 1])
 
         job = Job(
@@ -747,11 +745,12 @@ class TestWorkerCreation:
             ],  # 2 tasks for 3 replicas
         )
 
-        with pytest.raises(WorkerCreationError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             scheduler.create_workers(job)
 
-        assert "schedulings length (2) must be 1 or equal to replicas (3)" in str(
-            exc_info.value
+        assert (
+            "Number of scheduling specs (2) must be 1 or match number of workers (3)"
+            in str(exc_info.value)
         )
 
     @patch("areal.infra.scheduler.local.gethostip")
@@ -777,7 +776,7 @@ class TestWorkerCreation:
 
         scheduler = create_scheduler(tmp_path)
 
-        job = Job(replicas=1, role="test")
+        job = Job(replicas=1, role="test", tasks=[create_rpc_scheduling_spec()])
 
         with patch.object(
             scheduler, "_read_log_tail", return_value="Error: Failed to start server"
@@ -809,7 +808,7 @@ class TestWorkerCreation:
         mock_popen.side_effect = [conflict_proc, success_proc]
 
         scheduler = create_scheduler(tmp_path)
-        job = Job(replicas=1, role="test")
+        job = Job(replicas=1, role="test", tasks=[create_rpc_scheduling_spec()])
 
         with patch.object(
             scheduler,
@@ -844,7 +843,7 @@ class TestWorkerCreation:
 
         scheduler = create_scheduler(tmp_path)
 
-        job = Job(replicas=2, role="test")
+        job = Job(replicas=2, role="test", tasks=[create_rpc_scheduling_spec()])
 
         with patch.object(scheduler, "_cleanup_workers") as mock_cleanup:
             with pytest.raises(WorkerCreationError) as exc_info:
@@ -1809,7 +1808,7 @@ class TestEdgeCases:
 
         scheduler = create_scheduler(tmp_path)
 
-        job = Job(replicas=5, role="worker")
+        job = Job(replicas=5, role="worker", tasks=[create_rpc_scheduling_spec()])
         with patch.object(scheduler, "_configure_worker", return_value=None):
             worker_ids = scheduler.create_workers(job)
 
@@ -1880,7 +1879,7 @@ class TestColocationBehavior:
         scheduler = create_scheduler(tmp_path, gpu_devices=[0, 1])
 
         # Create target workers
-        actor_job = Job(replicas=1, role="actor")
+        actor_job = Job(replicas=1, role="actor", tasks=[create_rpc_scheduling_spec()])
         with patch.object(scheduler, "_configure_worker", return_value=None):
             scheduler.create_workers(actor_job)
 
@@ -1888,6 +1887,7 @@ class TestColocationBehavior:
         ref_job = Job(
             replicas=1,
             role="ref",
+            tasks=[create_rpc_scheduling_spec()],
             scheduling_strategy=SchedulingStrategy(
                 type=SchedulingStrategyType.colocation, target="actor", fork=False
             ),
@@ -1922,7 +1922,7 @@ class TestColocationBehavior:
         scheduler = create_scheduler(tmp_path)
 
         # Create target workers
-        actor_job = Job(replicas=1, role="actor")
+        actor_job = Job(replicas=1, role="actor", tasks=[create_rpc_scheduling_spec()])
         with patch.object(scheduler, "_configure_worker", return_value=None):
             scheduler.create_workers(actor_job)
 
@@ -1930,6 +1930,7 @@ class TestColocationBehavior:
         ref_job = Job(
             replicas=1,
             role="ref",
+            tasks=[create_rpc_scheduling_spec()],
             scheduling_strategy=SchedulingStrategy(
                 type=SchedulingStrategyType.colocation, target="actor", fork=False
             ),
@@ -1977,7 +1978,7 @@ class TestColocationBehavior:
         scheduler = create_scheduler(tmp_path, gpu_devices=[0, 1])
 
         # Create target workers with 2 replicas
-        actor_job = Job(replicas=2, role="actor")
+        actor_job = Job(replicas=2, role="actor", tasks=[create_rpc_scheduling_spec()])
         with patch.object(scheduler, "_configure_worker", return_value=None):
             scheduler.create_workers(actor_job)
 
@@ -1985,6 +1986,7 @@ class TestColocationBehavior:
         ref_job = Job(
             replicas=1,  # Mismatch!
             role="ref",
+            tasks=[create_rpc_scheduling_spec()],
             scheduling_strategy=SchedulingStrategy(
                 type=SchedulingStrategyType.colocation, target="actor"
             ),
@@ -2013,6 +2015,7 @@ class TestColocationBehavior:
         ref_job = Job(
             replicas=1,
             role="ref",
+            tasks=[create_rpc_scheduling_spec()],
             scheduling_strategy=SchedulingStrategy(
                 type=SchedulingStrategyType.colocation, target="nonexistent"
             ),
@@ -2327,6 +2330,7 @@ class TestForkColocationBehavior:
             ref_job = Job(
                 replicas=1,
                 role="ref",
+                tasks=[create_rpc_scheduling_spec()],
                 scheduling_strategy=SchedulingStrategy(
                     type=SchedulingStrategyType.colocation, target="actor", fork=True
                 ),
@@ -2457,6 +2461,7 @@ class TestForkColocationBehavior:
             ref_job = Job(
                 replicas=1,  # Mismatch - actor has 2 replicas!
                 role="ref",
+                tasks=[create_rpc_scheduling_spec()],
                 scheduling_strategy=SchedulingStrategy(
                     type=SchedulingStrategyType.colocation, target="actor", fork=True
                 ),
@@ -2480,6 +2485,7 @@ class TestForkColocationBehavior:
         ref_job = Job(
             replicas=1,
             role="ref",
+            tasks=[create_rpc_scheduling_spec()],
             scheduling_strategy=SchedulingStrategy(
                 type=SchedulingStrategyType.colocation, target="nonexistent", fork=True
             ),
@@ -2573,6 +2579,7 @@ class TestForkColocationBehavior:
             ref_job = Job(
                 replicas=1,
                 role="ref",
+                tasks=[create_rpc_scheduling_spec()],
                 scheduling_strategy=SchedulingStrategy(
                     type=SchedulingStrategyType.colocation, target="actor", fork=True
                 ),

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -23,6 +23,44 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+_ISOLATED_MODULES = (
+    "megatron",
+    "megatron.core",
+    "megatron.core.dist_checkpointing",
+    "megatron.core.dist_checkpointing.mapping",
+    "megatron.core.dist_checkpointing.serialization",
+    "megatron.core.dist_checkpointing.strategies",
+    "megatron.core.dist_checkpointing.strategies.async_utils",
+    "megatron.core.dist_checkpointing.strategies.fully_parallel",
+    "areal",
+    "areal.engine",
+    "areal.engine.megatron_utils",
+    "areal.engine.megatron_utils.checkpointer",
+    "areal.infra",
+    "areal.infra.platforms",
+    "areal.utils",
+    "areal.utils.logging",
+    "areal.utils.stats_tracker",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def isolate_checkpointer_modules():
+    missing = object()
+    original_modules = {
+        name: sys.modules.get(name, missing) for name in _ISOLATED_MODULES
+    }
+    for name in _ISOLATED_MODULES:
+        sys.modules.pop(name, None)
+
+    yield
+
+    for name in _ISOLATED_MODULES:
+        sys.modules.pop(name, None)
+        original = original_modules[name]
+        if original is not missing:
+            sys.modules[name] = original
+
 
 def _import_checkpointer():
     """Import the checkpointer module without triggering the full areal package."""
@@ -31,23 +69,12 @@ def _import_checkpointer():
 
     # Stub out heavy/optional dependencies so the module loads on a CPU box
     # without Megatron or a Stager-capable torch build.
-    for path in (
-        "megatron",
-        "megatron.core",
-        "megatron.core.dist_checkpointing",
-        "megatron.core.dist_checkpointing.mapping",
-        "megatron.core.dist_checkpointing.serialization",
-        "megatron.core.dist_checkpointing.strategies",
-        "megatron.core.dist_checkpointing.strategies.async_utils",
-        "megatron.core.dist_checkpointing.strategies.fully_parallel",
-        "areal",
-        "areal.engine",
-        "areal.engine.megatron_utils",
-        "areal.infra",
-        "areal.infra.platforms",
-        "areal.utils",
-        "areal.utils.logging",
-    ):
+    for path in _ISOLATED_MODULES:
+        if path in (
+            "areal.engine.megatron_utils.checkpointer",
+            "areal.utils.stats_tracker",
+        ):
+            continue
         sys.modules.setdefault(path, types.ModuleType(path))
 
     sys.modules["megatron.core"].dist_checkpointing = sys.modules[
@@ -196,13 +223,6 @@ def test_close_is_idempotent(patched_checkpointer):
     assert manager._async_queue is None
 
 
-@pytest.mark.skip(
-    reason="Fixture is not isolated across test files: if test_megatron_engine "
-    "(or any test that imports MegatronEngine) runs first, "
-    "areal.engine.megatron_utils.checkpointer is already cached in sys.modules, "
-    "so _import_checkpointer's stub-installation branch (which mocks "
-    "areal.utils.stats_tracker.scalar) is skipped. Tracked in a follow-up issue."
-)
 def test_async_save_reports_queue_depth_only(patched_checkpointer, tmp_path):
     """async_save emits ckpt/async_save_queue_depth on schedule and no other metric.
 
@@ -236,13 +256,6 @@ def test_async_save_reports_queue_depth_only(patched_checkpointer, tmp_path):
     assert all_keys == {"ckpt/async_save_queue_depth"}
 
 
-@pytest.mark.skip(
-    reason="Fixture is not isolated across test files: if test_megatron_engine "
-    "(or any test that imports MegatronEngine) runs first, "
-    "areal.engine.megatron_utils.checkpointer is already cached in sys.modules, "
-    "so _import_checkpointer's stub-installation branch (which mocks "
-    "areal.utils.stats_tracker.scalar) is skipped. Tracked in a follow-up issue."
-)
 def test_sync_save_emits_no_async_metrics(patched_checkpointer, tmp_path):
     """Sync save path stays metric-free; trainer-side `timeperf/save` is sufficient."""
     mod, manager, _ = patched_checkpointer


### PR DESCRIPTION
## Description

Restore 100 CPU test cases that were unconditionally skipped because of stale LocalScheduler fixtures, cached Megatron test stubs, and legacy inference-service trajectory export assertions. This is test-only and does not change production or workflow behavior.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable; test-only change)
- [x] Branch is up to date with `ascend`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

The LocalScheduler suite now supplies the required `SchedulingSpec` fields and all 91 cases pass. The Megatron async-save fixture restores cached modules after its isolated stubs, allowing both previously skipped metric cases to run regardless of test order. Seven inference-service tests now validate the serialized `traj` response and distinguish explicit from latest trajectory selection using request-token markers. Validation: 105 recovered cases passed together in 88.28 seconds; the four affected inference-service files produced 128 passes locally, and their four existing callback tests passed separately with local proxy bypass; full pre-commit passed. Based on the latest Ascend CPU report, expected results change from 2,321 passed and 111 skipped to 2,421 passed and 11 skipped, with 2,432 selected cases unchanged.

______________________________________________________________________

**Need help?** Check the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md) or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
