### PR TITLE
fix: make V2 AWEX recovery reconnect-safe

### DIFF
--- a/areal/infra/rpc/guard/app.py
+++ b/areal/infra/rpc/guard/app.py
@@ -75,6 +75,8 @@ class GuardState:
         # Port tracking (thread-safe)
         self.allocated_ports: set[int] = set()
         self.owned_ports: dict[tuple[str, int], set[int]] = {}
+        self.token_ports: dict[str, tuple[tuple[int, tuple[int, ...]], set[int]]] = {}
+        self.released_port_tokens: set[str] = set()
         self.port_lock_files: dict[int, Any] = {}
         self.allocated_ports_lock = Lock()
 
@@ -153,6 +155,8 @@ def cleanup_forked_children(state: GuardState) -> None:
         state.port_lock_files.clear()
         state.allocated_ports.clear()
         state.owned_ports.clear()
+        state.token_ports.clear()
+        state.released_port_tokens.clear()
     for lock_file in lock_files:
         lock_file.close()
 
@@ -161,6 +165,22 @@ def _release_owned_ports(state: GuardState, key: tuple[str, int]) -> list[int]:
     """Release one fork owner's reserved ports. Caller need not hold a lock."""
     with state.allocated_ports_lock:
         ports = state.owned_ports.pop(key, set())
+        state.allocated_ports.difference_update(ports)
+        lock_files = [state.port_lock_files.pop(port, None) for port in ports]
+    for lock_file in lock_files:
+        if lock_file is not None:
+            lock_file.close()
+    return sorted(ports)
+
+
+def _release_token_ports(state: GuardState, token: str) -> list[int]:
+    """Idempotently release one client-token port reservation."""
+    with state.allocated_ports_lock:
+        # Retain a tombstone so a delayed alloc request cannot recreate a
+        # reservation after cleanup has already observed a successful release.
+        state.released_port_tokens.add(token)
+        reservation = state.token_ports.pop(token, None)
+        ports = set() if reservation is None else reservation[1]
         state.allocated_ports.difference_update(ports)
         lock_files = [state.port_lock_files.pop(port, None) for port in ports]
     for lock_file in lock_files:
@@ -292,6 +312,13 @@ def create_app(state: GuardState) -> Flask:
 
             role = data.get("role")
             worker_index = data.get("worker_index")
+            token = data.get("token")
+            if token is not None and (not isinstance(token, str) or not token):
+                return jsonify({"error": "'token' must be a non-empty string"}), 400
+            if token is not None and (role is not None or worker_index is not None):
+                return jsonify(
+                    {"error": "token and role owner are mutually exclusive"}
+                ), 400
             exclude_ports_raw = data.get("exclude_ports", [])
             if not isinstance(exclude_ports_raw, list) or not all(
                 isinstance(port, int) for port in exclude_ports_raw
@@ -303,7 +330,30 @@ def create_app(state: GuardState) -> Flask:
                 return jsonify({"error": str(e)}), 400
 
             s = get_state()
-            if owner is None:
+            if token is not None:
+                signature = (count, tuple(sorted(exclude_ports_raw)))
+                with s.allocated_ports_lock:
+                    if token in s.released_port_tokens:
+                        return jsonify(
+                            {"error": "token has already been released"}
+                        ), 410
+                    existing = s.token_ports.get(token)
+                    if existing is not None:
+                        if existing[0] != signature:
+                            return (
+                                jsonify(
+                                    {
+                                        "error": "token already has a different reservation"
+                                    }
+                                ),
+                                409,
+                            )
+                        ports = sorted(existing[1])
+                    else:
+                        ports = _reserve_node_ports(s, count, set(exclude_ports_raw))
+                        s.allocated_ports.update(ports)
+                        s.token_ports[token] = (signature, set(ports))
+            elif owner is None:
                 with s.allocated_ports_lock:
                     ports = _reserve_node_ports(s, count, set(exclude_ports_raw))
                     s.allocated_ports.update(ports)
@@ -331,6 +381,16 @@ def create_app(state: GuardState) -> Flask:
         data = request.get_json(silent=True) or {}
         role = data.get("role")
         worker_index = data.get("worker_index")
+        token = data.get("token")
+        if token is not None:
+            if role is not None or worker_index is not None:
+                return jsonify(
+                    {"error": "token and role owner are mutually exclusive"}
+                ), 400
+            if not isinstance(token, str) or not token:
+                return jsonify({"error": "'token' must be a non-empty string"}), 400
+            ports = _release_token_ports(state, token)
+            return jsonify({"status": "success", "ports": ports})
         try:
             key = _normalize_owner_key(role, worker_index)
         except ValueError as e:

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import os
+import time
 from collections.abc import Callable
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, cast
@@ -120,13 +121,17 @@ class PPOTrainer:
     ):
         try:
             self._init_impl(config, train_dataset, valid_dataset)
-        except Exception:
+        except Exception as original_error:
             logger.error(
                 "PPOTrainer construction failed; tearing down partially "
                 "created workers",
                 exc_info=True,
             )
-            self.close()
+            try:
+                self.close()
+            except Exception as cleanup_error:
+                original_error.add_note(f"Cleanup also failed: {cleanup_error}")
+                logger.warning("Cleanup failed after construction error", exc_info=True)
             raise
 
     def _init_impl(
@@ -495,6 +500,17 @@ class PPOTrainer:
         else:
             raise ValueError(
                 f"Invalid weight update mode: {self.config.actor.weight_update_mode}"
+            )
+
+        if (
+            isinstance(self.rollout, RolloutControllerV2)
+            and self.weight_update_meta.type == "awex"
+            and self._is_actor_rollout_colocated(config)
+            and config.recover.mode not in ("disabled", "off")
+        ):
+            raise NotImplementedError(
+                "V2 colocated AWEX recovery is not supported; disable "
+                "`recover.mode` or use separated actor/rollout placement."
             )
 
         self.actor.connect_engine(self.rollout, self.weight_update_meta)
@@ -1198,7 +1214,17 @@ class PPOTrainer:
                 logger.warning(
                     "mopd_teacher_phase.close() failed during close", exc_info=True
                 )
+        actor = getattr(self, "actor", None)
+        cleanup_pairs = getattr(actor, "cleanup_weight_update_pairs", None)
+        cleanup_error = None
+        if cleanup_pairs is not None:
+            try:
+                cleanup_pairs(time.monotonic() + 30.0)
+            except Exception as exc:
+                cleanup_error = exc
         for attr in ("eval_rollout", "rollout", "teacher", "ref", "critic", "actor"):
+            if cleanup_error is not None and attr in ("rollout", "actor"):
+                continue
             engine = getattr(self, attr, None)
             if engine is not None:
                 try:
@@ -1208,6 +1234,8 @@ class PPOTrainer:
                         f"{attr}.destroy() failed during close", exc_info=True
                     )
         perf_tracer.save(force=True)
+        if cleanup_error is not None:
+            raise cleanup_error
 
     def _config_perf_tracer(self):
         rank = int(os.getenv("RANK", "0"))
@@ -1918,5 +1946,12 @@ class PPOTrainer:
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is not None:
             logger.error(f"Training failed with exception: {exc_value}", exc_info=True)
-        self.close()
+            try:
+                self.close()
+            except Exception as cleanup_error:
+                if exc_value is not None:
+                    exc_value.add_note(f"Cleanup also failed: {cleanup_error}")
+                logger.warning("Cleanup failed after training error", exc_info=True)
+        else:
+            self.close()
         return False

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import dataclasses
-import inspect
 import json
 import os
 import pickle
+import time
 from typing import TYPE_CHECKING, Any
 
 import torch.distributed as dist
@@ -198,38 +198,16 @@ class RecoverHandler:
         non-LoRA run regardless of placement, so the caller has to state whether
         actor and rollout physically share devices.
         """
+        from areal.v2.inference_service.controller.controller import (
+            RolloutControllerV2,
+        )
+
         return (
-            inference_engine is not None
+            isinstance(inference_engine, RolloutControllerV2)
+            and inference_engine is not None
             and getattr(weight_update_meta, "type", None) == "awex"
             and colocated_rollout
         )
-
-    @staticmethod
-    def _require_colocate_rollout_protocol(
-        inference_engine: InferenceEngine,
-    ) -> None:
-        missing = []
-        if not callable(getattr(inference_engine, "pause_generation_sync", None)):
-            missing.append("pause_generation_sync()")
-
-        offload = getattr(inference_engine, "offload", None)
-        if not callable(offload):
-            missing.append("offload(tags=...)")
-        else:
-            try:
-                accepts_tags = "tags" in inspect.signature(offload).parameters
-            except (TypeError, ValueError):
-                accepts_tags = True
-            if not accepts_tags:
-                missing.append("offload(tags=...)")
-
-        if missing:
-            raise NotImplementedError(
-                "Colocated AWEX recovery needs a rollout engine implementing "
-                f"{', '.join(missing)}, which {type(inference_engine).__name__} "
-                "does not provide. Disable `recover.mode` or run this "
-                "configuration without actor-rollout colocation."
-            )
 
     def dump(
         self,
@@ -298,6 +276,15 @@ class RecoverHandler:
             return
         if inference_engine is not None and weight_update_meta is None:
             raise ValueError("Weight update meta is required for recovery.")
+        if self._should_run_awex_colocate_transfer(
+            inference_engine,
+            weight_update_meta,
+            colocated_rollout,
+        ):
+            raise NotImplementedError(
+                "V2 colocated AWEX recovery is not supported; disable "
+                "`recover.mode` or use separated actor/rollout placement."
+            )
 
         normalized_engine: dict[str, TrainEngine | TrainController] = (
             self._normalize_recover_engines(engine)
@@ -321,17 +308,8 @@ class RecoverHandler:
             global_step = recover_info.last_step_info.global_step
             recovery_version = global_step + 1
 
-            is_awex_colocate = self._should_run_awex_colocate_transfer(
-                inference_engine=inference_engine,
-                weight_update_meta=weight_update_meta,
-                colocated_rollout=colocated_rollout,
-            )
-            if is_awex_colocate:
-                self._require_colocate_rollout_protocol(inference_engine)
-
-            if not is_awex_colocate:
-                for name, engine_ in normalized_engine.items():
-                    self._load_checkpoint(engine_, name=name)
+            for name, engine_ in normalized_engine.items():
+                self._load_checkpoint(engine_, name=name)
 
             if inference_engine is not None:
                 assert weight_update_meta is not None
@@ -339,52 +317,82 @@ class RecoverHandler:
                 versioned_meta = weight_update_meta.with_version(recovery_version)
                 update_engine.connect_engine(inference_engine, versioned_meta)
                 inference_engine.pause()
-                should_resume_inference = True
                 transfer_started = False
+                transfer_completed = False
+                transactional_publish = all(
+                    callable(getattr(controller, method, None))
+                    for controller, method in (
+                        (update_engine, "broadcast_version"),
+                        (update_engine, "commit_local_version"),
+                        (inference_engine, "broadcast_version"),
+                        (inference_engine, "commit_local_version"),
+                    )
+                )
                 try:
-                    # AWEX colocate transfer requires the full engine-level
-                    # pause/offload protocol, not just the controller pause. The
-                    # sglang plugin's patched event loop only drains the weight-
-                    # update queue while scheduler._engine_paused is True (set by
-                    # pause_generation), and the reader-side protocol expects the
-                    # engine's kv/weights released before the writer publishes.
-                    # Without this the recover-path transfer deadlocks: reader
-                    # never consumes the queued version marker, writer blocks on
-                    # weights_update_finished forever.
-                    # Mirror of the trainer's pre-update sequence; the reverse
-                    # side (kv_cache onload) happens inside update_weights.
-                    if is_awex_colocate:
-                        inference_engine.pause_generation_sync()
-                        inference_engine.offload(tags=["kv_cache"])
-                        inference_engine.offload(tags=["weights"])
-                        # Load the actor checkpoint only after the colocated
-                        # rollout engine has released its GPU memory; loading
-                        # first would stack DCP weights/optimizer on top of the
-                        # still-resident sglang allocation and risk OOM.
-                        for name, engine_ in normalized_engine.items():
-                            self._load_checkpoint(engine_, name=name)
                     transfer_started = True
-                    update_engine.update_weights(versioned_meta)
-                except BaseException as exc:
-                    # A transfer error is unsafe by default: inference may have
-                    # applied only part of the payload. The controller can
-                    # explicitly mark errors that occurred before any mutation.
-                    if transfer_started:
-                        should_resume_inference = not getattr(
-                            exc, "inference_weights_may_be_mutated", True
+                    if transactional_publish:
+                        update_engine.update_weights(
+                            versioned_meta, resume_generation=False
                         )
-                    raise
-                finally:
-                    if should_resume_inference:
-                        inference_engine.resume()
                     else:
-                        logger.critical(
-                            "Recovery weight synchronization may have partially "
-                            "mutated inference weights; leaving inference paused "
-                            "until a known-good recovery succeeds"
-                        )
-                update_engine.set_version(recovery_version)
-                inference_engine.set_version(recovery_version)
+                        update_engine.update_weights(versioned_meta)
+                    transfer_completed = True
+
+                    if transactional_publish:
+                        publish_deadline = time.monotonic() + 30.0
+                        for attempt in range(3):
+                            try:
+                                remaining = publish_deadline - time.monotonic()
+                                if remaining <= 0:
+                                    raise TimeoutError(
+                                        "Recovery version publish deadline exceeded"
+                                    )
+                                update_engine.broadcast_version(
+                                    recovery_version, timeout=remaining
+                                )
+                                remaining = publish_deadline - time.monotonic()
+                                inference_engine.broadcast_version(
+                                    recovery_version, timeout=max(0.001, remaining)
+                                )
+                                break
+                            except BaseException:
+                                if attempt == 2 or time.monotonic() >= publish_deadline:
+                                    raise
+                                time.sleep(
+                                    min(
+                                        0.1,
+                                        max(
+                                            0.0,
+                                            publish_deadline - time.monotonic(),
+                                        ),
+                                    )
+                                )
+                        update_engine.commit_local_version(recovery_version)
+                        inference_engine.commit_local_version(recovery_version)
+                        inference_engine.continue_generation()
+                    else:
+                        update_engine.set_version(recovery_version)
+                        inference_engine.set_version(recovery_version)
+                    inference_engine.resume()
+                except BaseException as exc:
+                    setattr(exc, "weight_transfer_completed", transfer_completed)
+                    safe_to_resume = (
+                        transfer_started
+                        and not transfer_completed
+                        and not getattr(exc, "inference_weights_may_be_mutated", True)
+                        and not getattr(exc, "generation_pause_state_unresolved", False)
+                    )
+                    if safe_to_resume:
+                        try:
+                            if transactional_publish:
+                                inference_engine.continue_generation()
+                            inference_engine.resume()
+                        except BaseException as resume_error:
+                            exc.add_note(
+                                f"Generation/dispatcher rollback also failed: "
+                                f"{resume_error}"
+                            )
+                    raise
             return recover_info
         except (FileNotFoundError, InValidRecoverInfo):
             logger.warning(

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -177,38 +177,6 @@ class RecoverHandler:
         )
 
     @staticmethod
-    def _is_gateway_train_controller(
-        engine: TrainEngine
-        | TrainController
-        | dict[str, TrainEngine | TrainController],
-    ) -> bool:
-        from areal.v2.training_service.controller.controller import (
-            GatewayTrainController,
-        )
-
-        if isinstance(engine, GatewayTrainController):
-            return True
-        if isinstance(engine, dict):
-            return any(
-                isinstance(controller, GatewayTrainController)
-                for controller in engine.values()
-            )
-        return False
-
-    def _ensure_recover_supported(
-        self,
-        engine: TrainEngine
-        | TrainController
-        | dict[str, TrainEngine | TrainController],
-    ) -> None:
-        if self._is_gateway_train_controller(engine):
-            raise NotImplementedError(
-                "Recovery is not supported with GatewayTrainController "
-                '(`_version="v2"`) yet. Disable `recover.mode` or use '
-                '`_version="v1"`.'
-            )
-
-    @staticmethod
     def _normalize_recover_engines(
         engine: TrainEngine
         | TrainController
@@ -279,7 +247,6 @@ class RecoverHandler:
     ):
         if self.config.mode in ("disabled", "off"):
             return
-        self._ensure_recover_supported(engine)
         # currently only support recover on one engine
         if not self.freq_ctl.check(
             epochs=int(step_info.epoch_step == self.ft_spec.steps_per_epoch - 1),
@@ -329,14 +296,9 @@ class RecoverHandler:
     ) -> RecoverInfo | None:
         if self.config.mode in ("disabled", "off"):
             return
-        self._ensure_recover_supported(engine)
         if inference_engine is not None and weight_update_meta is None:
             raise ValueError("Weight update meta is required for recovery.")
 
-        # TODO(agent): GatewayTrainController is currently duck-typed and does
-        # not satisfy this TrainController type check. Extend recovery to accept
-        # controller-v2 instances (or make v2 inherit TrainController) before
-        # relying on resumed runs with `_version="v2"`.
         normalized_engine: dict[str, TrainEngine | TrainController] = (
             self._normalize_recover_engines(engine)
         )
@@ -377,6 +339,8 @@ class RecoverHandler:
                 versioned_meta = weight_update_meta.with_version(recovery_version)
                 update_engine.connect_engine(inference_engine, versioned_meta)
                 inference_engine.pause()
+                should_resume_inference = True
+                transfer_started = False
                 try:
                     # AWEX colocate transfer requires the full engine-level
                     # pause/offload protocol, not just the controller pause. The
@@ -399,11 +363,26 @@ class RecoverHandler:
                         # still-resident sglang allocation and risk OOM.
                         for name, engine_ in normalized_engine.items():
                             self._load_checkpoint(engine_, name=name)
+                    transfer_started = True
                     update_engine.update_weights(versioned_meta)
+                except BaseException as exc:
+                    # A transfer error is unsafe by default: inference may have
+                    # applied only part of the payload. The controller can
+                    # explicitly mark errors that occurred before any mutation.
+                    if transfer_started:
+                        should_resume_inference = not getattr(
+                            exc, "inference_weights_may_be_mutated", True
+                        )
+                    raise
                 finally:
-                    # Always resume: leaving rollout paused after a failed
-                    # checkpoint load or transfer would hang every later step.
-                    inference_engine.resume()
+                    if should_resume_inference:
+                        inference_engine.resume()
+                    else:
+                        logger.critical(
+                            "Recovery weight synchronization may have partially "
+                            "mutated inference weights; leaving inference paused "
+                            "until a known-good recovery succeeds"
+                        )
                 update_engine.set_version(recovery_version)
                 inference_engine.set_version(recovery_version)
             return recover_info

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -1593,11 +1593,34 @@ class RolloutControllerV2:
             ],
             return_exceptions=True,
         )
-        failed = [r for r in results if isinstance(r, Exception)]
+        failed = [r for r in results if isinstance(r, BaseException)]
         for r in failed:
             logger.error("Failed to pause generation on a worker: %s", r)
-        if failed and len(failed) == len(results):
-            raise RuntimeError(f"pause_generation failed on ALL {len(failed)} workers")
+        if failed:
+            paused_addrs = [
+                addr
+                for addr, result in zip(self._data_proxy_addrs, results)
+                if not isinstance(result, BaseException)
+            ]
+            resume_results = await asyncio.gather(
+                *[
+                    self._async_data_proxy_post(addr, "/continue_generation", {})
+                    for addr in paused_addrs
+                ],
+                return_exceptions=True,
+            )
+            resume_failed = [
+                result for result in resume_results if isinstance(result, BaseException)
+            ]
+            for result in resume_failed:
+                logger.error(
+                    "Failed to resume a worker after partial pause: %s", result
+                )
+            raise RuntimeError(
+                f"pause_generation failed on {len(failed)}/{len(results)} workers; "
+                f"rollback resume failed on {len(resume_failed)}/"
+                f"{len(paused_addrs)} paused workers"
+            ) from failed[0]
 
     def continue_generation(self) -> None:
         """Continue generation on all workers."""
@@ -1616,13 +1639,13 @@ class RolloutControllerV2:
             ],
             return_exceptions=True,
         )
-        failed = [r for r in results if isinstance(r, Exception)]
+        failed = [r for r in results if isinstance(r, BaseException)]
         for r in failed:
             logger.error("Failed to continue generation on a worker: %s", r)
-        if failed and len(failed) == len(results):
+        if failed:
             raise RuntimeError(
-                f"continue_generation failed on ALL {len(failed)} workers"
-            )
+                f"continue_generation failed on {len(failed)}/{len(results)} workers"
+            ) from failed[0]
 
     # -- Stats -------------------------------------------------------------
 

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -1160,35 +1160,47 @@ class RolloutControllerV2:
     # -- Version management ------------------------------------------------
 
     def set_version(self, version: int) -> None:
-        """Set version locally and broadcast to all data proxy workers."""
+        """Broadcast a version, then commit it locally."""
+        self.broadcast_version(version)
+        self.commit_local_version(version)
+
+    def broadcast_version(self, version: int, timeout: float | None = None) -> None:
         from areal.infra.utils.concurrent import run_async_task
 
         self._ensure_initialized()
+        if not self._gateway_addr:
+            return
+        run_async_task(self._async_set_version, version, timeout)
 
+    def commit_local_version(self, version: int) -> None:
         with self._version_lock:
             self._version = version
 
-        if not self._gateway_addr:
-            return
-
-        run_async_task(self._async_set_version, version)
-
-    async def _async_set_version(self, version: int) -> None:
+    async def _async_set_version(
+        self, version: int, timeout: float | None = None
+    ) -> None:
         payload = {"version": version}
-        results = await asyncio.gather(
+        gather = asyncio.gather(
             *[
-                self._async_data_proxy_post(addr, "/set_version", payload)
+                self._async_data_proxy_post(
+                    addr, "/set_version", payload, timeout=timeout
+                )
                 for addr in self._data_proxy_addrs
             ],
             return_exceptions=True,
         )
-        failed = [r for r in results if isinstance(r, Exception)]
+        results = (
+            await gather
+            if timeout is None
+            else await asyncio.wait_for(gather, timeout=timeout)
+        )
+        failed = [r for r in results if isinstance(r, BaseException)]
         for r in failed:
             logger.error("Failed to set version on a worker: %s", r)
-        if failed and len(failed) == len(results):
+        if failed:
             raise RuntimeError(
-                f"set_version({version}) failed on ALL {len(failed)} workers"
-            )
+                f"set_version({version}) failed on {len(failed)}/{len(results)} workers"
+            ) from failed[0]
 
     def get_version(self) -> int:
         """Return the local version (compatible with VersionProvider protocol)."""
@@ -1597,15 +1609,10 @@ class RolloutControllerV2:
         for r in failed:
             logger.error("Failed to pause generation on a worker: %s", r)
         if failed:
-            paused_addrs = [
-                addr
-                for addr, result in zip(self._data_proxy_addrs, results)
-                if not isinstance(result, BaseException)
-            ]
             resume_results = await asyncio.gather(
                 *[
                     self._async_data_proxy_post(addr, "/continue_generation", {})
-                    for addr in paused_addrs
+                    for addr in self._data_proxy_addrs
                 ],
                 return_exceptions=True,
             )
@@ -1616,11 +1623,14 @@ class RolloutControllerV2:
                 logger.error(
                     "Failed to resume a worker after partial pause: %s", result
                 )
-            raise RuntimeError(
+            error = RuntimeError(
                 f"pause_generation failed on {len(failed)}/{len(results)} workers; "
                 f"rollback resume failed on {len(resume_failed)}/"
-                f"{len(paused_addrs)} paused workers"
-            ) from failed[0]
+                f"{len(self._data_proxy_addrs)} workers"
+            )
+            error.generation_pause_state_unresolved = bool(resume_failed)
+            error.inference_weights_may_be_mutated = False
+            raise error from failed[0]
 
     def continue_generation(self) -> None:
         """Continue generation on all workers."""
@@ -2033,13 +2043,18 @@ class RolloutControllerV2:
 
     @async_http_retry
     async def _async_data_proxy_post(
-        self, addr: str, endpoint: str, payload: dict[str, Any]
+        self,
+        addr: str,
+        endpoint: str,
+        payload: dict[str, Any],
+        timeout: float | None = None,
     ) -> None:
         """POST directly to a data proxy, bypassing gateway/router resolution."""
         url = f"{addr}{endpoint}"
         try:
             client = await self._get_async_client()
-            resp = await client.post(url, json=payload)
+            request_kwargs = {} if timeout is None else {"timeout": timeout}
+            resp = await client.post(url, json=payload, **request_kwargs)
             if resp.status_code >= 400:
                 raise RuntimeError(
                     f"Data proxy {url} returned {resp.status_code}: {resp.text}"

--- a/areal/v2/inference_service/sglang/awex.py
+++ b/areal/v2/inference_service/sglang/awex.py
@@ -59,8 +59,13 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     async def update_weights(request: Request) -> JSONResponse:
         try:
             data = await request.json()
+            pair_name = data["pair_name"]
             version = data.get("version", 0)
-            rpc_proxy.collective_rpc("awex_execute_weight_update", version=version)
+            rpc_proxy.collective_rpc(
+                "awex_execute_weight_update",
+                pair_name=pair_name,
+                version=version,
+            )
             return JSONResponse(content={"status": "ok", "version": version})
         except Exception as e:
             logger.error("Failed to update weights: %s", e)
@@ -74,6 +79,20 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed batch_isend_irecv: %s", e)
+            return JSONResponse(status_code=500, content={"error": str(e)})
+
+    @app.post("/awex/teardown")
+    async def teardown(request: Request) -> JSONResponse:
+        try:
+            data = await request.json()
+            pair_name = data["pair_name"]
+            rpc_proxy.collective_rpc(
+                "awex_teardown_weight_update_group",
+                pair_name=pair_name,
+            )
+            return JSONResponse(content={"status": "ok"})
+        except Exception as e:
+            logger.error("Failed to teardown weights update group: %s", e)
             return JSONResponse(status_code=500, content={"error": str(e)})
 
     @app.post("/awex/debug/get_parameters")
@@ -109,9 +128,12 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     async def execute_colocate_weight_update(request: Request) -> JSONResponse:
         try:
             data = await request.json()
+            pair_name = data["pair_name"]
             version = data.get("version", 0)
             rpc_proxy.collective_rpc(
-                "awex_execute_colocate_weight_update", version=version
+                "awex_execute_colocate_weight_update",
+                pair_name=pair_name,
+                version=version,
             )
             return JSONResponse(content={"status": "ok", "version": version})
         except Exception as e:

--- a/areal/v2/inference_service/sglang/awex.py
+++ b/areal/v2/inference_service/sglang/awex.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI, Request
@@ -23,10 +24,21 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     values into ``RpcReqOutput.message``.
     """
 
+    def _operation_timeout(data: dict) -> float | None:
+        timeout = data.pop("rpc_timeout_s", None)
+        ttl = data.pop("operation_ttl_s", None)
+        if ttl is not None:
+            ttl = max(0.0, float(ttl))
+            data["operation_expiry_monotonic"] = time.monotonic() + ttl
+            timeout = ttl if timeout is None else min(float(timeout), ttl)
+        return None if timeout is None else float(timeout)
+
     @app.post("/awex/report_weight_meta")
     async def report_weight_meta() -> JSONResponse:
         try:
-            result = rpc_proxy.collective_rpc_with_result("awex_report_weight_meta")
+            result = await rpc_proxy.collective_rpc_with_result(
+                "awex_report_weight_meta"
+            )
             return JSONResponse(content={"status": "ok", "meta": result})
         except Exception as e:
             logger.error("Failed to report weight meta: %s", e)
@@ -35,7 +47,9 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     @app.get("/awex/report_parallelism")
     async def report_parallelism() -> JSONResponse:
         try:
-            result = rpc_proxy.collective_rpc_with_result("awex_report_parallelism")
+            result = await rpc_proxy.collective_rpc_with_result(
+                "awex_report_parallelism"
+            )
             if not isinstance(result, dict):
                 err_msg = f"Expected dict from awex_report_parallelism, but got {type(result).__name__}"
                 logger.error(err_msg)
@@ -49,7 +63,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     async def init_weights_update_group(request: Request) -> JSONResponse:
         try:
             data = await request.json()
-            rpc_proxy.collective_rpc("awex_init_weights_update_group", **data)
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
+                "awex_init_weights_update_group", timeout_s=timeout, **data
+            )
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed to init weights update group: %s", e)
@@ -61,8 +78,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
             data = await request.json()
             pair_name = data["pair_name"]
             version = data.get("version", 0)
-            rpc_proxy.collective_rpc(
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
                 "awex_execute_weight_update",
+                timeout_s=timeout,
                 pair_name=pair_name,
                 version=version,
             )
@@ -75,7 +94,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     async def batch_isend_irecv(request: Request) -> JSONResponse:
         try:
             data = await request.json()
-            rpc_proxy.collective_rpc("awex_batch_isend_irecv", **data)
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
+                "awex_batch_isend_irecv", timeout_s=timeout, **data
+            )
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed batch_isend_irecv: %s", e)
@@ -86,9 +108,13 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
         try:
             data = await request.json()
             pair_name = data["pair_name"]
-            rpc_proxy.collective_rpc(
+            operation_id = data.get("operation_id", "")
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
                 "awex_teardown_weight_update_group",
+                timeout_s=timeout,
                 pair_name=pair_name,
+                operation_id=operation_id,
             )
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
@@ -99,7 +125,7 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     async def get_parameters(request: Request) -> JSONResponse:
         try:
             data = await request.json()
-            rpc_proxy.collective_rpc("awex_get_parameters", **data)
+            await rpc_proxy.collective_rpc("awex_get_parameters", **data)
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed to get parameters: %s", e)
@@ -108,7 +134,7 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     @app.post("/awex/debug/randomize_parameters")
     async def randomize_parameters() -> JSONResponse:
         try:
-            rpc_proxy.collective_rpc("awex_randomize_parameters")
+            await rpc_proxy.collective_rpc("awex_randomize_parameters")
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed to randomize parameters: %s", e)
@@ -118,7 +144,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
     async def init_colocate_weight_update(request: Request) -> JSONResponse:
         try:
             data = await request.json()
-            rpc_proxy.collective_rpc("awex_init_colocate_weight_update", **data)
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
+                "awex_init_colocate_weight_update", timeout_s=timeout, **data
+            )
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed to init colocate weight update: %s", e)
@@ -130,8 +159,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
             data = await request.json()
             pair_name = data["pair_name"]
             version = data.get("version", 0)
-            rpc_proxy.collective_rpc(
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
                 "awex_execute_colocate_weight_update",
+                timeout_s=timeout,
                 pair_name=pair_name,
                 version=version,
             )
@@ -145,7 +176,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
         try:
             data = await request.json()
             tags = data.get("tags")
-            rpc_proxy.collective_rpc("awex_release_memory", tags=tags)
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
+                "awex_release_memory", timeout_s=timeout, tags=tags
+            )
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed to release memory: %s", e)
@@ -156,7 +190,10 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
         try:
             data = await request.json()
             tags = data.get("tags")
-            rpc_proxy.collective_rpc("awex_resume_memory", tags=tags)
+            timeout = _operation_timeout(data)
+            await rpc_proxy.collective_rpc(
+                "awex_resume_memory", timeout_s=timeout, tags=tags
+            )
             return JSONResponse(content={"status": "ok"})
         except Exception as e:
             logger.error("Failed to resume memory: %s", e)

--- a/areal/v2/inference_service/sglang/rpc_proxy.py
+++ b/areal/v2/inference_service/sglang/rpc_proxy.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Any
+from uuid import uuid4
 
 import zmq
+import zmq.asyncio
 from sglang.srt.managers.io_struct import RpcReqInput, RpcReqOutput
 from sglang.srt.server_args import PortArgs
 
@@ -21,29 +25,95 @@ class RpcProxy:
       pushed by :class:`AwexSchedulerBridge` rank 0 via its PUSH socket.
     """
 
-    def __init__(self, port_args: PortArgs, result_ipc: str) -> None:
+    def __init__(
+        self, port_args: PortArgs, result_ipc: str, default_timeout_s: float = 300.0
+    ) -> None:
         from sglang.srt.utils.network import get_zmq_socket
 
-        self._rpc_ctx = zmq.Context(1)
+        self._rpc_ctx = zmq.asyncio.Context(1)
         self._rpc_socket = get_zmq_socket(
             self._rpc_ctx, zmq.DEALER, port_args.rpc_ipc_name, True
         )
 
-        self._result_ctx = zmq.Context(1)
+        self._result_ctx = zmq.asyncio.Context(1)
         self._result_pull = self._result_ctx.socket(zmq.PULL)
         self._result_pull.bind(result_ipc)
+        self._lock = asyncio.Lock()
+        self._default_timeout_s = default_timeout_s
 
-    def collective_rpc(self, method: str, **kwargs: Any) -> None:
-        req = RpcReqInput(method=method, parameters=kwargs if kwargs else None)
-        self._rpc_socket.send_pyobj(req)
-        resp: RpcReqOutput = self._rpc_socket.recv_pyobj()
-        assert isinstance(resp, RpcReqOutput)
-        if not resp.success:
-            raise RuntimeError(f"RPC {method} failed: {resp.message}")
+    @staticmethod
+    def _remaining(deadline: float) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("SGLang collective RPC deadline exceeded")
+        return remaining
 
-    def collective_rpc_with_result(self, method: str, **kwargs: Any) -> Any:
-        self.collective_rpc(method, **kwargs)
-        return self._result_pull.recv_pyobj()
+    async def _recv_ack(self, rid: str, deadline: float) -> RpcReqOutput:
+        while True:
+            resp = await asyncio.wait_for(
+                self._rpc_socket.recv_pyobj(), timeout=self._remaining(deadline)
+            )
+            if isinstance(resp, RpcReqOutput) and resp.rid == rid:
+                return resp
+
+    async def _recv_result(self, rid: str, deadline: float) -> Any:
+        while True:
+            envelope = await asyncio.wait_for(
+                self._result_pull.recv_pyobj(), timeout=self._remaining(deadline)
+            )
+            if isinstance(envelope, dict) and envelope.get("rid") == rid:
+                return envelope.get("value")
+
+    async def _collective_rpc(
+        self,
+        method: str,
+        *,
+        timeout_s: float | None,
+        expect_result: bool,
+        kwargs: dict[str, Any],
+    ) -> Any:
+        deadline = time.monotonic() + (
+            self._default_timeout_s if timeout_s is None else timeout_s
+        )
+        await asyncio.wait_for(self._lock.acquire(), timeout=self._remaining(deadline))
+        try:
+            rid = uuid4().hex
+            req = RpcReqInput(
+                method=method,
+                parameters=kwargs if kwargs else None,
+                rid=rid,
+            )
+            await asyncio.wait_for(
+                self._rpc_socket.send_pyobj(req), timeout=self._remaining(deadline)
+            )
+            resp = await self._recv_ack(rid, deadline)
+            if not resp.success:
+                raise RuntimeError(f"RPC {method} failed: {resp.message}")
+            if expect_result:
+                return await self._recv_result(rid, deadline)
+            return None
+        finally:
+            self._lock.release()
+
+    async def collective_rpc(
+        self, method: str, *, timeout_s: float | None = None, **kwargs: Any
+    ) -> None:
+        await self._collective_rpc(
+            method,
+            timeout_s=timeout_s,
+            expect_result=False,
+            kwargs=kwargs,
+        )
+
+    async def collective_rpc_with_result(
+        self, method: str, *, timeout_s: float | None = None, **kwargs: Any
+    ) -> Any:
+        return await self._collective_rpc(
+            method,
+            timeout_s=timeout_s,
+            expect_result=True,
+            kwargs=kwargs,
+        )
 
     def close(self) -> None:
         for sock in (self._rpc_socket, self._result_pull):

--- a/areal/v2/inference_service/sglang/scheduler.py
+++ b/areal/v2/inference_service/sglang/scheduler.py
@@ -60,6 +60,7 @@ class AwexSchedulerBridge:
             "awex_init_weights_update_group",
             "awex_execute_weight_update",
             "awex_batch_isend_irecv",
+            "awex_teardown_weight_update_group",
             "awex_get_parameters",
             "awex_randomize_parameters",
             "awex_init_colocate_weight_update",
@@ -105,11 +106,15 @@ class AwexSchedulerBridge:
     def awex_init_weights_update_group(self, **kwargs: Any) -> None:
         self._require_adapter().init_weight_update_group(**kwargs)
 
-    def awex_execute_weight_update(self, version: int = 0) -> None:
-        self._require_adapter().execute_weight_update(version)
+    def awex_execute_weight_update(self, pair_name: str, version: int = 0) -> None:
+        self._require_adapter().execute_weight_update(pair_name, version)
 
-    def awex_batch_isend_irecv(self, **kwargs: Any) -> None:
-        self._require_adapter().batch_isend_irecv(**kwargs)
+    def awex_batch_isend_irecv(self, pair_name: str, **kwargs: Any) -> None:
+        self._require_adapter().batch_isend_irecv(pair_name, **kwargs)
+
+    def awex_teardown_weight_update_group(self, pair_name: str) -> None:
+        if self._adapter is not None:
+            self._adapter.teardown_weight_update_group(pair_name)
 
     def awex_get_parameters(
         self, save_path: str, names: list[str] | None = None
@@ -124,8 +129,10 @@ class AwexSchedulerBridge:
     def awex_init_colocate_weight_update(self, **kwargs: Any) -> None:
         self._require_adapter().init_colocate_weight_update(**kwargs)
 
-    def awex_execute_colocate_weight_update(self, version: int = 0) -> None:
-        self._require_adapter().execute_colocate_weight_update(version)
+    def awex_execute_colocate_weight_update(
+        self, pair_name: str, version: int = 0
+    ) -> None:
+        self._require_adapter().execute_colocate_weight_update(pair_name, version)
 
     def awex_release_memory(self, tags: list[str] | None = None) -> None:
         self._require_adapter().release_memory(tags)

--- a/areal/v2/inference_service/sglang/scheduler.py
+++ b/areal/v2/inference_service/sglang/scheduler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+import time
 from typing import Any
 
 import torch.distributed as dist
@@ -35,6 +36,8 @@ class AwexSchedulerBridge:
         self._scheduler = scheduler
         self._adapter: Any | None = None
         self._result_push: zmq.Socket | None = None
+        self._current_rid: str | None = None
+        self._cancelled_operations: set[tuple[str, str]] = set()
 
         result_ipc = os.environ.get(RESULT_IPC_ENV)
         # Only tp_rank==0 AND dp_rank==0 should push results to avoid
@@ -71,6 +74,23 @@ class AwexSchedulerBridge:
         for name in methods:
             setattr(self._scheduler, name, getattr(self, name))
 
+        original_handler = self._scheduler.handle_rpc_request
+
+        def handle_rpc_request(request):
+            self._current_rid = request.rid
+            try:
+                response = original_handler(request)
+                response.rid = request.rid
+                return response
+            finally:
+                self._current_rid = None
+
+        # Scheduler.__init__ caches bound handlers in _request_dispatcher.
+        # Rebuild it after replacing handle_rpc_request so the real dispatch
+        # path, not just the instance attribute, copies the request rid.
+        self._scheduler.handle_rpc_request = handle_rpc_request
+        self._scheduler.init_request_dispatcher()
+
     def _require_adapter(self) -> Any:
         if self._adapter is None:
             from areal.v2.weight_update.awex.sglang_adapter import (
@@ -82,7 +102,30 @@ class AwexSchedulerBridge:
 
     def _push_result(self, result: Any) -> None:
         if self._result_push is not None:
-            self._result_push.send_pyobj(result)
+            self._result_push.send_pyobj({"rid": self._current_rid, "value": result})
+
+    def _check_operation(self, kwargs: dict[str, Any]) -> float | None:
+        pair_name = kwargs["pair_name"]
+        operation_id = kwargs.pop("operation_id", "")
+        expiry = kwargs.pop("operation_expiry_monotonic", None)
+        remaining = None if expiry is None else float(expiry) - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            raise TimeoutError(f"AWEX init for pair {pair_name!r} expired in queue")
+        if operation_id and (pair_name, operation_id) in self._cancelled_operations:
+            raise RuntimeError(
+                f"AWEX operation {operation_id!r} for pair {pair_name!r} was cancelled"
+            )
+        return remaining
+
+    @staticmethod
+    def _apply_remaining_pg_timeout(
+        kwargs: dict[str, Any], remaining: float | None
+    ) -> None:
+        if remaining is not None:
+            configured = kwargs.get("process_group_timeout_s")
+            kwargs["process_group_timeout_s"] = min(
+                remaining, remaining if configured is None else float(configured)
+            )
 
     def awex_report_weight_meta(self) -> None:
         adapter = self._require_adapter()
@@ -104,15 +147,24 @@ class AwexSchedulerBridge:
         self._push_result(self._require_adapter().parallelism_strategy)
 
     def awex_init_weights_update_group(self, **kwargs: Any) -> None:
+        remaining = self._check_operation(kwargs)
+        self._apply_remaining_pg_timeout(kwargs, remaining)
         self._require_adapter().init_weight_update_group(**kwargs)
 
     def awex_execute_weight_update(self, pair_name: str, version: int = 0) -> None:
         self._require_adapter().execute_weight_update(pair_name, version)
 
     def awex_batch_isend_irecv(self, pair_name: str, **kwargs: Any) -> None:
+        self._check_operation({"pair_name": pair_name, **kwargs})
+        kwargs.pop("operation_id", None)
+        kwargs.pop("operation_expiry_monotonic", None)
         self._require_adapter().batch_isend_irecv(pair_name, **kwargs)
 
-    def awex_teardown_weight_update_group(self, pair_name: str) -> None:
+    def awex_teardown_weight_update_group(
+        self, pair_name: str, operation_id: str = ""
+    ) -> None:
+        if operation_id:
+            self._cancelled_operations.add((pair_name, operation_id))
         if self._adapter is not None:
             self._adapter.teardown_weight_update_group(pair_name)
 
@@ -127,6 +179,8 @@ class AwexSchedulerBridge:
         self._require_adapter().randomize_parameters()
 
     def awex_init_colocate_weight_update(self, **kwargs: Any) -> None:
+        remaining = self._check_operation(kwargs)
+        self._apply_remaining_pg_timeout(kwargs, remaining)
         self._require_adapter().init_colocate_weight_update(**kwargs)
 
     def awex_execute_colocate_weight_update(

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -58,6 +58,7 @@ class GatewayTrainController:
         self._own_process_group = False
         self.rollout: Any | None = None
         self._weight_update_ctrl: Any | None = None
+        self._stale_weight_update_ctrls: list[Any] = []
 
         # Version management
         self._version_lock = Lock()
@@ -1061,6 +1062,36 @@ class GatewayTrainController:
 
     # -- RL parity methods (connect_engine / update_weights / batch) --------
 
+    def _remember_stale_weight_update_ctrl(self, ctrl: Any) -> None:
+        if all(stale is not ctrl for stale in self._stale_weight_update_ctrls):
+            self._stale_weight_update_ctrls.append(ctrl)
+
+    def _retry_stale_weight_update_cleanup(self, timeout: float) -> None:
+        remaining = []
+        for stale in self._stale_weight_update_ctrls:
+            try:
+                stale.disconnect(timeout=timeout)
+            except Exception:
+                logger.warning(
+                    "Failed to clean up stale weight-update pair %r; "
+                    "cleanup will be retried",
+                    getattr(stale, "pair_name", None),
+                    exc_info=True,
+                )
+                remaining.append(stale)
+            else:
+                try:
+                    stale.destroy()
+                except Exception:
+                    logger.warning(
+                        "Disconnected stale weight-update pair %r but failed to "
+                        "destroy its gateway; cleanup will be retried",
+                        getattr(stale, "pair_name", None),
+                        exc_info=True,
+                    )
+                    remaining.append(stale)
+        self._stale_weight_update_ctrls = remaining
+
     def connect_engine(self, rollout: Any, meta: Any) -> None:
         self._ensure_initialized()
         import requests
@@ -1082,14 +1113,13 @@ class GatewayTrainController:
                 f"Ensure _version='v2' is set on InferenceEngineConfig."
             )
 
-        self.rollout = rollout
-
         if meta.type not in ("awex", "disk"):
             raise ValueError(
                 f"GatewayTrainController supports 'awex' or 'disk' weight "
                 f"updates, got '{meta.type}'"
             )
 
+        existing_ctrl = self._weight_update_ctrl
         ctrl = WeightUpdateController(
             WeightUpdateControllerConfig(
                 # Bind gateway to this node's outbound IP so cross-host
@@ -1098,45 +1128,99 @@ class GatewayTrainController:
                 host=gethostip(),
                 admin_api_key=self.config.admin_api_key,
                 log_level=self.config.log_level,
+                setup_timeout=self.config.setup_timeout,
+                request_timeout=self.config.request_timeout,
+                init_timeout_s=self.config.request_timeout,
+                update_timeout_s=self.config.request_timeout,
             )
         )
-        ctrl.initialize()
+
+        setup_timeout = self.config.setup_timeout
+        rollback_timeout = min(30.0, max(1.0, setup_timeout * 0.1))
+        setup_deadline = time.monotonic() + setup_timeout
+
+        def _remaining_setup_time() -> float:
+            remaining = setup_deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("Weight-update connection setup deadline exceeded")
+            return remaining
 
         inference_urls: list[str] = rollout.inference_worker_urls
-        pair_name = f"{self._role}-rollout"
-
+        base_pair_name = f"{self._role}-rollout"
+        pair_name = base_pair_name
+        if meta.type == "awex" and getattr(meta, "version", None) is not None:
+            pair_name = f"{base_pair_name}-v{meta.version}"
         if meta.type == "awex":
-            # NCCL rendezvous master must live on the rank-0 process's node.
-            # awex assigns rank 0 to inference[0], so allocate on the inference
-            # rank-0 guard rather than a train guard.
-            inf_guard_addrs = rollout.inference_guard_addrs
-            resp = requests.post(
-                f"{inf_guard_addrs[0]}/alloc_ports",
-                json={"count": 1},
-                timeout=30,
-            )
-            resp.raise_for_status()
-            port_data = resp.json()
-            ctrl.connect(
-                pair_name=pair_name,
-                train_worker_urls=self._worker_addrs,
-                inference_worker_urls=inference_urls,
-                mode="awex",
-                nccl_master_addr=port_data["host"],
-                nccl_master_port=port_data["ports"][0],
-            )
-        else:  # disk
-            ctrl.connect(
-                pair_name=pair_name,
-                train_worker_urls=self._worker_addrs,
-                inference_worker_urls=inference_urls,
-                mode="disk",
-                save_path=meta.path or "",
-                use_lora=meta.use_lora,
-                lora_name=meta.lora_name,
-                lora_keep_versions=meta.lora_keep_versions,
-            )
+            occupied_pair_names = {
+                existing_pair_name
+                for controller in [existing_ctrl, *self._stale_weight_update_ctrls]
+                if (existing_pair_name := getattr(controller, "pair_name", None))
+            }
+            candidate_pair_base_name = pair_name
+            while pair_name in occupied_pair_names:
+                pair_name = f"{candidate_pair_base_name}-{uuid4().hex[:8]}"
+
+        try:
+            ctrl.initialize(timeout=_remaining_setup_time())
+
+            if meta.type == "awex":
+                # NCCL rendezvous master must live on the rank-0 process's node.
+                # AWEX assigns rank 0 to inference[0], so allocate on the inference
+                # rank-0 guard rather than a train guard.
+                inf_guard_addrs = rollout.inference_guard_addrs
+                resp = requests.post(
+                    f"{inf_guard_addrs[0]}/alloc_ports",
+                    json={"count": 1},
+                    timeout=min(30.0, _remaining_setup_time()),
+                )
+                resp.raise_for_status()
+                port_data = resp.json()
+                gateway_setup_timeout = _remaining_setup_time() - rollback_timeout
+                if gateway_setup_timeout <= 0:
+                    raise TimeoutError(
+                        "No setup time remains after reserving AWEX rollback time"
+                    )
+                ctrl.connect(
+                    pair_name=pair_name,
+                    train_worker_urls=self._worker_addrs,
+                    inference_worker_urls=inference_urls,
+                    mode="awex",
+                    nccl_master_addr=port_data["host"],
+                    nccl_master_port=port_data["ports"][0],
+                    setup_timeout_s=gateway_setup_timeout,
+                    rollback_timeout_s=rollback_timeout,
+                    request_timeout=(gateway_setup_timeout + rollback_timeout + 1.0),
+                )
+            else:  # disk
+                ctrl.connect(
+                    pair_name=pair_name,
+                    train_worker_urls=self._worker_addrs,
+                    inference_worker_urls=inference_urls,
+                    mode="disk",
+                    save_path=meta.path or "",
+                    use_lora=meta.use_lora,
+                    lora_name=meta.lora_name,
+                    lora_keep_versions=meta.lora_keep_versions,
+                    request_timeout=_remaining_setup_time(),
+                )
+        except BaseException:
+            try:
+                ctrl.destroy(raise_on_error=True)
+            except Exception:
+                self._remember_stale_weight_update_ctrl(ctrl)
+                logger.warning(
+                    "Candidate pair %r rollback is incomplete; retaining its "
+                    "controller for stale cleanup",
+                    ctrl.pair_name,
+                    exc_info=True,
+                )
+            raise
+
         self._weight_update_ctrl = ctrl
+        self.rollout = rollout
+        if existing_ctrl is not None:
+            self._remember_stale_weight_update_ctrl(existing_ctrl)
+        self._retry_stale_weight_update_cleanup(timeout=rollback_timeout)
         logger.info(
             "WeightUpdateController connected (pair=%s, train=%d, inf=%d)",
             pair_name,
@@ -1149,12 +1233,47 @@ class GatewayTrainController:
             raise RuntimeError(
                 "connect_engine() must be called before update_weights()"
             )
-        self.rollout.pause_generation()
         assert meta.version is not None and meta.version > 0, (
             f"meta.version must be a positive integer, got {meta.version}"
         )
-        result = self._weight_update_ctrl.update_weights(version=meta.version)
-        self.rollout.continue_generation()
+        try:
+            self.rollout.pause_generation()
+        except BaseException as exc:
+            # No transfer has started, so callers may retry resume while still
+            # surfacing the partial-pause failure.
+            setattr(exc, "inference_weights_may_be_mutated", False)
+            raise
+        # A failed AWEX transfer can leave inference weights partly updated. Do
+        # not resume request handling in that state: recovery must restore a
+        # known-good checkpoint first. Errors explicitly marked as pre-mutation
+        # remain safe to resume.
+        should_continue_generation = False
+        update_error: BaseException | None = None
+        try:
+            result = self._weight_update_ctrl.update_weights(version=meta.version)
+            should_continue_generation = True
+        except BaseException as exc:
+            update_error = exc
+            should_continue_generation = not getattr(
+                exc, "inference_weights_may_be_mutated", True
+            )
+            raise
+        finally:
+            if should_continue_generation:
+                try:
+                    self.rollout.continue_generation()
+                except Exception:
+                    if update_error is None:
+                        raise
+                    logger.exception(
+                        "Failed to resume generation after a safe-to-resume "
+                        "weight-update error; preserving the original error"
+                    )
+            else:
+                logger.critical(
+                    "Weight update may have partially mutated inference weights; "
+                    "leaving generation paused until recovery completes"
+                )
         logger.info(
             "Weight update v%d completed (%s, %.0fms)",
             meta.version,
@@ -1229,6 +1348,98 @@ class GatewayTrainController:
 
     # -- Destroy -----------------------------------------------------------
 
+    def _direct_teardown_weight_update_pair(
+        self,
+        pair_name: str,
+        train_worker_urls: list[str],
+        inference_worker_urls: list[str],
+    ) -> bool:
+        """Best-effort per-pair fallback when gateway disconnect fails."""
+
+        async def _teardown_all() -> list[BaseException]:
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                results = await asyncio.gather(
+                    *[
+                        _teardown_one(session, addr)
+                        for addr in train_worker_urls + inference_worker_urls
+                    ],
+                    return_exceptions=True,
+                )
+            return [result for result in results if isinstance(result, BaseException)]
+
+        async def _teardown_one(session: aiohttp.ClientSession, addr: str) -> None:
+            async with session.post(
+                f"{addr}/awex/teardown",
+                json={"pair_name": pair_name},
+            ) as resp:
+                resp.raise_for_status()
+
+        errors = run_async_task(_teardown_all)
+        if errors:
+            logger.warning(
+                "Direct teardown for pair %r failed on %d endpoint(s): %s",
+                pair_name,
+                len(errors),
+                errors,
+            )
+            return False
+        return True
+
+    def _teardown_weight_update_controllers(self, controllers: list[Any]) -> list[Any]:
+        """Disconnect all known pairs without dropping unresolved ownership."""
+
+        unresolved: list[Any] = []
+        for controller in controllers:
+            pair_name = getattr(controller, "pair_name", None)
+            if pair_name is not None:
+                try:
+                    controller.disconnect(timeout=30.0)
+                except Exception:
+                    logger.warning(
+                        "Gateway disconnect failed for pair %r; trying direct "
+                        "worker teardown",
+                        pair_name,
+                        exc_info=True,
+                    )
+                    direct_ok = self._direct_teardown_weight_update_pair(
+                        pair_name,
+                        getattr(controller, "train_worker_urls", []),
+                        getattr(controller, "inference_worker_urls", []),
+                    )
+                    if direct_ok:
+                        try:
+                            # Let the gateway observe the now-idempotent worker
+                            # teardown and only then clear its registry/KV state.
+                            controller.disconnect(timeout=30.0)
+                        except Exception:
+                            logger.warning(
+                                "Gateway bookkeeping cleanup still failed for "
+                                "pair %r after direct teardown; terminating its "
+                                "private gateway",
+                                pair_name,
+                                exc_info=True,
+                            )
+                            # All worker resources are known to be gone. Registry
+                            # and KV state are private to this gateway process, so
+                            # it is now safe to terminate even if /disconnect is
+                            # unreachable.
+                            controller.destroy(raise_on_error=False)
+                            continue
+
+            if getattr(controller, "pair_name", None) is not None:
+                unresolved.append(controller)
+                continue
+            try:
+                controller.destroy(raise_on_error=True)
+            except Exception:
+                logger.warning(
+                    "Failed to destroy disconnected weight-update controller",
+                    exc_info=True,
+                )
+                unresolved.append(controller)
+        return unresolved
+
     def _graceful_shutdown_workers(self) -> None:
         """Destroy engines on all training workers before killing processes.
 
@@ -1250,15 +1461,6 @@ class GatewayTrainController:
                 await asyncio.gather(*tasks, return_exceptions=True)
 
         async def _shutdown_one(session: aiohttp.ClientSession, addr: str) -> None:
-            try:
-                async with session.post(f"{addr}/awex/teardown") as resp:
-                    resp.raise_for_status()
-            except Exception as e:
-                logger.warning(
-                    "Graceful shutdown: failed to call /awex/teardown on %s: %s",
-                    addr,
-                    e,
-                )
             try:
                 async with session.post(f"{addr}/destroy_engine", json={}) as resp:
                     resp.raise_for_status()
@@ -1342,5 +1544,25 @@ class GatewayTrainController:
         self._init_future = None
         if future is not None:
             future.cancel()
+
+        controllers = [
+            controller
+            for controller in [
+                self._weight_update_ctrl,
+                *self._stale_weight_update_ctrls,
+            ]
+            if controller is not None
+        ]
+        unresolved = self._teardown_weight_update_controllers(controllers)
+        self._weight_update_ctrl = None
+        self._stale_weight_update_ctrls = unresolved
+
+        if unresolved:
+            logger.error(
+                "Deferring runtime shutdown while %d weight-update pair(s) "
+                "still own live worker resources; call destroy() again to retry",
+                len(unresolved),
+            )
+            return
 
         self._cleanup_runtime_state()

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -30,6 +30,14 @@ logger = logging.getLogger("GatewayTrainController")
 _MAX_CLEAR_STEP_FAILURES = 2
 
 
+class WeightUpdateCleanupPending(RuntimeError):
+    def __init__(self, unresolved_pairs: list[str]) -> None:
+        self.unresolved_pairs = unresolved_pairs
+        super().__init__(
+            "AWEX cleanup remains pending for: " + ", ".join(unresolved_pairs)
+        )
+
+
 class GatewayTrainController:
     _GUARD_SUFFIX = "-guard"
 
@@ -58,7 +66,10 @@ class GatewayTrainController:
         self._own_process_group = False
         self.rollout: Any | None = None
         self._weight_update_ctrl: Any | None = None
+        self._candidate_weight_update_ctrl: Any | None = None
+        self._candidate_weight_update_done: threading.Event | None = None
         self._stale_weight_update_ctrls: list[Any] = []
+        self._weight_update_lifecycle_lock = Lock()
 
         # Version management
         self._version_lock = Lock()
@@ -674,7 +685,9 @@ class GatewayTrainController:
 
     # -- Gateway HTTP helpers (duck-type TrainController interface) ---------
 
-    def _gateway_post(self, path: str, payload: Any = None) -> Any:
+    def _gateway_post(
+        self, path: str, payload: Any = None, *, timeout: float | None = None
+    ) -> Any:
         import requests
 
         self._ensure_initialized()
@@ -683,7 +696,7 @@ class GatewayTrainController:
             url,
             json=payload,
             headers={"Authorization": f"Bearer {self.api_key}"},
-            timeout=self.config.request_timeout,
+            timeout=self.config.request_timeout if timeout is None else timeout,
         )
         if resp.status_code >= 400:
             raise RuntimeError(
@@ -808,10 +821,11 @@ class GatewayTrainController:
         return self
 
     def set_version(self, version: int) -> None:
-        from areal.infra.rpc.serialization import serialize_value
+        self.broadcast_version(version)
+        self.commit_local_version(version)
 
-        with self._version_lock:
-            self._version = version
+    def broadcast_version(self, version: int, timeout: float | None = None) -> None:
+        from areal.infra.rpc.serialization import serialize_value
 
         self._gateway_post(
             "/set_version",
@@ -819,7 +833,12 @@ class GatewayTrainController:
                 "args": serialize_value([version]),
                 "kwargs": serialize_value({}),
             },
+            timeout=timeout,
         )
+
+    def commit_local_version(self, version: int) -> None:
+        with self._version_lock:
+            self._version = version
 
     def get_version(self) -> int:
         with self._version_lock:
@@ -1067,30 +1086,9 @@ class GatewayTrainController:
             self._stale_weight_update_ctrls.append(ctrl)
 
     def _retry_stale_weight_update_cleanup(self, timeout: float) -> None:
-        remaining = []
-        for stale in self._stale_weight_update_ctrls:
-            try:
-                stale.disconnect(timeout=timeout)
-            except Exception:
-                logger.warning(
-                    "Failed to clean up stale weight-update pair %r; "
-                    "cleanup will be retried",
-                    getattr(stale, "pair_name", None),
-                    exc_info=True,
-                )
-                remaining.append(stale)
-            else:
-                try:
-                    stale.destroy()
-                except Exception:
-                    logger.warning(
-                        "Disconnected stale weight-update pair %r but failed to "
-                        "destroy its gateway; cleanup will be retried",
-                        getattr(stale, "pair_name", None),
-                        exc_info=True,
-                    )
-                    remaining.append(stale)
-        self._stale_weight_update_ctrls = remaining
+        self._stale_weight_update_ctrls = self._cleanup_weight_update_controllers(
+            self._stale_weight_update_ctrls, time.monotonic() + timeout
+        )
 
     def connect_engine(self, rollout: Any, meta: Any) -> None:
         self._ensure_initialized()
@@ -1148,17 +1146,23 @@ class GatewayTrainController:
         inference_urls: list[str] = rollout.inference_worker_urls
         base_pair_name = f"{self._role}-rollout"
         pair_name = base_pair_name
+        operation_id = uuid4().hex
         if meta.type == "awex" and getattr(meta, "version", None) is not None:
-            pair_name = f"{base_pair_name}-v{meta.version}"
-        if meta.type == "awex":
-            occupied_pair_names = {
-                existing_pair_name
-                for controller in [existing_ctrl, *self._stale_weight_update_ctrls]
-                if (existing_pair_name := getattr(controller, "pair_name", None))
-            }
-            candidate_pair_base_name = pair_name
-            while pair_name in occupied_pair_names:
-                pair_name = f"{candidate_pair_base_name}-{uuid4().hex[:8]}"
+            pair_name = f"{base_pair_name}-v{meta.version}-{operation_id[:8]}"
+        ctrl.retain_pending_connection(
+            pair_name,
+            operation_id,
+            self._worker_addrs,
+            inference_urls,
+        )
+        candidate_done = threading.Event()
+        with self._weight_update_lifecycle_lock:
+            if self._shutdown_requested.is_set():
+                raise RuntimeError(
+                    "Cannot connect AWEX while controller is shutting down"
+                )
+            self._candidate_weight_update_ctrl = ctrl
+            self._candidate_weight_update_done = candidate_done
 
         try:
             ctrl.initialize(timeout=_remaining_setup_time())
@@ -1168,11 +1172,19 @@ class GatewayTrainController:
                 # AWEX assigns rank 0 to inference[0], so allocate on the inference
                 # rank-0 guard rather than a train guard.
                 inf_guard_addrs = rollout.inference_guard_addrs
-                resp = requests.post(
-                    f"{inf_guard_addrs[0]}/alloc_ports",
-                    json={"count": 1},
-                    timeout=min(30.0, _remaining_setup_time()),
-                )
+                port_token = uuid4().hex
+                ctrl.retain_port_reservation(inf_guard_addrs[0], port_token)
+                for attempt in range(2):
+                    try:
+                        resp = requests.post(
+                            f"{inf_guard_addrs[0]}/alloc_ports",
+                            json={"count": 1, "token": port_token},
+                            timeout=min(30.0, _remaining_setup_time()),
+                        )
+                        break
+                    except requests.RequestException:
+                        if attempt == 1:
+                            raise
                 resp.raise_for_status()
                 port_data = resp.json()
                 gateway_setup_timeout = _remaining_setup_time() - rollback_timeout
@@ -1190,6 +1202,7 @@ class GatewayTrainController:
                     setup_timeout_s=gateway_setup_timeout,
                     rollback_timeout_s=rollback_timeout,
                     request_timeout=(gateway_setup_timeout + rollback_timeout + 1.0),
+                    operation_id=operation_id,
                 )
             else:  # disk
                 ctrl.connect(
@@ -1202,25 +1215,43 @@ class GatewayTrainController:
                     lora_name=meta.lora_name,
                     lora_keep_versions=meta.lora_keep_versions,
                     request_timeout=_remaining_setup_time(),
+                    operation_id=operation_id,
                 )
+
+            with self._weight_update_lifecycle_lock:
+                if (
+                    self._candidate_weight_update_ctrl is not ctrl
+                    or self._shutdown_requested.is_set()
+                ):
+                    raise RuntimeError("AWEX candidate was claimed by shutdown")
+                self._candidate_weight_update_ctrl = None
+                self._candidate_weight_update_done = None
+                self._weight_update_ctrl = ctrl
         except BaseException:
-            try:
-                ctrl.destroy(raise_on_error=True)
-            except Exception:
-                self._remember_stale_weight_update_ctrl(ctrl)
-                logger.warning(
-                    "Candidate pair %r rollback is incomplete; retaining its "
-                    "controller for stale cleanup",
-                    ctrl.pair_name,
-                    exc_info=True,
+            with self._weight_update_lifecycle_lock:
+                owns_candidate = self._candidate_weight_update_ctrl is ctrl
+                if owns_candidate:
+                    self._candidate_weight_update_ctrl = None
+                    self._candidate_weight_update_done = None
+            if owns_candidate:
+                unresolved = self._cleanup_weight_update_controllers(
+                    [ctrl], time.monotonic() + rollback_timeout
                 )
+                if unresolved:
+                    self._remember_stale_weight_update_ctrl(ctrl)
+                    logger.warning(
+                        "Candidate pair %r rollback is incomplete; retaining its "
+                        "controller for stale cleanup",
+                        ctrl.pair_name,
+                    )
+            candidate_done.set()
             raise
 
-        self._weight_update_ctrl = ctrl
         self.rollout = rollout
         if existing_ctrl is not None:
             self._remember_stale_weight_update_ctrl(existing_ctrl)
         self._retry_stale_weight_update_cleanup(timeout=rollback_timeout)
+        candidate_done.set()
         logger.info(
             "WeightUpdateController connected (pair=%s, train=%d, inf=%d)",
             pair_name,
@@ -1228,7 +1259,7 @@ class GatewayTrainController:
             len(inference_urls),
         )
 
-    def update_weights(self, meta: Any) -> None:
+    def update_weights(self, meta: Any, *, resume_generation: bool = True) -> None:
         if self._weight_update_ctrl is None or self.rollout is None:
             raise RuntimeError(
                 "connect_engine() must be called before update_weights()"
@@ -1241,7 +1272,8 @@ class GatewayTrainController:
         except BaseException as exc:
             # No transfer has started, so callers may retry resume while still
             # surfacing the partial-pause failure.
-            setattr(exc, "inference_weights_may_be_mutated", False)
+            if not hasattr(exc, "inference_weights_may_be_mutated"):
+                setattr(exc, "inference_weights_may_be_mutated", False)
             raise
         # A failed AWEX transfer can leave inference weights partly updated. Do
         # not resume request handling in that state: recovery must restore a
@@ -1251,10 +1283,10 @@ class GatewayTrainController:
         update_error: BaseException | None = None
         try:
             result = self._weight_update_ctrl.update_weights(version=meta.version)
-            should_continue_generation = True
+            should_continue_generation = resume_generation
         except BaseException as exc:
             update_error = exc
-            should_continue_generation = not getattr(
+            should_continue_generation = resume_generation and not getattr(
                 exc, "inference_weights_may_be_mutated", True
             )
             raise
@@ -1269,7 +1301,7 @@ class GatewayTrainController:
                         "Failed to resume generation after a safe-to-resume "
                         "weight-update error; preserving the original error"
                     )
-            else:
+            elif resume_generation:
                 logger.critical(
                     "Weight update may have partially mutated inference weights; "
                     "leaving generation paused until recovery completes"
@@ -1351,14 +1383,16 @@ class GatewayTrainController:
     def _direct_teardown_weight_update_pair(
         self,
         pair_name: str,
+        operation_id: str,
         train_worker_urls: list[str],
         inference_worker_urls: list[str],
+        timeout: float,
     ) -> bool:
         """Best-effort per-pair fallback when gateway disconnect fails."""
 
         async def _teardown_all() -> list[BaseException]:
-            timeout = aiohttp.ClientTimeout(total=30)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            client_timeout = aiohttp.ClientTimeout(total=timeout)
+            async with aiohttp.ClientSession(timeout=client_timeout) as session:
                 results = await asyncio.gather(
                     *[
                         _teardown_one(session, addr)
@@ -1371,7 +1405,11 @@ class GatewayTrainController:
         async def _teardown_one(session: aiohttp.ClientSession, addr: str) -> None:
             async with session.post(
                 f"{addr}/awex/teardown",
-                json={"pair_name": pair_name},
+                json={
+                    "pair_name": pair_name,
+                    "operation_id": operation_id,
+                    "rpc_timeout_s": timeout,
+                },
             ) as resp:
                 resp.raise_for_status()
 
@@ -1386,59 +1424,119 @@ class GatewayTrainController:
             return False
         return True
 
-    def _teardown_weight_update_controllers(self, controllers: list[Any]) -> list[Any]:
-        """Disconnect all known pairs without dropping unresolved ownership."""
+    def _cleanup_weight_update_controllers(
+        self, controllers: list[Any], deadline: float
+    ) -> list[Any]:
+        """Advance each pair through worker, port, then gateway cleanup."""
 
+        controllers = list(dict.fromkeys(controllers))
         unresolved: list[Any] = []
-        for controller in controllers:
+        for index, controller in enumerate(controllers):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                unresolved.extend(controllers[index:])
+                break
+            attempt_timeout = max(0.05, remaining / (len(controllers) - index))
             pair_name = getattr(controller, "pair_name", None)
-            if pair_name is not None:
-                try:
-                    controller.disconnect(timeout=30.0)
-                except Exception:
-                    logger.warning(
-                        "Gateway disconnect failed for pair %r; trying direct "
-                        "worker teardown",
-                        pair_name,
-                        exc_info=True,
-                    )
-                    direct_ok = self._direct_teardown_weight_update_pair(
-                        pair_name,
-                        getattr(controller, "train_worker_urls", []),
-                        getattr(controller, "inference_worker_urls", []),
-                    )
-                    if direct_ok:
-                        try:
-                            # Let the gateway observe the now-idempotent worker
-                            # teardown and only then clear its registry/KV state.
-                            controller.disconnect(timeout=30.0)
-                        except Exception:
-                            logger.warning(
-                                "Gateway bookkeeping cleanup still failed for "
-                                "pair %r after direct teardown; terminating its "
-                                "private gateway",
-                                pair_name,
-                                exc_info=True,
-                            )
-                            # All worker resources are known to be gone. Registry
-                            # and KV state are private to this gateway process, so
-                            # it is now safe to terminate even if /disconnect is
-                            # unreachable.
-                            controller.destroy(raise_on_error=False)
-                            continue
 
-            if getattr(controller, "pair_name", None) is not None:
-                unresolved.append(controller)
-                continue
+            if not getattr(controller, "workers_cleaned", False):
+                if pair_name is None:
+                    controller.mark_workers_cleaned()
+                else:
+                    try:
+                        controller.disconnect(timeout=attempt_timeout)
+                    except Exception as exc:
+                        status_code = getattr(
+                            getattr(exc, "response", None), "status_code", None
+                        )
+                        if status_code == 409:
+                            logger.warning(
+                                "Pair %r has not quiesced; deferring teardown",
+                                pair_name,
+                            )
+                            unresolved.append(controller)
+                            continue
+                        logger.warning(
+                            "Gateway disconnect failed for pair %r; trying "
+                            "direct worker teardown",
+                            pair_name,
+                            exc_info=True,
+                        )
+                        if not self._direct_teardown_weight_update_pair(
+                            pair_name,
+                            getattr(controller, "operation_id", "") or "",
+                            getattr(controller, "train_worker_urls", []),
+                            getattr(controller, "inference_worker_urls", []),
+                            attempt_timeout,
+                        ):
+                            unresolved.append(controller)
+                            continue
+                        controller.mark_workers_cleaned()
+
+            cleanup_failed = False
+            remaining = max(0.001, deadline - time.monotonic())
             try:
-                controller.destroy(raise_on_error=True)
+                controller.release_port_reservation(timeout=remaining)
             except Exception:
+                cleanup_failed = True
+                logger.warning("Failed to release AWEX port reservation", exc_info=True)
+            try:
+                controller.terminate_private_gateway(
+                    timeout=max(0.001, deadline - time.monotonic()),
+                    raise_on_error=True,
+                )
+            except Exception:
+                cleanup_failed = True
                 logger.warning(
-                    "Failed to destroy disconnected weight-update controller",
+                    "Failed to terminate private weight-update gateway",
                     exc_info=True,
                 )
+            if cleanup_failed:
                 unresolved.append(controller)
         return unresolved
+
+    def cleanup_weight_update_pairs(self, deadline: float) -> None:
+        """Clean active, candidate and stale AWEX ownership before workers."""
+
+        self._shutdown_requested.set()
+        with self._weight_update_lifecycle_lock:
+            candidate = self._candidate_weight_update_ctrl
+            candidate_done = self._candidate_weight_update_done
+
+        if candidate is not None and candidate_done is not None:
+            candidate_done.wait(timeout=max(0.0, deadline - time.monotonic()))
+            if not candidate_done.is_set():
+                raise WeightUpdateCleanupPending(
+                    [getattr(candidate, "pair_name", "candidate")]
+                )
+
+        with self._weight_update_lifecycle_lock:
+            controllers = [
+                controller
+                for controller in [
+                    self._candidate_weight_update_ctrl,
+                    self._weight_update_ctrl,
+                    *self._stale_weight_update_ctrls,
+                ]
+                if controller is not None
+            ]
+            self._candidate_weight_update_ctrl = None
+            self._candidate_weight_update_done = None
+            self._weight_update_ctrl = None
+            self._stale_weight_update_ctrls = []
+
+        unresolved = self._cleanup_weight_update_controllers(controllers, deadline)
+        if unresolved:
+            with self._weight_update_lifecycle_lock:
+                self._stale_weight_update_ctrls.extend(unresolved)
+            raise WeightUpdateCleanupPending(
+                [
+                    getattr(controller, "pair_name", None)
+                    or getattr(controller, "port_token", None)
+                    or "private-gateway"
+                    for controller in unresolved
+                ]
+            )
 
     def _graceful_shutdown_workers(self) -> None:
         """Destroy engines on all training workers before killing processes.
@@ -1545,24 +1643,7 @@ class GatewayTrainController:
         if future is not None:
             future.cancel()
 
-        controllers = [
-            controller
-            for controller in [
-                self._weight_update_ctrl,
-                *self._stale_weight_update_ctrls,
-            ]
-            if controller is not None
-        ]
-        unresolved = self._teardown_weight_update_controllers(controllers)
-        self._weight_update_ctrl = None
-        self._stale_weight_update_ctrls = unresolved
-
-        if unresolved:
-            logger.error(
-                "Deferring runtime shutdown while %d weight-update pair(s) "
-                "still own live worker resources; call destroy() again to retry",
-                len(unresolved),
-            )
-            return
-
+        self.cleanup_weight_update_pairs(
+            time.monotonic() + min(30.0, self.config.setup_timeout)
+        )
         self._cleanup_runtime_state()

--- a/areal/v2/training_service/worker/awex.py
+++ b/areal/v2/training_service/worker/awex.py
@@ -73,11 +73,12 @@ def create_awex_blueprint(
     @bp.route("/update_weights", methods=["POST"])
     def update_weights():
         data = flask_module.request.get_json(force=True)
+        pair_name = data["pair_name"]
         version = data.get("version", 0)
 
         def action():
             adapter = _require_adapter()
-            adapter.execute_weight_update(version)
+            adapter.execute_weight_update(pair_name, version)
 
         return run_endpoint(
             "update_weights",
@@ -87,10 +88,11 @@ def create_awex_blueprint(
     @bp.route("/batch_isend_irecv", methods=["POST"])
     def batch_isend_irecv():
         data = flask_module.request.get_json(force=True)
+        pair_name = data.pop("pair_name")
 
         def action():
             adapter = _require_adapter()
-            adapter.batch_isend_irecv(**data)
+            adapter.batch_isend_irecv(pair_name, **data)
 
         return run_endpoint(
             "batch_isend_irecv",
@@ -99,13 +101,16 @@ def create_awex_blueprint(
 
     @bp.route("/teardown", methods=["POST"])
     def teardown():
+        data = flask_module.request.get_json(silent=True) or {}
+        pair_name = data.get("pair_name")
+        if not pair_name:
+            return flask_module.jsonify({"error": "pair_name is required"}), 400
         adapter = _state.get("adapter")
         if adapter is None:
             return flask_module.jsonify({"status": "success"})
 
         def action():
-            adapter.teardown_weight_update_group()
-            _state["adapter"] = None
+            adapter.teardown_weight_update_group(pair_name)
 
         return run_endpoint(
             "awex_teardown",
@@ -130,11 +135,12 @@ def create_awex_blueprint(
     @bp.route("/execute_colocate_weight_update", methods=["POST"])
     def execute_colocate_weight_update():
         data = flask_module.request.get_json(force=True)
+        pair_name = data["pair_name"]
         version = data.get("version", 0)
 
         def action():
             adapter = _require_adapter()
-            adapter.execute_colocate_weight_update(version)
+            adapter.execute_colocate_weight_update(pair_name, version)
 
         return run_endpoint(
             "execute_colocate_weight_update",

--- a/areal/v2/training_service/worker/awex.py
+++ b/areal/v2/training_service/worker/awex.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 from areal.utils import logging
@@ -28,7 +30,43 @@ def create_awex_blueprint(
     """
     bp = flask_module.Blueprint("awex", __name__, url_prefix="/awex")
 
-    _state: dict[str, Any] = {"adapter": None}
+    _state: dict[str, Any] = {
+        "adapter": None,
+        "cancelled_operations": set(),
+        "operation_lock": Lock(),
+    }
+
+    def _operation(data: dict[str, Any]) -> tuple[str, str, float | None]:
+        pair_name = data["pair_name"]
+        operation_id = data.pop("operation_id", "")
+        ttl = data.pop("operation_ttl_s", None)
+        expiry = None if ttl is None else time.monotonic() + max(0.0, float(ttl))
+        return pair_name, operation_id, expiry
+
+    def _check_operation(
+        pair_name: str, operation_id: str, expiry: float | None
+    ) -> float | None:
+        remaining = None if expiry is None else expiry - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            raise TimeoutError(f"AWEX init for pair {pair_name!r} expired in queue")
+        if operation_id:
+            with _state["operation_lock"]:
+                cancelled = (pair_name, operation_id) in _state["cancelled_operations"]
+            if cancelled:
+                raise RuntimeError(
+                    f"AWEX operation {operation_id!r} for pair {pair_name!r} "
+                    "was cancelled"
+                )
+        return remaining
+
+    def _apply_remaining_pg_timeout(
+        data: dict[str, Any], remaining: float | None
+    ) -> None:
+        if remaining is not None:
+            configured = data.get("process_group_timeout_s")
+            data["process_group_timeout_s"] = min(
+                remaining, remaining if configured is None else float(configured)
+            )
 
     def _require_adapter():
         if _state["adapter"] is None:
@@ -60,8 +98,11 @@ def create_awex_blueprint(
     @bp.route("/init_weights_update_group", methods=["POST"])
     def init_weights_update_group():
         data = flask_module.request.get_json(force=True)
+        pair_name, operation_id, expiry = _operation(data)
 
         def action():
+            remaining = _check_operation(pair_name, operation_id, expiry)
+            _apply_remaining_pg_timeout(data, remaining)
             adapter = _require_adapter()
             adapter.init_weight_update_group(**data)
 
@@ -88,9 +129,11 @@ def create_awex_blueprint(
     @bp.route("/batch_isend_irecv", methods=["POST"])
     def batch_isend_irecv():
         data = flask_module.request.get_json(force=True)
-        pair_name = data.pop("pair_name")
+        pair_name, operation_id, expiry = _operation(data)
+        data.pop("pair_name")
 
         def action():
+            _check_operation(pair_name, operation_id, expiry)
             adapter = _require_adapter()
             adapter.batch_isend_irecv(pair_name, **data)
 
@@ -105,12 +148,15 @@ def create_awex_blueprint(
         pair_name = data.get("pair_name")
         if not pair_name:
             return flask_module.jsonify({"error": "pair_name is required"}), 400
-        adapter = _state.get("adapter")
-        if adapter is None:
-            return flask_module.jsonify({"status": "success"})
+        operation_id = data.get("operation_id", "")
+        if operation_id:
+            with _state["operation_lock"]:
+                _state["cancelled_operations"].add((pair_name, operation_id))
 
         def action():
-            adapter.teardown_weight_update_group(pair_name)
+            adapter = _state.get("adapter")
+            if adapter is not None:
+                adapter.teardown_weight_update_group(pair_name)
 
         return run_endpoint(
             "awex_teardown",
@@ -121,8 +167,11 @@ def create_awex_blueprint(
     @bp.route("/init_colocate_weight_update", methods=["POST"])
     def init_colocate_weight_update():
         data = flask_module.request.get_json(force=True)
+        pair_name, operation_id, expiry = _operation(data)
 
         def action():
+            remaining = _check_operation(pair_name, operation_id, expiry)
+            _apply_remaining_pg_timeout(data, remaining)
             adapter = _require_adapter()
             adapter.init_colocate_weight_update(**data)
 

--- a/areal/v2/weight_update/awex/__init__.py
+++ b/areal/v2/weight_update/awex/__init__.py
@@ -27,6 +27,7 @@ def awex_wu_use_group() -> bool:
 async def _fetch_kv_metadata(
     kv_store_url: str,
     pair_name: str,
+    timeout_s: float | None = None,
 ) -> tuple[Any, Any]:
     """Fetch infer and training parameter metadata from the gateway KV store.
 
@@ -41,7 +42,8 @@ async def _fetch_kv_metadata(
     infer_url = f"{kv_store_url}/weight_meta/{pair_name}/infer_params_meta"
     train_url = f"{kv_store_url}/weight_meta/{pair_name}/training_params_meta"
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
 
         async def _get(url: str) -> Any:
             async with session.get(url) as resp:
@@ -54,10 +56,16 @@ async def _fetch_kv_metadata(
     return deserialize_value(infer_json), deserialize_value(train_json)
 
 
-def fetch_kv_metadata(kv_store_url: str, pair_name: str) -> tuple[Any, Any]:
+def fetch_kv_metadata(
+    kv_store_url: str,
+    pair_name: str,
+    timeout_s: float | None = None,
+) -> tuple[Any, Any]:
     """Sync wrapper around :func:`_fetch_kv_metadata`.
 
     Bridges async ``aiohttp`` into the synchronous adapter context using
     :func:`~areal.infra.utils.concurrent.run_async_task`.
     """
-    return run_async_task(_fetch_kv_metadata, kv_store_url, pair_name)
+    if timeout_s is not None and timeout_s <= 0:
+        raise TimeoutError("Metadata fetch deadline exceeded")
+    return run_async_task(_fetch_kv_metadata, kv_store_url, pair_name, timeout_s)

--- a/areal/v2/weight_update/awex/fsdp_adapter.py
+++ b/areal/v2/weight_update/awex/fsdp_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 # pyright: reportMissingImports=false
 import os
+import time
 from typing import TYPE_CHECKING
 
 import torch
@@ -14,7 +15,7 @@ from awex.meta.weight_meta import (
 from awex.sharding.param_sharding import ShardingType
 from awex.sharding.rank_info import RankInfo
 from awex.transfer.nccl_comm import batch_send_recv, nccl_build_send_ops
-from awex.transfer.transfer_plan import TransferPlan, TransferPlanBuilder
+from awex.transfer.transfer_plan import TransferPlanBuilder
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Shard
 
@@ -23,6 +24,10 @@ from areal.utils import logging
 from areal.v2.weight_update.awex import (
     awex_wu_use_group,
     fetch_kv_metadata,
+)
+from areal.v2.weight_update.awex.state import (
+    AwexPairState,
+    teardown_pair_process_groups,
 )
 from areal.v2.weight_update.nccl_group import (
     init_weights_update_group,
@@ -43,10 +48,7 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
 
     def __init__(self, engine: FSDPEngine):
         self._engine = engine
-        self._transfer_plan: TransferPlan | None = None
-        self._weights_update_group = None
-        self._weights_update_group_gloo = None
-        self._transfer_rank: int | None = None
+        self._pair_states: dict[str, AwexPairState] = {}
 
     @property
     def parallelism_strategy(self) -> dict:
@@ -138,37 +140,94 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        process_group_timeout_s: float | None = None,
     ) -> None:
-        self._transfer_rank = transfer_rank
+        existing_state = self._pair_states.get(pair_name)
+        if existing_state is not None:
+            if (
+                existing_state.weights_update_group is not None
+                and existing_state.control_group is not None
+            ):
+                logger.info("AWEX pair '%s' is already initialized", pair_name)
+                return
+            raise RuntimeError(
+                f"AWEX pair {pair_name!r} is only partially initialized; "
+                "teardown must complete before retrying initialization"
+            )
 
-        infer_meta, train_meta = fetch_kv_metadata(kv_store_url, pair_name)
+        deadline = (
+            None
+            if process_group_timeout_s is None
+            else time.monotonic() + process_group_timeout_s
+        )
+
+        def _remaining() -> float | None:
+            if deadline is None:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("AWEX process-group setup deadline exceeded")
+            return remaining
+
+        infer_meta, train_meta = fetch_kv_metadata(
+            kv_store_url, pair_name, timeout_s=_remaining()
+        )
 
         builder = TransferPlanBuilder(
             infer_world_size=infer_world_size,
             train_world_size=train_world_size,
             num_infer_engines=num_engines,
         )
-        self._transfer_plan = builder.build_local_transfer_plan(
+        transfer_plan = builder.build_local_transfer_plan(
             infer_meta, train_meta, global_transfer_rank=transfer_rank
         )
 
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
-        self._weights_update_group = init_weights_update_group(
-            master_address=master_addr,
-            master_port=master_port,
-            rank=transfer_rank,
-            world_size=world_size,
-            group_name=f"awex_{pair_name}",
-            role="training",
-        )
-        self._weights_update_group_gloo = init_weights_update_group(
-            master_address=master_addr,
-            master_port=master_port,
-            rank=transfer_rank,
-            world_size=world_size,
-            group_name=f"awex_{pair_name}_gloo",
-            backend="gloo",
-            role="training",
+        weights_update_group = None
+        control_group = None
+        try:
+            weights_update_group = init_weights_update_group(
+                master_address=master_addr,
+                master_port=master_port,
+                rank=transfer_rank,
+                world_size=world_size,
+                group_name=f"awex_{pair_name}",
+                role="training",
+                timeout_s=_remaining(),
+            )
+            control_group = init_weights_update_group(
+                master_address=master_addr,
+                master_port=master_port,
+                rank=transfer_rank,
+                world_size=world_size,
+                group_name=f"awex_{pair_name}_gloo",
+                backend="gloo",
+                role="training",
+                timeout_s=_remaining(),
+            )
+        except BaseException:
+            state = AwexPairState(
+                weights_update_group=weights_update_group,
+                control_group=control_group,
+                transfer_plan=transfer_plan,
+                transfer_rank=transfer_rank,
+            )
+            self._pair_states[pair_name] = state
+            try:
+                self.teardown_weight_update_group(pair_name)
+            except Exception:
+                logger.warning(
+                    "Failed to rollback partially initialized AWEX pair '%s'",
+                    pair_name,
+                    exc_info=True,
+                )
+            raise
+
+        self._pair_states[pair_name] = AwexPairState(
+            weights_update_group=weights_update_group,
+            control_group=control_group,
+            transfer_plan=transfer_plan,
+            transfer_rank=transfer_rank,
         )
         logger.info(
             "Initialized AWEX weight update groups for pair=%s role=training "
@@ -180,23 +239,16 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             pair_name,
         )
 
-    def execute_weight_update(self, version: int) -> None:
+    def execute_weight_update(self, pair_name: str, version: int) -> None:
         del version
-        if self._transfer_plan is None:
-            raise RuntimeError("Transfer plan is not initialized")
-        if self._weights_update_group is None:
-            raise RuntimeError("Weight update group is not initialized")
-        if self._weights_update_group_gloo is None:
-            raise RuntimeError("Gloo weight update group is not initialized")
-        if self._transfer_rank is None:
-            raise RuntimeError("Transfer rank is not initialized")
+        state = self._require_pair_state(pair_name)
 
         params = self.get_local_shard_parameters()
         send_ops, _, _ = nccl_build_send_ops(
             params,
-            self._transfer_plan,
-            self._weights_update_group,
-            copy_rank=self._transfer_rank,
+            state.transfer_plan,
+            state.weights_update_group,
+            copy_rank=state.transfer_rank,
         )
         batch_send_recv(
             send_ops=send_ops,
@@ -204,37 +256,42 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             blocking=True,
             use_group=awex_wu_use_group(),
         )
-        torch.distributed.barrier(group=self._weights_update_group_gloo)
+        torch.distributed.barrier(group=state.control_group)
 
-    def batch_isend_irecv(self, **kwargs) -> None:
-        if self._weights_update_group_gloo is None:
-            raise RuntimeError("Gloo weight update group is not initialized")
+    def batch_isend_irecv(self, pair_name: str, **kwargs) -> None:
+        state = self._require_pair_state(pair_name)
         setup_kwargs = {
             k: v for k, v in kwargs.items() if k not in ("world_size", "barrier_group")
         }
         setup_batch_isend_irecv(
-            self._weights_update_group,
-            self._transfer_rank,
+            state.weights_update_group,
+            state.transfer_rank,
             kwargs.get("world_size", 0),
-            barrier_group=self._weights_update_group_gloo,
+            barrier_group=state.control_group,
             **setup_kwargs,
         )
 
-    def teardown_weight_update_group(self) -> None:
-        if (
-            self._weights_update_group is not None
-            and torch.distributed.is_initialized()
-        ):
-            torch.distributed.destroy_process_group(self._weights_update_group)
-        if (
-            self._weights_update_group_gloo is not None
-            and torch.distributed.is_initialized()
-        ):
-            torch.distributed.destroy_process_group(self._weights_update_group_gloo)
-        self._weights_update_group = None
-        self._weights_update_group_gloo = None
-        self._transfer_plan = None
-        self._transfer_rank = None
+    def teardown_weight_update_group(self, pair_name: str) -> None:
+        state = self._pair_states.get(pair_name)
+        if state is None:
+            return
+
+        errors = teardown_pair_process_groups(state, pair_name, torch.distributed)
+
+        if state.weights_update_group is None and state.control_group is None:
+            self._pair_states.pop(pair_name, None)
+        if errors:
+            raise RuntimeError(
+                f"Failed to teardown AWEX pair {pair_name!r} on this rank"
+            ) from errors[0]
+
+    def _require_pair_state(self, pair_name: str) -> AwexPairState:
+        state = self._pair_states.get(pair_name)
+        if state is None:
+            raise RuntimeError(f"AWEX pair {pair_name!r} is not initialized")
+        if state.weights_update_group is None or state.control_group is None:
+            raise RuntimeError(f"AWEX pair {pair_name!r} is partially torn down")
+        return state
 
     def _to_hf_name(self, name: str) -> str:
         if self._engine.is_vision_model and is_qwen_vl_model(

--- a/areal/v2/weight_update/awex/megatron_adapter.py
+++ b/areal/v2/weight_update/awex/megatron_adapter.py
@@ -36,6 +36,11 @@ from areal.v2.weight_update.awex.delta_config import (
     validate_dte_world_size,
 )
 from areal.v2.weight_update.awex.delta_detect import AdamWInversionDetector
+from areal.v2.weight_update.awex.state import (
+    AwexPairState,
+    MegatronColocatePairState,
+    teardown_pair_process_groups,
+)
 from areal.v2.weight_update.nccl_group import (
     init_weights_update_group,
     setup_batch_isend_irecv,
@@ -66,6 +71,9 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
 
     def __init__(self, engine: MegatronEngine):
         self._engine = engine
+        self._pair_states: dict[str, AwexPairState] = {}
+        self._active_pair_name: str | None = None
+        self._colocate_pair_states: dict[str, MegatronColocatePairState] = {}
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
         self._weights_update_group_gloo = None
@@ -77,12 +85,68 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         self._offloaded_weights: dict[str, torch.Tensor] = {}
         self._released_tags: set[str] = set()
         self._colocate_lock = threading.Lock()
-        self._colocate_admin_api_key: str = "areal-admin-key"
-        self._colocate_http_client: httpx.Client | None = None
-        self._colocate_timeout_s: float = 120.0
         self._dte_config = DTERuntimeConfig.from_env()
         self._delta_tracker = None
         self._delta_detector = None
+
+    def _capture_active_pair_state(self) -> AwexPairState:
+        return AwexPairState(
+            weights_update_group=self._weights_update_group,
+            control_group=self._weights_update_group_gloo,
+            transfer_plan=self._transfer_plan,
+            transfer_rank=self._transfer_rank or 0,
+            runtime_state={
+                "world_size": self._world_size,
+                "separation_delta_transport": self._separation_delta_transport,
+                "separation_wire_dtypes": self._separation_wire_dtypes,
+                "delta_tracker": self._delta_tracker,
+                "delta_detector": self._delta_detector,
+            },
+        )
+
+    def _clear_active_pair_state(self) -> None:
+        self._weights_update_group = None
+        self._weights_update_group_gloo = None
+        self._transfer_plan = None
+        self._transfer_rank = None
+        self._world_size = None
+        self._separation_delta_transport = None
+        self._separation_wire_dtypes = None
+        self._delta_tracker = None
+        self._delta_detector = None
+
+    def _park_active_pair(self) -> None:
+        if self._active_pair_name is not None:
+            self._pair_states[self._active_pair_name] = (
+                self._capture_active_pair_state()
+            )
+        self._active_pair_name = None
+        self._clear_active_pair_state()
+
+    def _activate_pair(self, pair_name: str) -> AwexPairState:
+        if self._active_pair_name == pair_name:
+            state = self._capture_active_pair_state()
+        else:
+            state = self._pair_states.pop(pair_name, None)
+            if state is None:
+                raise RuntimeError(f"AWEX pair {pair_name!r} is not initialized")
+            if state.weights_update_group is None or state.control_group is None:
+                raise RuntimeError(f"AWEX pair {pair_name!r} is partially torn down")
+            self._park_active_pair()
+            runtime = state.runtime_state or {}
+            self._weights_update_group = state.weights_update_group
+            self._weights_update_group_gloo = state.control_group
+            self._transfer_plan = state.transfer_plan
+            self._transfer_rank = state.transfer_rank
+            self._world_size = runtime.get("world_size")
+            self._separation_delta_transport = runtime.get("separation_delta_transport")
+            self._separation_wire_dtypes = runtime.get("separation_wire_dtypes")
+            self._delta_tracker = runtime.get("delta_tracker")
+            self._delta_detector = runtime.get("delta_detector")
+            self._active_pair_name = pair_name
+        if state.weights_update_group is None or state.control_group is None:
+            raise RuntimeError(f"AWEX pair {pair_name!r} is partially torn down")
+        return state
 
     @property
     def parallelism_strategy(self) -> dict:
@@ -175,47 +239,120 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        process_group_timeout_s: float | None = None,
     ) -> None:
+        if self._active_pair_name == pair_name:
+            if (
+                self._weights_update_group is None
+                or self._weights_update_group_gloo is None
+            ):
+                raise RuntimeError(
+                    f"AWEX pair {pair_name!r} is only partially initialized"
+                )
+            logger.info("AWEX pair '%s' is already initialized", pair_name)
+            return
+        if pair_name in self._pair_states:
+            raise RuntimeError(
+                f"AWEX pair {pair_name!r} is still registered; "
+                "teardown must complete before it can be reused"
+            )
         if self._dte_config.enabled:
             validate_dte_world_size(world_size, infer_world_size, train_world_size)
 
-        self._transfer_rank = transfer_rank
-        self._world_size = world_size
+        deadline = (
+            None
+            if process_group_timeout_s is None
+            else time.monotonic() + process_group_timeout_s
+        )
 
-        infer_meta, train_meta = fetch_kv_metadata(kv_store_url, pair_name)
+        def _remaining() -> float | None:
+            if deadline is None:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("AWEX process-group setup deadline exceeded")
+            return remaining
+
+        infer_meta, train_meta = fetch_kv_metadata(
+            kv_store_url, pair_name, timeout_s=_remaining()
+        )
 
         builder = TransferPlanBuilder(
             infer_world_size=infer_world_size,
             train_world_size=train_world_size,
             num_infer_engines=num_engines,
         )
-        self._transfer_plan = builder.build_local_transfer_plan(
+        transfer_plan = builder.build_local_transfer_plan(
             infer_meta, train_meta, global_transfer_rank=transfer_rank
         )
 
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
-        self._weights_update_group = init_weights_update_group(
-            master_address=master_addr,
-            master_port=master_port,
-            rank=transfer_rank,
-            world_size=world_size,
-            group_name=f"awex_{pair_name}",
-            role="training",
-        )
-        self._weights_update_group_gloo = init_weights_update_group(
-            master_address=master_addr,
-            master_port=master_port,
-            rank=transfer_rank,
-            world_size=world_size,
-            group_name=f"awex_{pair_name}_gloo",
-            backend="gloo",
-            role="training",
-        )
-        if self._dte_config.enabled:
-            self._separation_wire_dtypes = synchronize_wire_dtypes(
-                self._transfer_plan,
-                self._weights_update_group_gloo,
+        weights_update_group = None
+        control_group = None
+        separation_wire_dtypes = None
+        try:
+            weights_update_group = init_weights_update_group(
+                master_address=master_addr,
+                master_port=master_port,
+                rank=transfer_rank,
+                world_size=world_size,
+                group_name=f"awex_{pair_name}",
+                role="training",
+                timeout_s=_remaining(),
             )
+            control_group = init_weights_update_group(
+                master_address=master_addr,
+                master_port=master_port,
+                rank=transfer_rank,
+                world_size=world_size,
+                group_name=f"awex_{pair_name}_gloo",
+                backend="gloo",
+                role="training",
+                timeout_s=_remaining(),
+            )
+            if self._dte_config.enabled:
+                separation_wire_dtypes = synchronize_wire_dtypes(
+                    transfer_plan,
+                    control_group,
+                )
+        except BaseException:
+            self._pair_states[pair_name] = AwexPairState(
+                weights_update_group=weights_update_group,
+                control_group=control_group,
+                transfer_plan=transfer_plan,
+                transfer_rank=transfer_rank,
+                runtime_state={
+                    "world_size": world_size,
+                    "separation_delta_transport": None,
+                    "separation_wire_dtypes": separation_wire_dtypes,
+                    "delta_tracker": None,
+                    "delta_detector": None,
+                },
+            )
+            try:
+                self.teardown_weight_update_group(pair_name)
+            except Exception:
+                logger.warning(
+                    "Failed to roll back candidate AWEX pair %r; "
+                    "retaining its remaining handles for retry",
+                    pair_name,
+                    exc_info=True,
+                )
+            raise
+
+        # Do not disturb a working pair until the candidate has all of its
+        # metadata, NCCL/Gloo groups and optional DTE state ready.
+        self._park_active_pair()
+        self._weights_update_group = weights_update_group
+        self._weights_update_group_gloo = control_group
+        self._transfer_plan = transfer_plan
+        self._transfer_rank = transfer_rank
+        self._world_size = world_size
+        self._separation_delta_transport = None
+        self._separation_wire_dtypes = separation_wire_dtypes
+        self._delta_tracker = None
+        self._delta_detector = None
+        self._active_pair_name = pair_name
         logger.info(
             "Initialized AWEX weight update groups for pair=%s role=training "
             "rank=%s world_size=%s nccl=awex_%s gloo=awex_%s_gloo",
@@ -226,7 +363,8 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             pair_name,
         )
 
-    def execute_weight_update(self, version: int) -> None:
+    def execute_weight_update(self, pair_name: str, version: int) -> None:
+        self._activate_pair(pair_name)
         if self._dte_config.enabled:
             self._release_grad_buffers_for_separation_sync()
             try:
@@ -460,7 +598,8 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             len(self._separation_wire_dtypes),
         )
 
-    def batch_isend_irecv(self, **kwargs) -> None:
+    def batch_isend_irecv(self, pair_name: str, **kwargs) -> None:
+        self._activate_pair(pair_name)
         if self._weights_update_group_gloo is None:
             raise RuntimeError("Gloo weight update group is not initialized")
         setup_kwargs = {
@@ -474,23 +613,50 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             **setup_kwargs,
         )
 
-    def teardown_weight_update_group(self) -> None:
-        if self._weights_update_group is not None and dist.is_initialized():
-            dist.destroy_process_group(self._weights_update_group)
-        if self._weights_update_group_gloo is not None and dist.is_initialized():
-            dist.destroy_process_group(self._weights_update_group_gloo)
-        self._weights_update_group = None
-        self._weights_update_group_gloo = None
-        self._transfer_plan = None
-        self._transfer_rank = None
-        self._world_size = None
-        self._separation_delta_transport = None
-        self._separation_wire_dtypes = None
-        self._delta_tracker = None
-        self._delta_detector = None
-        if self._colocate_http_client is not None:
-            self._colocate_http_client.close()
-            self._colocate_http_client = None
+    def teardown_weight_update_group(self, pair_name: str) -> None:
+        is_active = self._active_pair_name == pair_name
+        if is_active:
+            state = self._capture_active_pair_state()
+        else:
+            state = self._pair_states.get(pair_name)
+
+        errors = (
+            teardown_pair_process_groups(state, pair_name, dist)
+            if state is not None
+            else []
+        )
+
+        if state is not None and is_active:
+            self._weights_update_group = state.weights_update_group
+            self._weights_update_group_gloo = state.control_group
+            if state.weights_update_group is None and state.control_group is None:
+                self._active_pair_name = None
+                self._clear_active_pair_state()
+        elif (
+            state is not None
+            and state.weights_update_group is None
+            and state.control_group is None
+        ):
+            self._pair_states.pop(pair_name, None)
+
+        colocate_state = self._colocate_pair_states.get(pair_name)
+        if colocate_state is not None:
+            try:
+                colocate_state.http_client.close()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to close colocate client for AWEX pair '%s'",
+                    pair_name,
+                    exc_info=True,
+                )
+                errors.append(exc)
+            else:
+                self._colocate_pair_states.pop(pair_name, None)
+
+        if errors:
+            raise RuntimeError(
+                f"Failed to teardown AWEX pair {pair_name!r} on this rank"
+            ) from errors[0]
 
     def _build_rank_info(self) -> RankInfo:
         from megatron.core import parallel_state as mpu
@@ -642,35 +808,47 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        process_group_timeout_s: float | None = None,
     ) -> None:
-        self._colocate_pair_name = pair_name
-        self._colocate_kv_store_url = kv_store_url
-        self._colocate_transfer_rank = transfer_rank
-        self._colocate_infer_world_size = infer_world_size
-        self._colocate_admin_api_key = admin_api_key
-        self._colocate_timeout_s = timeout_s
-        if self._colocate_http_client is None:
-            self._colocate_http_client = httpx.Client()
+        del process_group_timeout_s
+        existing_state = self._colocate_pair_states.get(pair_name)
+        if existing_state is not None:
+            if existing_state.http_client is None:
+                raise RuntimeError(
+                    f"AWEX colocate pair {pair_name!r} is partially torn down; "
+                    "teardown must complete before retrying initialization"
+                )
+            logger.info("AWEX colocate pair '%s' is already initialized", pair_name)
+            return
+        self._colocate_pair_states[pair_name] = MegatronColocatePairState(
+            kv_store_url=kv_store_url,
+            transfer_rank=transfer_rank,
+            infer_world_size=infer_world_size,
+            admin_api_key=admin_api_key,
+            timeout_s=timeout_s,
+            http_client=httpx.Client(),
+        )
         logger.info(
             "Initialized colocate weight update for pair '%s', transfer_rank=%d",
             pair_name,
             transfer_rank,
         )
 
-    def execute_colocate_weight_update(self, version: int) -> None:
+    def execute_colocate_weight_update(self, pair_name: str, version: int) -> None:
         with self._colocate_lock:
-            self._execute_colocate_weight_update_locked(version)
+            self._execute_colocate_weight_update_locked(pair_name, version)
 
-    def _execute_colocate_weight_update_locked(self, version: int) -> None:
-        kv_store_url = self._colocate_kv_store_url
-        pair_name = self._colocate_pair_name
-        transfer_rank = self._colocate_transfer_rank
-        assert self._colocate_http_client is not None, (
-            "init_colocate_weight_update must be called first"
-        )
-        client = self._colocate_http_client
-        auth_headers = {"Authorization": f"Bearer {self._colocate_admin_api_key}"}
-        timeout_s = self._colocate_timeout_s
+    def _execute_colocate_weight_update_locked(
+        self, pair_name: str, version: int
+    ) -> None:
+        state = self._colocate_pair_states.get(pair_name)
+        if state is None:
+            raise RuntimeError(f"AWEX colocate pair {pair_name!r} is not initialized")
+        kv_store_url = state.kv_store_url
+        transfer_rank = state.transfer_rank
+        client = state.http_client
+        auth_headers = {"Authorization": f"Bearer {state.admin_api_key}"}
+        timeout_s = state.timeout_s
 
         weights_offloaded = "weights" in self._released_tags
         if weights_offloaded:

--- a/areal/v2/weight_update/awex/megatron_adapter.py
+++ b/areal/v2/weight_update/awex/megatron_adapter.py
@@ -38,7 +38,6 @@ from areal.v2.weight_update.awex.delta_config import (
 from areal.v2.weight_update.awex.delta_detect import AdamWInversionDetector
 from areal.v2.weight_update.awex.state import (
     AwexPairState,
-    MegatronColocatePairState,
     teardown_pair_process_groups,
 )
 from areal.v2.weight_update.nccl_group import (
@@ -73,7 +72,6 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         self._engine = engine
         self._pair_states: dict[str, AwexPairState] = {}
         self._active_pair_name: str | None = None
-        self._colocate_pair_states: dict[str, MegatronColocatePairState] = {}
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
         self._weights_update_group_gloo = None
@@ -85,6 +83,9 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         self._offloaded_weights: dict[str, torch.Tensor] = {}
         self._released_tags: set[str] = set()
         self._colocate_lock = threading.Lock()
+        self._colocate_admin_api_key = "areal-admin-key"
+        self._colocate_http_client: httpx.Client | None = None
+        self._colocate_timeout_s = 120.0
         self._dte_config = DTERuntimeConfig.from_env()
         self._delta_tracker = None
         self._delta_detector = None
@@ -639,10 +640,12 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         ):
             self._pair_states.pop(pair_name, None)
 
-        colocate_state = self._colocate_pair_states.get(pair_name)
-        if colocate_state is not None:
+        if (
+            getattr(self, "_colocate_pair_name", None) == pair_name
+            and self._colocate_http_client is not None
+        ):
             try:
-                colocate_state.http_client.close()
+                self._colocate_http_client.close()
             except Exception as exc:
                 logger.warning(
                     "Failed to close colocate client for AWEX pair '%s'",
@@ -651,7 +654,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
                 )
                 errors.append(exc)
             else:
-                self._colocate_pair_states.pop(pair_name, None)
+                self._colocate_http_client = None
 
         if errors:
             raise RuntimeError(
@@ -811,23 +814,14 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         process_group_timeout_s: float | None = None,
     ) -> None:
         del process_group_timeout_s
-        existing_state = self._colocate_pair_states.get(pair_name)
-        if existing_state is not None:
-            if existing_state.http_client is None:
-                raise RuntimeError(
-                    f"AWEX colocate pair {pair_name!r} is partially torn down; "
-                    "teardown must complete before retrying initialization"
-                )
-            logger.info("AWEX colocate pair '%s' is already initialized", pair_name)
-            return
-        self._colocate_pair_states[pair_name] = MegatronColocatePairState(
-            kv_store_url=kv_store_url,
-            transfer_rank=transfer_rank,
-            infer_world_size=infer_world_size,
-            admin_api_key=admin_api_key,
-            timeout_s=timeout_s,
-            http_client=httpx.Client(),
-        )
+        self._colocate_pair_name = pair_name
+        self._colocate_kv_store_url = kv_store_url
+        self._colocate_transfer_rank = transfer_rank
+        self._colocate_infer_world_size = infer_world_size
+        self._colocate_admin_api_key = admin_api_key
+        self._colocate_timeout_s = timeout_s
+        if self._colocate_http_client is None:
+            self._colocate_http_client = httpx.Client()
         logger.info(
             "Initialized colocate weight update for pair '%s', transfer_rank=%d",
             pair_name,
@@ -841,14 +835,14 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
     def _execute_colocate_weight_update_locked(
         self, pair_name: str, version: int
     ) -> None:
-        state = self._colocate_pair_states.get(pair_name)
-        if state is None:
+        if getattr(self, "_colocate_pair_name", None) != pair_name:
             raise RuntimeError(f"AWEX colocate pair {pair_name!r} is not initialized")
-        kv_store_url = state.kv_store_url
-        transfer_rank = state.transfer_rank
-        client = state.http_client
-        auth_headers = {"Authorization": f"Bearer {state.admin_api_key}"}
-        timeout_s = state.timeout_s
+        assert self._colocate_http_client is not None
+        kv_store_url = self._colocate_kv_store_url
+        transfer_rank = self._colocate_transfer_rank
+        client = self._colocate_http_client
+        auth_headers = {"Authorization": f"Bearer {self._colocate_admin_api_key}"}
+        timeout_s = self._colocate_timeout_s
 
         weights_offloaded = "weights" in self._released_tags
         if weights_offloaded:

--- a/areal/v2/weight_update/awex/sglang_adapter.py
+++ b/areal/v2/weight_update/awex/sglang_adapter.py
@@ -41,6 +41,11 @@ from areal.v2.weight_update.awex.delta_config import (
     synchronize_wire_dtypes,
     validate_dte_world_size,
 )
+from areal.v2.weight_update.awex.state import (
+    AwexPairState,
+    SGLangColocatePairState,
+    teardown_pair_process_groups,
+)
 from areal.v2.weight_update.inference_adapter import (
     AwexInferenceAdapter,
 )
@@ -57,6 +62,9 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
 
     def __init__(self, scheduler: Any):
         self._scheduler = scheduler
+        self._pair_states: dict[str, AwexPairState] = {}
+        self._active_pair_name: str | None = None
+        self._colocate_pair_states: dict[str, SGLangColocatePairState] = {}
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
         self._weights_update_group_gloo = None
@@ -67,13 +75,66 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._rank_info: RankInfo | None = None
         self._parameters: dict[str, torch.Tensor] | None = None
         self._released_tags: set[str] = set()
-        self._colocate_admin_api_key: str = "areal-admin-key"
-        self._colocate_http_client: httpx.Client | None = None
-        self._colocate_timeout_s: float = 120.0
-        self._colocate_transport = None
-        self._train_to_infer_device_mapping: dict | None = None
-        self._infer_to_train_device_mapping: dict | None = None
         self._dte_config = DTERuntimeConfig.from_env()
+
+    def _capture_active_pair_state(self) -> AwexPairState:
+        return AwexPairState(
+            weights_update_group=self._weights_update_group,
+            control_group=self._weights_update_group_gloo,
+            transfer_plan=self._transfer_plan,
+            transfer_rank=self._transfer_rank or 0,
+            runtime_state={
+                "world_size": self._world_size,
+                "separation_delta_transport": self._separation_delta_transport,
+                "separation_wire_dtypes": self._separation_wire_dtypes,
+                "rank_info": self._rank_info,
+                "parameters": self._parameters,
+            },
+        )
+
+    def _clear_active_pair_state(self) -> None:
+        self._weights_update_group = None
+        self._weights_update_group_gloo = None
+        self._transfer_plan = None
+        self._transfer_rank = None
+        self._world_size = None
+        self._separation_delta_transport = None
+        self._separation_wire_dtypes = None
+        self._rank_info = None
+        self._parameters = None
+
+    def _park_active_pair(self) -> None:
+        if self._active_pair_name is not None:
+            self._pair_states[self._active_pair_name] = (
+                self._capture_active_pair_state()
+            )
+        self._active_pair_name = None
+        self._clear_active_pair_state()
+
+    def _activate_pair(self, pair_name: str) -> AwexPairState:
+        if self._active_pair_name == pair_name:
+            state = self._capture_active_pair_state()
+        else:
+            state = self._pair_states.pop(pair_name, None)
+            if state is None:
+                raise RuntimeError(f"AWEX pair {pair_name!r} is not initialized")
+            if state.weights_update_group is None or state.control_group is None:
+                raise RuntimeError(f"AWEX pair {pair_name!r} is partially torn down")
+            self._park_active_pair()
+            runtime = state.runtime_state or {}
+            self._weights_update_group = state.weights_update_group
+            self._weights_update_group_gloo = state.control_group
+            self._transfer_plan = state.transfer_plan
+            self._transfer_rank = state.transfer_rank
+            self._world_size = runtime.get("world_size")
+            self._separation_delta_transport = runtime.get("separation_delta_transport")
+            self._separation_wire_dtypes = runtime.get("separation_wire_dtypes")
+            self._rank_info = runtime.get("rank_info")
+            self._parameters = runtime.get("parameters")
+            self._active_pair_name = pair_name
+        if state.weights_update_group is None or state.control_group is None:
+            raise RuntimeError(f"AWEX pair {pair_name!r} is partially torn down")
+        return state
 
     def _get_model(self) -> torch.nn.Module:
         return self._scheduler.tp_worker.model_runner.model
@@ -370,7 +431,23 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        process_group_timeout_s: float | None = None,
     ) -> None:
+        if self._active_pair_name == pair_name:
+            if (
+                self._weights_update_group is None
+                or self._weights_update_group_gloo is None
+            ):
+                raise RuntimeError(
+                    f"AWEX pair {pair_name!r} is only partially initialized"
+                )
+            logger.info("AWEX pair '%s' is already initialized", pair_name)
+            return
+        if pair_name in self._pair_states:
+            raise RuntimeError(
+                f"AWEX pair {pair_name!r} is still registered; "
+                "teardown must complete before it can be reused"
+            )
         if self._dte_config.enabled:
             validate_dte_world_size(world_size, infer_world_size, train_world_size)
 
@@ -390,43 +467,98 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
 
         engine_local_rank = pp_rank * tp_size + tp_rank
         global_rank = transfer_rank * per_engine_world + engine_local_rank
-        self._transfer_rank = global_rank
-        self._world_size = world_size
+        deadline = (
+            None
+            if process_group_timeout_s is None
+            else time.monotonic() + process_group_timeout_s
+        )
 
-        infer_meta, train_meta = fetch_kv_metadata(kv_store_url, pair_name)
+        def _remaining() -> float | None:
+            if deadline is None:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("AWEX process-group setup deadline exceeded")
+            return remaining
+
+        infer_meta, train_meta = fetch_kv_metadata(
+            kv_store_url, pair_name, timeout_s=_remaining()
+        )
 
         builder = TransferPlanBuilder(
             infer_world_size=infer_world_size,
             train_world_size=train_world_size,
             num_infer_engines=num_engines,
         )
-        self._transfer_plan = builder.build_local_transfer_plan(
+        transfer_plan = builder.build_local_transfer_plan(
             infer_meta, train_meta, global_transfer_rank=global_rank
         )
 
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
-        self._weights_update_group = init_weights_update_group(
-            master_address=master_addr,
-            master_port=master_port,
-            rank=global_rank,
-            world_size=world_size,
-            group_name=f"awex_{pair_name}",
-            role="inference",
-        )
-        self._weights_update_group_gloo = init_weights_update_group(
-            master_address=master_addr,
-            master_port=master_port,
-            rank=global_rank,
-            world_size=world_size,
-            group_name=f"awex_{pair_name}_gloo",
-            backend="gloo",
-            role="inference",
-        )
-        if self._dte_config.enabled:
-            self._separation_wire_dtypes = synchronize_wire_dtypes(
-                self._transfer_plan,
-                self._weights_update_group_gloo,
+        weights_update_group = None
+        control_group = None
+        separation_wire_dtypes = None
+        try:
+            weights_update_group = init_weights_update_group(
+                master_address=master_addr,
+                master_port=master_port,
+                rank=global_rank,
+                world_size=world_size,
+                group_name=f"awex_{pair_name}",
+                role="inference",
+                timeout_s=_remaining(),
             )
+            control_group = init_weights_update_group(
+                master_address=master_addr,
+                master_port=master_port,
+                rank=global_rank,
+                world_size=world_size,
+                group_name=f"awex_{pair_name}_gloo",
+                backend="gloo",
+                role="inference",
+                timeout_s=_remaining(),
+            )
+            if self._dte_config.enabled:
+                separation_wire_dtypes = synchronize_wire_dtypes(
+                    transfer_plan,
+                    control_group,
+                )
+        except BaseException:
+            self._pair_states[pair_name] = AwexPairState(
+                weights_update_group=weights_update_group,
+                control_group=control_group,
+                transfer_plan=transfer_plan,
+                transfer_rank=global_rank,
+                runtime_state={
+                    "world_size": world_size,
+                    "separation_delta_transport": None,
+                    "separation_wire_dtypes": separation_wire_dtypes,
+                    "rank_info": None,
+                    "parameters": None,
+                },
+            )
+            try:
+                self.teardown_weight_update_group(pair_name)
+            except Exception:
+                logger.warning(
+                    "Failed to roll back candidate AWEX pair %r; "
+                    "retaining its remaining handles for retry",
+                    pair_name,
+                    exc_info=True,
+                )
+            raise
+
+        self._park_active_pair()
+        self._weights_update_group = weights_update_group
+        self._weights_update_group_gloo = control_group
+        self._transfer_plan = transfer_plan
+        self._transfer_rank = global_rank
+        self._world_size = world_size
+        self._separation_delta_transport = None
+        self._separation_wire_dtypes = separation_wire_dtypes
+        self._rank_info = None
+        self._parameters = None
+        self._active_pair_name = pair_name
         logger.info(
             "Initialized AWEX weight update groups for pair=%s role=inference "
             "rank=%s world_size=%s nccl=awex_%s gloo=awex_%s_gloo",
@@ -437,7 +569,8 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             pair_name,
         )
 
-    def execute_weight_update(self, version: int) -> None:
+    def execute_weight_update(self, pair_name: str, version: int) -> None:
+        self._activate_pair(pair_name)
         if self._dte_config.enabled:
             self._execute_separation_weight_update(version)
             return
@@ -570,7 +703,8 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             len(self._separation_wire_dtypes),
         )
 
-    def batch_isend_irecv(self, **kwargs) -> None:
+    def batch_isend_irecv(self, pair_name: str, **kwargs) -> None:
+        self._activate_pair(pair_name)
         if self._weights_update_group_gloo is None:
             raise RuntimeError("Gloo weight update group is not initialized")
         setup_kwargs = {
@@ -584,26 +718,88 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             **setup_kwargs,
         )
 
-    def teardown_weight_update_group(self) -> None:
-        if self._weights_update_group is not None and dist.is_initialized():
-            dist.destroy_process_group(self._weights_update_group)
-        if self._weights_update_group_gloo is not None and dist.is_initialized():
-            dist.destroy_process_group(self._weights_update_group_gloo)
-        self._weights_update_group = None
-        self._weights_update_group_gloo = None
-        self._transfer_plan = None
-        self._transfer_rank = None
-        self._world_size = None
-        self._separation_delta_transport = None
-        self._separation_wire_dtypes = None
-        self._rank_info = None
-        self._parameters = None
-        if self._colocate_http_client is not None:
-            self._colocate_http_client.close()
-            self._colocate_http_client = None
-        self._colocate_transport = None
-        self._train_to_infer_device_mapping = None
-        self._infer_to_train_device_mapping = None
+    def teardown_weight_update_group(self, pair_name: str) -> None:
+        is_active = self._active_pair_name == pair_name
+        if is_active:
+            state = self._capture_active_pair_state()
+        else:
+            state = self._pair_states.get(pair_name)
+
+        errors = (
+            teardown_pair_process_groups(state, pair_name, dist)
+            if state is not None
+            else []
+        )
+
+        if state is not None and is_active:
+            self._weights_update_group = state.weights_update_group
+            self._weights_update_group_gloo = state.control_group
+            if state.weights_update_group is None and state.control_group is None:
+                self._active_pair_name = None
+                self._clear_active_pair_state()
+        elif (
+            state is not None
+            and state.weights_update_group is None
+            and state.control_group is None
+        ):
+            self._pair_states.pop(pair_name, None)
+
+        colocate_state = self._colocate_pair_states.get(pair_name)
+        if colocate_state is not None:
+            if colocate_state.weights_update_group is not None:
+                if dist.is_initialized():
+                    try:
+                        dist.destroy_process_group(colocate_state.weights_update_group)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to teardown colocate group for AWEX pair '%s'",
+                            pair_name,
+                            exc_info=True,
+                        )
+                        errors.append(exc)
+                    else:
+                        colocate_state.weights_update_group = None
+                else:
+                    colocate_state.weights_update_group = None
+            if colocate_state.transport is not None:
+                cleanup = getattr(colocate_state.transport, "close", None)
+                if cleanup is None:
+                    cleanup = getattr(colocate_state.transport, "destroy", None)
+                try:
+                    if cleanup is not None:
+                        cleanup()
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to close colocate transport for AWEX pair '%s'",
+                        pair_name,
+                        exc_info=True,
+                    )
+                    errors.append(exc)
+                else:
+                    colocate_state.transport = None
+            if colocate_state.http_client is not None:
+                try:
+                    colocate_state.http_client.close()
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to close colocate client for AWEX pair '%s'",
+                        pair_name,
+                        exc_info=True,
+                    )
+                    errors.append(exc)
+                else:
+                    colocate_state.http_client = None
+            if (
+                colocate_state.weights_update_group is None
+                and colocate_state.transport is None
+                and colocate_state.http_client is None
+            ):
+                self._colocate_pair_states.pop(pair_name, None)
+
+        if errors:
+            raise RuntimeError(
+                f"Failed to teardown AWEX pair {pair_name!r} on this rank"
+            ) from errors[0]
 
     # ── Colocated weight transfer methods ─────────────────────────────────
 
@@ -618,24 +814,44 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        process_group_timeout_s: float | None = None,
     ) -> None:
+        existing_state = self._colocate_pair_states.get(pair_name)
+        if existing_state is not None:
+            if (
+                existing_state.weights_update_group is None
+                or existing_state.transport is None
+                or existing_state.http_client is None
+            ):
+                raise RuntimeError(
+                    f"AWEX colocate pair {pair_name!r} is partially initialized; "
+                    "teardown must complete before retrying initialization"
+                )
+            logger.info("AWEX colocate pair '%s' is already initialized", pair_name)
+            return
         if infer_world_size != train_world_size:
             raise ValueError(
                 f"Colocate mode requires infer_world_size == train_world_size. "
                 f"Got infer_world_size={infer_world_size}, "
                 f"train_world_size={train_world_size}"
             )
-        self._colocate_pair_name = pair_name
-        self._colocate_kv_store_url = kv_store_url
-        self._transfer_rank = transfer_rank
-        self._colocate_infer_world_size = infer_world_size
-        self._colocate_train_world_size = train_world_size
-        self._colocate_admin_api_key = admin_api_key
-        self._colocate_timeout_s = timeout_s
-        if self._colocate_http_client is None:
-            self._colocate_http_client = httpx.Client()
+        deadline = (
+            None
+            if process_group_timeout_s is None
+            else time.monotonic() + process_group_timeout_s
+        )
 
-        infer_meta, train_meta = fetch_kv_metadata(kv_store_url, pair_name)
+        def _remaining() -> float | None:
+            if deadline is None:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("AWEX process-group setup deadline exceeded")
+            return remaining
+
+        infer_meta, train_meta = fetch_kv_metadata(
+            kv_store_url, pair_name, timeout_s=_remaining()
+        )
 
         builder = TransferPlanBuilder(
             infer_world_size=infer_world_size,
@@ -649,33 +865,58 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             train_rank = infer_world_size + i
             train_to_infer[train_rank] = i
             infer_to_train[i] = train_rank
-        self._train_to_infer_device_mapping = train_to_infer
-        self._infer_to_train_device_mapping = infer_to_train
-
-        self._send_transfer_plan = builder.build_local_transfer_plan(
+        send_transfer_plan = builder.build_local_transfer_plan(
             infer_meta,
             train_meta,
             global_transfer_rank=infer_to_train[transfer_rank],
         )
-        self._recv_transfer_plan = builder.build_local_transfer_plan(
+        recv_transfer_plan = builder.build_local_transfer_plan(
             infer_meta,
             train_meta,
             global_transfer_rank=transfer_rank,
         )
 
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
-        self._weights_update_group = init_weights_update_group(
-            master_address="127.0.0.1",
-            master_port=master_port,
-            rank=transfer_rank,
-            world_size=infer_world_size,
-            group_name=f"awex_colocate_{pair_name}",
-            role="inference",
+        state = SGLangColocatePairState(
+            weights_update_group=None,
+            transfer_rank=transfer_rank,
+            kv_store_url=kv_store_url,
+            infer_world_size=infer_world_size,
+            train_world_size=train_world_size,
+            admin_api_key=admin_api_key,
+            timeout_s=timeout_s,
+            http_client=httpx.Client(),
+            transport=None,
+            train_to_infer_device_mapping=train_to_infer,
+            infer_to_train_device_mapping=infer_to_train,
+            send_transfer_plan=send_transfer_plan,
+            recv_transfer_plan=recv_transfer_plan,
         )
-
-        self._colocate_transport = NcclColocateStreamBatchTransport(
-            transfer_rank, infer_world_size
-        )
+        self._colocate_pair_states[pair_name] = state
+        try:
+            state.weights_update_group = init_weights_update_group(
+                master_address="127.0.0.1",
+                master_port=master_port,
+                rank=transfer_rank,
+                world_size=infer_world_size,
+                group_name=f"awex_colocate_{pair_name}",
+                role="inference",
+                timeout_s=_remaining(),
+            )
+            state.transport = NcclColocateStreamBatchTransport(
+                transfer_rank, infer_world_size
+            )
+        except BaseException:
+            try:
+                self.teardown_weight_update_group(pair_name)
+            except Exception:
+                logger.warning(
+                    "Failed to roll back colocate AWEX pair %r; retaining its "
+                    "remaining resources for retry",
+                    pair_name,
+                    exc_info=True,
+                )
+            raise
 
         logger.info(
             "Initialized colocate weight update for pair '%s', "
@@ -685,19 +926,21 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             infer_world_size,
         )
 
-    def execute_colocate_weight_update(self, version: int) -> None:
-        kv_store_url = self._colocate_kv_store_url
-        pair_name = self._colocate_pair_name
-        transfer_rank = self._transfer_rank
-        assert self._colocate_http_client is not None, (
-            "init_colocate_weight_update must be called first"
-        )
-        assert self._infer_to_train_device_mapping is not None
-        client = self._colocate_http_client
-        auth_headers = {"Authorization": f"Bearer {self._colocate_admin_api_key}"}
-        timeout_s = self._colocate_timeout_s
+    def execute_colocate_weight_update(self, pair_name: str, version: int) -> None:
+        state = self._colocate_pair_states.get(pair_name)
+        if state is None:
+            raise RuntimeError(f"AWEX colocate pair {pair_name!r} is not initialized")
+        kv_store_url = state.kv_store_url
+        transfer_rank = state.transfer_rank
+        client = state.http_client
+        if client is None or state.transport is None:
+            raise RuntimeError(
+                f"AWEX colocate pair {pair_name!r} is partially torn down"
+            )
+        auth_headers = {"Authorization": f"Bearer {state.admin_api_key}"}
+        timeout_s = state.timeout_s
 
-        paired_train_rank = self._infer_to_train_device_mapping[transfer_rank]
+        paired_train_rank = state.infer_to_train_device_mapping[transfer_rank]
         kv_key = f"colocate_weights_rank{paired_train_rank}_{version}"
 
         deadline = time.monotonic() + timeout_s
@@ -734,16 +977,15 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         rank_info = self._build_rank_info()
         rank_coordinate = f"infer_{rank_info.global_rank}"
 
-        assert self._colocate_transport is not None
-        self._colocate_transport.update_weights_in_colocate_mode(
-            self._train_to_infer_device_mapping,
-            self._infer_to_train_device_mapping,
+        state.transport.update_weights_in_colocate_mode(
+            state.train_to_infer_device_mapping,
+            state.infer_to_train_device_mapping,
             transfer_rank,
             rank_coordinate,
-            self._colocate_infer_world_size,
-            self._send_transfer_plan,
-            self._recv_transfer_plan,
-            self._weights_update_group,
+            state.infer_world_size,
+            state.send_transfer_plan,
+            state.recv_transfer_plan,
+            state.weights_update_group,
             deserialized_weights,
             recv_parameters,
             step_id=version,

--- a/areal/v2/weight_update/awex/sglang_adapter.py
+++ b/areal/v2/weight_update/awex/sglang_adapter.py
@@ -43,7 +43,6 @@ from areal.v2.weight_update.awex.delta_config import (
 )
 from areal.v2.weight_update.awex.state import (
     AwexPairState,
-    SGLangColocatePairState,
     teardown_pair_process_groups,
 )
 from areal.v2.weight_update.inference_adapter import (
@@ -64,7 +63,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._scheduler = scheduler
         self._pair_states: dict[str, AwexPairState] = {}
         self._active_pair_name: str | None = None
-        self._colocate_pair_states: dict[str, SGLangColocatePairState] = {}
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
         self._weights_update_group_gloo = None
@@ -75,6 +73,12 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._rank_info: RankInfo | None = None
         self._parameters: dict[str, torch.Tensor] | None = None
         self._released_tags: set[str] = set()
+        self._colocate_admin_api_key = "areal-admin-key"
+        self._colocate_http_client: httpx.Client | None = None
+        self._colocate_timeout_s = 120.0
+        self._colocate_transport = None
+        self._train_to_infer_device_mapping: dict | None = None
+        self._infer_to_train_device_mapping: dict | None = None
         self._dte_config = DTERuntimeConfig.from_env()
 
     def _capture_active_pair_state(self) -> AwexPairState:
@@ -87,8 +91,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                 "world_size": self._world_size,
                 "separation_delta_transport": self._separation_delta_transport,
                 "separation_wire_dtypes": self._separation_wire_dtypes,
-                "rank_info": self._rank_info,
-                "parameters": self._parameters,
             },
         )
 
@@ -100,8 +102,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._world_size = None
         self._separation_delta_transport = None
         self._separation_wire_dtypes = None
-        self._rank_info = None
-        self._parameters = None
 
     def _park_active_pair(self) -> None:
         if self._active_pair_name is not None:
@@ -129,8 +129,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             self._world_size = runtime.get("world_size")
             self._separation_delta_transport = runtime.get("separation_delta_transport")
             self._separation_wire_dtypes = runtime.get("separation_wire_dtypes")
-            self._rank_info = runtime.get("rank_info")
-            self._parameters = runtime.get("parameters")
             self._active_pair_name = pair_name
         if state.weights_update_group is None or state.control_group is None:
             raise RuntimeError(f"AWEX pair {pair_name!r} is partially torn down")
@@ -533,8 +531,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                     "world_size": world_size,
                     "separation_delta_transport": None,
                     "separation_wire_dtypes": separation_wire_dtypes,
-                    "rank_info": None,
-                    "parameters": None,
                 },
             )
             try:
@@ -556,8 +552,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._world_size = world_size
         self._separation_delta_transport = None
         self._separation_wire_dtypes = separation_wire_dtypes
-        self._rank_info = None
-        self._parameters = None
         self._active_pair_name = pair_name
         logger.info(
             "Initialized AWEX weight update groups for pair=%s role=inference "
@@ -744,12 +738,11 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         ):
             self._pair_states.pop(pair_name, None)
 
-        colocate_state = self._colocate_pair_states.get(pair_name)
-        if colocate_state is not None:
-            if colocate_state.weights_update_group is not None:
+        if getattr(self, "_colocate_pair_name", None) == pair_name:
+            if self._weights_update_group is not None:
                 if dist.is_initialized():
                     try:
-                        dist.destroy_process_group(colocate_state.weights_update_group)
+                        dist.destroy_process_group(self._weights_update_group)
                     except Exception as exc:
                         logger.warning(
                             "Failed to teardown colocate group for AWEX pair '%s'",
@@ -758,28 +751,16 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                         )
                         errors.append(exc)
                     else:
-                        colocate_state.weights_update_group = None
+                        self._weights_update_group = None
                 else:
-                    colocate_state.weights_update_group = None
-            if colocate_state.transport is not None:
-                cleanup = getattr(colocate_state.transport, "close", None)
-                if cleanup is None:
-                    cleanup = getattr(colocate_state.transport, "destroy", None)
+                    self._weights_update_group = None
+            if self._weights_update_group is None:
+                # The pinned transport has no close/destroy protocol. Its
+                # resources are owned by the process group destroyed above.
+                self._colocate_transport = None
+            if self._colocate_http_client is not None:
                 try:
-                    if cleanup is not None:
-                        cleanup()
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to close colocate transport for AWEX pair '%s'",
-                        pair_name,
-                        exc_info=True,
-                    )
-                    errors.append(exc)
-                else:
-                    colocate_state.transport = None
-            if colocate_state.http_client is not None:
-                try:
-                    colocate_state.http_client.close()
+                    self._colocate_http_client.close()
                 except Exception as exc:
                     logger.warning(
                         "Failed to close colocate client for AWEX pair '%s'",
@@ -788,13 +769,7 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                     )
                     errors.append(exc)
                 else:
-                    colocate_state.http_client = None
-            if (
-                colocate_state.weights_update_group is None
-                and colocate_state.transport is None
-                and colocate_state.http_client is None
-            ):
-                self._colocate_pair_states.pop(pair_name, None)
+                    self._colocate_http_client = None
 
         if errors:
             raise RuntimeError(
@@ -816,19 +791,6 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         timeout_s: float = 120.0,
         process_group_timeout_s: float | None = None,
     ) -> None:
-        existing_state = self._colocate_pair_states.get(pair_name)
-        if existing_state is not None:
-            if (
-                existing_state.weights_update_group is None
-                or existing_state.transport is None
-                or existing_state.http_client is None
-            ):
-                raise RuntimeError(
-                    f"AWEX colocate pair {pair_name!r} is partially initialized; "
-                    "teardown must complete before retrying initialization"
-                )
-            logger.info("AWEX colocate pair '%s' is already initialized", pair_name)
-            return
         if infer_world_size != train_world_size:
             raise ValueError(
                 f"Colocate mode requires infer_world_size == train_world_size. "
@@ -849,6 +811,16 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
                 raise TimeoutError("AWEX process-group setup deadline exceeded")
             return remaining
 
+        self._colocate_pair_name = pair_name
+        self._colocate_kv_store_url = kv_store_url
+        self._transfer_rank = transfer_rank
+        self._colocate_infer_world_size = infer_world_size
+        self._colocate_train_world_size = train_world_size
+        self._colocate_admin_api_key = admin_api_key
+        self._colocate_timeout_s = timeout_s
+        if self._colocate_http_client is None:
+            self._colocate_http_client = httpx.Client()
+
         infer_meta, train_meta = fetch_kv_metadata(
             kv_store_url, pair_name, timeout_s=_remaining()
         )
@@ -865,58 +837,32 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             train_rank = infer_world_size + i
             train_to_infer[train_rank] = i
             infer_to_train[i] = train_rank
-        send_transfer_plan = builder.build_local_transfer_plan(
+        self._send_transfer_plan = builder.build_local_transfer_plan(
             infer_meta,
             train_meta,
             global_transfer_rank=infer_to_train[transfer_rank],
         )
-        recv_transfer_plan = builder.build_local_transfer_plan(
+        self._recv_transfer_plan = builder.build_local_transfer_plan(
             infer_meta,
             train_meta,
             global_transfer_rank=transfer_rank,
         )
 
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
-        state = SGLangColocatePairState(
-            weights_update_group=None,
-            transfer_rank=transfer_rank,
-            kv_store_url=kv_store_url,
-            infer_world_size=infer_world_size,
-            train_world_size=train_world_size,
-            admin_api_key=admin_api_key,
-            timeout_s=timeout_s,
-            http_client=httpx.Client(),
-            transport=None,
-            train_to_infer_device_mapping=train_to_infer,
-            infer_to_train_device_mapping=infer_to_train,
-            send_transfer_plan=send_transfer_plan,
-            recv_transfer_plan=recv_transfer_plan,
+        self._train_to_infer_device_mapping = train_to_infer
+        self._infer_to_train_device_mapping = infer_to_train
+        self._weights_update_group = init_weights_update_group(
+            master_address="127.0.0.1",
+            master_port=master_port,
+            rank=transfer_rank,
+            world_size=infer_world_size,
+            group_name=f"awex_colocate_{pair_name}",
+            role="inference",
+            timeout_s=_remaining(),
         )
-        self._colocate_pair_states[pair_name] = state
-        try:
-            state.weights_update_group = init_weights_update_group(
-                master_address="127.0.0.1",
-                master_port=master_port,
-                rank=transfer_rank,
-                world_size=infer_world_size,
-                group_name=f"awex_colocate_{pair_name}",
-                role="inference",
-                timeout_s=_remaining(),
-            )
-            state.transport = NcclColocateStreamBatchTransport(
-                transfer_rank, infer_world_size
-            )
-        except BaseException:
-            try:
-                self.teardown_weight_update_group(pair_name)
-            except Exception:
-                logger.warning(
-                    "Failed to roll back colocate AWEX pair %r; retaining its "
-                    "remaining resources for retry",
-                    pair_name,
-                    exc_info=True,
-                )
-            raise
+        self._colocate_transport = NcclColocateStreamBatchTransport(
+            transfer_rank, infer_world_size
+        )
 
         logger.info(
             "Initialized colocate weight update for pair '%s', "
@@ -927,20 +873,18 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         )
 
     def execute_colocate_weight_update(self, pair_name: str, version: int) -> None:
-        state = self._colocate_pair_states.get(pair_name)
-        if state is None:
+        if getattr(self, "_colocate_pair_name", None) != pair_name:
             raise RuntimeError(f"AWEX colocate pair {pair_name!r} is not initialized")
-        kv_store_url = state.kv_store_url
-        transfer_rank = state.transfer_rank
-        client = state.http_client
-        if client is None or state.transport is None:
-            raise RuntimeError(
-                f"AWEX colocate pair {pair_name!r} is partially torn down"
-            )
-        auth_headers = {"Authorization": f"Bearer {state.admin_api_key}"}
-        timeout_s = state.timeout_s
+        assert self._colocate_http_client is not None
+        assert self._infer_to_train_device_mapping is not None
+        assert self._colocate_transport is not None
+        kv_store_url = self._colocate_kv_store_url
+        transfer_rank = self._transfer_rank
+        client = self._colocate_http_client
+        auth_headers = {"Authorization": f"Bearer {self._colocate_admin_api_key}"}
+        timeout_s = self._colocate_timeout_s
 
-        paired_train_rank = state.infer_to_train_device_mapping[transfer_rank]
+        paired_train_rank = self._infer_to_train_device_mapping[transfer_rank]
         kv_key = f"colocate_weights_rank{paired_train_rank}_{version}"
 
         deadline = time.monotonic() + timeout_s
@@ -977,15 +921,15 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         rank_info = self._build_rank_info()
         rank_coordinate = f"infer_{rank_info.global_rank}"
 
-        state.transport.update_weights_in_colocate_mode(
-            state.train_to_infer_device_mapping,
-            state.infer_to_train_device_mapping,
+        self._colocate_transport.update_weights_in_colocate_mode(
+            self._train_to_infer_device_mapping,
+            self._infer_to_train_device_mapping,
             transfer_rank,
             rank_coordinate,
-            state.infer_world_size,
-            state.send_transfer_plan,
-            state.recv_transfer_plan,
-            state.weights_update_group,
+            self._colocate_infer_world_size,
+            self._send_transfer_plan,
+            self._recv_transfer_plan,
+            self._weights_update_group,
             deserialized_weights,
             recv_parameters,
             step_id=version,

--- a/areal/v2/weight_update/awex/state.py
+++ b/areal/v2/weight_update/awex/state.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from areal.utils import logging
+
+logger = logging.getLogger("AwexPairState")
+
+
+@dataclass
+class AwexPairState:
+    """Per-pair state for a non-colocated AWEX process group."""
+
+    weights_update_group: Any | None
+    control_group: Any | None
+    transfer_plan: Any
+    transfer_rank: int
+    runtime_state: dict[str, Any] | None = None
+
+
+@dataclass
+class MegatronColocatePairState:
+    """Per-pair state for the training side of colocated AWEX."""
+
+    kv_store_url: str
+    transfer_rank: int
+    infer_world_size: int
+    admin_api_key: str
+    timeout_s: float
+    http_client: Any | None
+
+
+@dataclass
+class SGLangColocatePairState:
+    """Per-pair state for the inference side of colocated AWEX."""
+
+    weights_update_group: Any | None
+    transfer_rank: int
+    kv_store_url: str
+    infer_world_size: int
+    train_world_size: int
+    admin_api_key: str
+    timeout_s: float
+    http_client: Any | None
+    transport: Any | None
+    train_to_infer_device_mapping: dict[int, int]
+    infer_to_train_device_mapping: dict[int, int]
+    send_transfer_plan: Any
+    recv_transfer_plan: Any
+
+
+def teardown_pair_process_groups(
+    state: AwexPairState,
+    pair_name: str,
+    distributed: Any,
+) -> list[Exception]:
+    """Destroy each pair group independently and retain failed handles."""
+    if not distributed.is_initialized():
+        state.weights_update_group = None
+        state.control_group = None
+        return []
+
+    errors: list[Exception] = []
+    for attr in ("weights_update_group", "control_group"):
+        group = getattr(state, attr)
+        if group is None:
+            continue
+        try:
+            distributed.destroy_process_group(group)
+        except Exception as exc:
+            logger.warning(
+                "Failed to teardown %s for AWEX pair '%s'",
+                attr,
+                pair_name,
+                exc_info=True,
+            )
+            errors.append(exc)
+        else:
+            setattr(state, attr, None)
+    return errors

--- a/areal/v2/weight_update/awex/state.py
+++ b/areal/v2/weight_update/awex/state.py
@@ -21,37 +21,6 @@ class AwexPairState:
     runtime_state: dict[str, Any] | None = None
 
 
-@dataclass
-class MegatronColocatePairState:
-    """Per-pair state for the training side of colocated AWEX."""
-
-    kv_store_url: str
-    transfer_rank: int
-    infer_world_size: int
-    admin_api_key: str
-    timeout_s: float
-    http_client: Any | None
-
-
-@dataclass
-class SGLangColocatePairState:
-    """Per-pair state for the inference side of colocated AWEX."""
-
-    weights_update_group: Any | None
-    transfer_rank: int
-    kv_store_url: str
-    infer_world_size: int
-    train_world_size: int
-    admin_api_key: str
-    timeout_s: float
-    http_client: Any | None
-    transport: Any | None
-    train_to_infer_device_mapping: dict[int, int]
-    infer_to_train_device_mapping: dict[int, int]
-    send_transfer_plan: Any
-    recv_transfer_plan: Any
-
-
 def teardown_pair_process_groups(
     state: AwexPairState,
     pair_name: str,

--- a/areal/v2/weight_update/controller/controller.py
+++ b/areal/v2/weight_update/controller/controller.py
@@ -20,12 +20,27 @@ from areal.v2.weight_update.gateway.config import WeightUpdateResult
 logger = logging.getLogger("WeightUpdateController")
 
 
+class WeightUpdateError(RuntimeError):
+    """A gateway-reported update failure with its inference safety status."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        inference_weights_may_be_mutated: bool,
+    ) -> None:
+        super().__init__(message)
+        self.inference_weights_may_be_mutated = inference_weights_may_be_mutated
+
+
 class WeightUpdateController:
     def __init__(self, config: WeightUpdateControllerConfig | None = None) -> None:
         self.config = config or WeightUpdateControllerConfig()
         self._gateway_url: str = ""
         self._gateway_proc: subprocess.Popen | None = None
         self._pair_name: str | None = None
+        self._train_worker_urls: list[str] = []
+        self._inference_worker_urls: list[str] = []
         self._session: httpx.Client | None = None
 
     @property
@@ -33,12 +48,24 @@ class WeightUpdateController:
         return self._gateway_url
 
     @property
+    def pair_name(self) -> str | None:
+        return self._pair_name
+
+    @property
+    def train_worker_urls(self) -> list[str]:
+        return list(self._train_worker_urls)
+
+    @property
+    def inference_worker_urls(self) -> list[str]:
+        return list(self._inference_worker_urls)
+
+    @property
     def _http(self) -> httpx.Client:
         if self._session is None:
             raise RuntimeError("Controller not initialized. Call initialize() first.")
         return self._session
 
-    def initialize(self) -> None:
+    def initialize(self, timeout: float | None = None) -> None:
         cfg = self.config
         port = cfg.port
         if port == 0:
@@ -62,20 +89,25 @@ class WeightUpdateController:
             cfg.log_level,
         ]
 
-        self._gateway_proc = subprocess.Popen(
-            cmd,
-            stdout=sys.stdout,
-            stderr=sys.stdout,
-        )
+        try:
+            self._gateway_proc = subprocess.Popen(
+                cmd,
+                stdout=sys.stdout,
+                stderr=sys.stdout,
+            )
 
-        self._gateway_url = f"http://{cfg.host}:{port}"
-        self._session = httpx.Client()
-        self._session.headers["Authorization"] = f"Bearer {cfg.admin_api_key}"
-        self._wait_for_health()
-        logger.info("Gateway ready at %s", self._gateway_url)
+            self._gateway_url = f"http://{cfg.host}:{port}"
+            self._session = httpx.Client()
+            self._session.headers["Authorization"] = f"Bearer {cfg.admin_api_key}"
+            self._wait_for_health(timeout=timeout)
+            logger.info("Gateway ready at %s", self._gateway_url)
+        except BaseException:
+            self.destroy()
+            raise
 
-    def _wait_for_health(self) -> None:
-        deadline = time.monotonic() + self.config.setup_timeout
+    def _wait_for_health(self, timeout: float | None = None) -> None:
+        timeout = self.config.setup_timeout if timeout is None else timeout
+        deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if self._gateway_proc is not None and self._gateway_proc.poll() is not None:
                 raise RuntimeError(
@@ -83,15 +115,17 @@ class WeightUpdateController:
                     f"(code {self._gateway_proc.returncode})"
                 )
             try:
-                resp = self._http.get(f"{self._gateway_url}/health", timeout=2.0)
+                remaining = deadline - time.monotonic()
+                resp = self._http.get(
+                    f"{self._gateway_url}/health",
+                    timeout=min(2.0, max(0.001, remaining)),
+                )
                 if resp.status_code == 200:
                     return
             except (httpx.ConnectError, httpx.TimeoutException):
                 pass
-            time.sleep(0.5)
-        raise TimeoutError(
-            f"Gateway did not become healthy within {self.config.setup_timeout}s"
-        )
+            time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+        raise TimeoutError(f"Gateway did not become healthy within {timeout}s")
 
     def health_check(self) -> bool:
         try:
@@ -116,8 +150,10 @@ class WeightUpdateController:
         colocate: bool = False,
         nccl_master_addr: str = "",
         nccl_master_port: int = 0,
+        setup_timeout_s: float | None = None,
+        rollback_timeout_s: float = 30.0,
+        request_timeout: float | None = None,
     ) -> None:
-        self._pair_name = pair_name
         payload: dict[str, Any] = {
             "pair_name": pair_name,
             "train_worker_urls": train_worker_urls,
@@ -130,11 +166,22 @@ class WeightUpdateController:
             "colocate": colocate,
             "nccl_master_addr": nccl_master_addr,
             "nccl_master_port": nccl_master_port,
+            "setup_timeout_s": setup_timeout_s,
+            "rollback_timeout_s": rollback_timeout_s,
         }
+        # Retain the pending identity before /connect so a timeout or partial
+        # gateway rollback can still be retried through /disconnect.
+        self._pair_name = pair_name
+        self._train_worker_urls = list(train_worker_urls)
+        self._inference_worker_urls = list(inference_worker_urls)
         resp = self._http.post(
             f"{self._gateway_url}/connect",
             json=payload,
-            timeout=self.config.request_timeout,
+            timeout=(
+                self.config.request_timeout
+                if request_timeout is None
+                else request_timeout
+            ),
         )
         resp.raise_for_status()
         logger.info(
@@ -155,26 +202,39 @@ class WeightUpdateController:
         )
         resp.raise_for_status()
         data = resp.json()
-        return WeightUpdateResult(
+        result = WeightUpdateResult(
             status=data["status"],
             version=data["version"],
             duration_ms=data["duration_ms"],
             error=data.get("error"),
+            inference_weights_may_be_mutated=data.get(
+                "inference_weights_may_be_mutated", True
+            ),
         )
+        if result.status != "ok":
+            raise WeightUpdateError(
+                f"Weight update failed for pair {self._pair_name!r}, "
+                f"version={version}: {result.error or 'unknown error'}",
+                inference_weights_may_be_mutated=(
+                    result.inference_weights_may_be_mutated
+                ),
+            )
+        return result
 
-    def disconnect(self) -> None:
+    def disconnect(self, timeout: float | None = None) -> None:
         if self._pair_name is None:
             return
-        try:
-            resp = self._http.post(
-                f"{self._gateway_url}/disconnect",
-                json={"pair_name": self._pair_name},
-                timeout=self.config.request_timeout,
-            )
-            resp.raise_for_status()
-            logger.info("Disconnected pair '%s'", self._pair_name)
-        finally:
-            self._pair_name = None
+        pair_name = self._pair_name
+        resp = self._http.post(
+            f"{self._gateway_url}/disconnect",
+            json={"pair_name": pair_name},
+            timeout=self.config.request_timeout if timeout is None else timeout,
+        )
+        resp.raise_for_status()
+        self._pair_name = None
+        self._train_worker_urls = []
+        self._inference_worker_urls = []
+        logger.info("Disconnected pair '%s'", pair_name)
 
     def _gateway_get(self, path: str) -> Any:
         resp = self._http.get(
@@ -198,12 +258,17 @@ class WeightUpdateController:
             )
         return resp.json()
 
-    def destroy(self) -> None:
+    def destroy(self, *, raise_on_error: bool = False) -> None:
+        disconnect_error: Exception | None = None
         if self._pair_name is not None:
             try:
                 self.disconnect()
-            except Exception:
+            except Exception as e:
+                disconnect_error = e
                 logger.warning("Failed to disconnect during destroy", exc_info=True)
+
+        if disconnect_error is not None and raise_on_error:
+            raise disconnect_error
 
         if self._session is not None:
             self._session.close()

--- a/areal/v2/weight_update/controller/controller.py
+++ b/areal/v2/weight_update/controller/controller.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 from typing import Any
+from uuid import uuid4
 
 import httpx
 
@@ -39,6 +40,10 @@ class WeightUpdateController:
         self._gateway_url: str = ""
         self._gateway_proc: subprocess.Popen | None = None
         self._pair_name: str | None = None
+        self._operation_id: str | None = None
+        self._port_guard_url: str = ""
+        self._port_token: str | None = None
+        self._workers_cleaned = False
         self._train_worker_urls: list[str] = []
         self._inference_worker_urls: list[str] = []
         self._session: httpx.Client | None = None
@@ -54,6 +59,54 @@ class WeightUpdateController:
     @property
     def train_worker_urls(self) -> list[str]:
         return list(self._train_worker_urls)
+
+    @property
+    def operation_id(self) -> str | None:
+        return self._operation_id
+
+    @property
+    def port_token(self) -> str | None:
+        return self._port_token
+
+    def retain_port_reservation(self, guard_url: str, token: str) -> None:
+        self._port_guard_url = guard_url
+        self._port_token = token
+
+    @property
+    def workers_cleaned(self) -> bool:
+        return self._workers_cleaned
+
+    def mark_workers_cleaned(self) -> None:
+        self._workers_cleaned = True
+        self._pair_name = None
+        self._operation_id = None
+        self._train_worker_urls = []
+        self._inference_worker_urls = []
+
+    def retain_pending_connection(
+        self,
+        pair_name: str,
+        operation_id: str,
+        train_worker_urls: list[str],
+        inference_worker_urls: list[str],
+    ) -> None:
+        self._pair_name = pair_name
+        self._operation_id = operation_id
+        self._train_worker_urls = list(train_worker_urls)
+        self._inference_worker_urls = list(inference_worker_urls)
+        self._workers_cleaned = False
+
+    def release_port_reservation(self, timeout: float) -> None:
+        if self._port_token is None:
+            return
+        resp = httpx.post(
+            f"{self._port_guard_url}/release_ports",
+            json={"token": self._port_token},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        self._port_guard_url = ""
+        self._port_token = None
 
     @property
     def inference_worker_urls(self) -> list[str]:
@@ -102,7 +155,16 @@ class WeightUpdateController:
             self._wait_for_health(timeout=timeout)
             logger.info("Gateway ready at %s", self._gateway_url)
         except BaseException:
-            self.destroy()
+            # /connect has not been sent yet, so there is no worker pair to
+            # disconnect. Avoid the long request timeout and terminate only the
+            # private process within the setup budget.
+            cleanup_timeout = max(
+                0.001,
+                min(5.0, self.config.setup_timeout if timeout is None else timeout),
+            )
+            self.terminate_private_gateway(
+                timeout=cleanup_timeout, raise_on_error=False
+            )
             raise
 
     def _wait_for_health(self, timeout: float | None = None) -> None:
@@ -153,9 +215,12 @@ class WeightUpdateController:
         setup_timeout_s: float | None = None,
         rollback_timeout_s: float = 30.0,
         request_timeout: float | None = None,
+        operation_id: str | None = None,
     ) -> None:
+        operation_id = operation_id or uuid4().hex
         payload: dict[str, Any] = {
             "pair_name": pair_name,
+            "operation_id": operation_id,
             "train_worker_urls": train_worker_urls,
             "inference_worker_urls": inference_worker_urls,
             "mode": mode,
@@ -171,9 +236,12 @@ class WeightUpdateController:
         }
         # Retain the pending identity before /connect so a timeout or partial
         # gateway rollback can still be retried through /disconnect.
-        self._pair_name = pair_name
-        self._train_worker_urls = list(train_worker_urls)
-        self._inference_worker_urls = list(inference_worker_urls)
+        self.retain_pending_connection(
+            pair_name,
+            operation_id,
+            train_worker_urls,
+            inference_worker_urls,
+        )
         resp = self._http.post(
             f"{self._gateway_url}/connect",
             json=payload,
@@ -227,13 +295,15 @@ class WeightUpdateController:
         pair_name = self._pair_name
         resp = self._http.post(
             f"{self._gateway_url}/disconnect",
-            json={"pair_name": pair_name},
+            json={
+                "pair_name": pair_name,
+                "operation_id": self._operation_id or "",
+                "timeout_s": timeout,
+            },
             timeout=self.config.request_timeout if timeout is None else timeout,
         )
         resp.raise_for_status()
-        self._pair_name = None
-        self._train_worker_urls = []
-        self._inference_worker_urls = []
+        self.mark_workers_cleaned()
         logger.info("Disconnected pair '%s'", pair_name)
 
     def _gateway_get(self, path: str) -> Any:
@@ -258,27 +328,63 @@ class WeightUpdateController:
             )
         return resp.json()
 
-    def destroy(self, *, raise_on_error: bool = False) -> None:
-        disconnect_error: Exception | None = None
-        if self._pair_name is not None:
-            try:
-                self.disconnect()
-            except Exception as e:
-                disconnect_error = e
-                logger.warning("Failed to disconnect during destroy", exc_info=True)
-
-        if disconnect_error is not None and raise_on_error:
-            raise disconnect_error
-
+    def terminate_private_gateway(
+        self, *, timeout: float = 5.0, raise_on_error: bool = True
+    ) -> None:
         if self._session is not None:
             self._session.close()
             self._session = None
 
-        if self._gateway_proc is not None:
+        error: Exception | None = None
+        proc = self._gateway_proc
+        if proc is not None:
             try:
-                kill_process_tree(self._gateway_proc.pid)
-            except Exception:
+                kill_process_tree(proc.pid, timeout=max(1, int(timeout)))
+                if proc.poll() is None:
+                    proc.wait(timeout=max(0.001, timeout))
+                if proc.poll() is None:
+                    raise RuntimeError("Gateway process is still running after kill")
+            except Exception as exc:
+                error = exc
                 logger.warning("Failed to kill gateway process", exc_info=True)
-            self._gateway_proc = None
-        self._gateway_url = ""
+            else:
+                self._gateway_proc = None
+                self._gateway_url = ""
+
+        if error is not None and raise_on_error:
+            raise error
+
+    def destroy(
+        self,
+        *,
+        raise_on_error: bool = False,
+        timeout: float | None = None,
+        disconnect: bool = True,
+    ) -> None:
+        deadline = None if timeout is None else time.monotonic() + max(0.001, timeout)
+
+        def _remaining() -> float:
+            assert deadline is not None
+            return max(0.001, deadline - time.monotonic())
+
+        disconnect_error: Exception | None = None
+        if disconnect and self._pair_name is not None:
+            try:
+                self.disconnect(timeout=None if deadline is None else _remaining())
+            except Exception as e:
+                disconnect_error = e
+                logger.warning("Failed to disconnect during destroy", exc_info=True)
+
+        if disconnect_error is not None:
+            # The private gateway is still the retry channel and owns the pair's
+            # registry/KV state. Preserve all controller state until disconnect
+            # has been confirmed.
+            if raise_on_error:
+                raise disconnect_error
+            return
+
+        self.terminate_private_gateway(
+            timeout=5.0 if deadline is None else _remaining(),
+            raise_on_error=raise_on_error,
+        )
         logger.info("WeightUpdateController destroyed")

--- a/areal/v2/weight_update/gateway/app.py
+++ b/areal/v2/weight_update/gateway/app.py
@@ -6,7 +6,9 @@ import os
 import socket
 import time
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from typing import Any
+from uuid import uuid4
 
 import aiohttp  # pyright: ignore[reportMissingImports]
 from fastapi import FastAPI, Request  # pyright: ignore[reportMissingImports]
@@ -30,6 +32,7 @@ logger = logging.getLogger("WeightUpdateGateway")
 
 class ConnectRequest(BaseModel):
     pair_name: str
+    operation_id: str = ""
     train_worker_urls: list[str]
     inference_worker_urls: list[str]
     nccl_master_addr: str = ""
@@ -51,6 +54,8 @@ class UpdateWeightsRequest(BaseModel):
 
 class DisconnectRequest(BaseModel):
     pair_name: str
+    operation_id: str = ""
+    timeout_s: float | None = None
 
 
 class KVPutBody(BaseModel):
@@ -91,6 +96,15 @@ class KVSetSizeResponse(BaseModel):
     size: int
 
 
+@dataclass
+class PairOperation:
+    generation: int = 0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    inflight_task: asyncio.Task | None = None
+    kind: str | None = None
+    deadline: float = 0.0
+
+
 @async_http_retry
 async def _get_json(session: aiohttp.ClientSession, url: str, timeout_s: float) -> Any:
     timeout = aiohttp.ClientTimeout(total=timeout_s)
@@ -119,6 +133,18 @@ async def _post(
     timeout_s: float,
     json_data: Any = None,
 ) -> None:
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    async with session.post(url, json=json_data, timeout=timeout) as resp:
+        resp.raise_for_status()
+
+
+async def _post_once(
+    session: aiohttp.ClientSession,
+    url: str,
+    timeout_s: float,
+    json_data: Any = None,
+) -> None:
+    """Send a non-retriable collective side-effect request."""
     timeout = aiohttp.ClientTimeout(total=timeout_s)
     async with session.post(url, json=json_data, timeout=timeout) as resp:
         resp.raise_for_status()
@@ -182,9 +208,11 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
 
     kv_store = WeightMetaStore()
     registry = PairRegistry()
+    operations: dict[str, PairOperation] = {}
 
     app.state.kv_store = kv_store
     app.state.registry = registry
+    app.state.operations = operations
     app.state.config = config
 
     def _auth(request: Request) -> None:
@@ -218,9 +246,82 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             ) from errors[0]
         return results
 
+    async def _require_current_operation(
+        pair_info: PairInfo,
+        operation: PairOperation,
+        generation: int,
+    ) -> None:
+        async with operation.lock:
+            if (
+                registry.get_by_name(pair_info.pair_name) is not pair_info
+                or operation.generation != generation
+                or pair_info.status == "cleanup_pending"
+            ):
+                raise RuntimeError(
+                    f"Pair {pair_info.pair_name!r} operation was cancelled"
+                )
+
+    def _operation_payload(pair_info: PairInfo, deadline: float) -> dict[str, Any]:
+        return {
+            "operation_id": pair_info.operation_id,
+            "operation_ttl_s": _remaining(deadline),
+        }
+
+    async def _load_worker_metadata(
+        session: aiohttp.ClientSession,
+        train_urls: list[str],
+        inference_urls: list[str],
+        deadline: float,
+    ) -> tuple[int, int, list[Any], list[Any]]:
+        train_par, infer_par = await _run_setup_stage(
+            asyncio.gather(
+                _get_json(
+                    session,
+                    f"{train_urls[0]}/awex/report_parallelism",
+                    _remaining(deadline),
+                ),
+                _get_json(
+                    session,
+                    f"{inference_urls[0]}/awex/report_parallelism",
+                    _remaining(deadline),
+                ),
+            ),
+            deadline,
+        )
+        responses = await _run_setup_stage(
+            asyncio.gather(
+                *[
+                    _post_json(
+                        session,
+                        f"{url}/awex/report_weight_meta",
+                        _remaining(deadline),
+                    )
+                    for url in train_urls + inference_urls
+                ]
+            ),
+            deadline,
+        )
+
+        def _flatten(items: list[Any]) -> list[Any]:
+            flattened = []
+            for item in items:
+                value = item.get("result", item.get("meta", item))
+                flattened.extend(value if isinstance(value, list) else [value])
+            return flattened
+
+        split = len(train_urls)
+        train_meta = _merge_training_meta_by_name(_flatten(responses[:split]))
+        return (
+            train_par["world_size"],
+            infer_par["world_size"],
+            train_meta,
+            _flatten(responses[split:]),
+        )
+
     async def _teardown_awex_workers(
         session: aiohttp.ClientSession,
         pair_name: str,
+        operation_id: str,
         train_urls: list[str],
         inference_urls: list[str],
         timeout_s: float,
@@ -231,11 +332,15 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         results = await asyncio.gather(
             *[
                 asyncio.wait_for(
-                    _post(
+                    _post_once(
                         session,
                         f"{url}/awex/teardown",
                         timeout_s,
-                        json_data={"pair_name": pair_name},
+                        json_data={
+                            "pair_name": pair_name,
+                            "operation_id": operation_id,
+                            "rpc_timeout_s": timeout_s,
+                        },
                     ),
                     timeout=timeout_s,
                 )
@@ -248,29 +353,24 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
     async def _rollback_connect(
         session: aiohttp.ClientSession,
         pair_name: str,
+        operation_id: str,
         train_urls: list[str],
         inference_urls: list[str],
         timeout_s: float,
     ) -> None:
-        deadline = time.monotonic() + timeout_s
-        errors: list[BaseException] = []
-        for attempt in range(3):
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-            errors = await _teardown_awex_workers(
-                session,
-                pair_name,
-                train_urls,
-                inference_urls,
-                min(5.0, remaining),
-            )
-            if not errors:
-                registry.unregister(pair_name)
-                kv_store.clear_pair(pair_name)
-                return
-            if attempt < 2:
-                await asyncio.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
+        errors = await _teardown_awex_workers(
+            session,
+            pair_name,
+            operation_id,
+            train_urls,
+            inference_urls,
+            timeout_s,
+        )
+        if not errors:
+            registry.unregister(pair_name)
+            kv_store.clear_pair(pair_name)
+            operations.pop(pair_name, None)
+            return
 
         pair_info = registry.get_by_name(pair_name)
         if pair_info is not None:
@@ -369,10 +469,12 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             )
         deadline = time.monotonic() + setup_timeout_s
         session = request.app.state.http_session
+        operation_id = body.operation_id or uuid4().hex
         pair_info = PairInfo(
             pair_name=pair_name,
             train_worker_urls=train_urls,
             inference_worker_urls=inference_urls,
+            operation_id=operation_id,
             mode="awex",
             colocate=body.colocate,
             master_addr=body.nccl_master_addr,
@@ -380,79 +482,78 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             status="connecting",
         )
         registry.register(pair_info)
-        try:
-            if body.colocate:
-                return await _connect_colocate(
+        operation = PairOperation(deadline=deadline, kind="connect")
+        operations[pair_name] = operation
+        generation = operation.generation
+
+        async def _run_connect() -> ConnectResponse:
+            try:
+                if body.colocate:
+                    return await _connect_colocate(
+                        request,
+                        pair_info,
+                        operation,
+                        generation,
+                        deadline,
+                    )
+                return await _connect_awex(
                     request,
-                    pair_name,
-                    train_urls,
-                    inference_urls,
+                    body,
+                    pair_info,
+                    operation,
+                    generation,
                     deadline,
                 )
-            return await _connect_awex(
-                request,
-                body,
-                train_urls,
-                inference_urls,
-                deadline,
-            )
-        except BaseException:
-            rollback_task = asyncio.create_task(
-                _rollback_connect(
-                    session,
-                    pair_name,
-                    train_urls,
-                    inference_urls,
-                    body.rollback_timeout_s,
-                )
-            )
-            try:
-                await asyncio.shield(rollback_task)
-            except asyncio.CancelledError:
+            except BaseException:
+                async with operation.lock:
+                    if registry.get_by_name(pair_name) is pair_info:
+                        pair_info.status = "cleanup_pending"
                 try:
-                    await rollback_task
+                    await _rollback_connect(
+                        session,
+                        pair_name,
+                        operation_id,
+                        train_urls,
+                        inference_urls,
+                        body.rollback_timeout_s,
+                    )
                 except Exception:
                     logger.exception(
-                        "Rollback for pair %r failed while handling cancellation; "
-                        "preserving the original connect error",
+                        "Rollback for pair %r raised unexpectedly; preserving "
+                        "the original connect error",
                         pair_name,
                     )
-            except Exception:
-                logger.exception(
-                    "Rollback for pair %r raised unexpectedly; preserving the "
-                    "original connect error",
-                    pair_name,
-                )
-            raise
+                raise
+            finally:
+                current = asyncio.current_task()
+                async with operation.lock:
+                    if operation.inflight_task is current:
+                        operation.inflight_task = None
+                        operation.kind = None
+
+        task = asyncio.create_task(_run_connect())
+        operation.inflight_task = task
+        return await asyncio.shield(task)
 
     async def _connect_awex(
         request: Request,
         body: ConnectRequest,
-        train_urls: list[str],
-        inference_urls: list[str],
+        pair_info: PairInfo,
+        operation: PairOperation,
+        generation: int,
         deadline: float,
     ) -> ConnectResponse:
-        pair_name = body.pair_name
+        pair_name = pair_info.pair_name
+        train_urls = pair_info.train_worker_urls
+        inference_urls = pair_info.inference_worker_urls
         session = request.app.state.http_session
 
-        train_par, infer_par = await _run_setup_stage(
-            asyncio.gather(
-                _get_json(
-                    session,
-                    f"{train_urls[0]}/awex/report_parallelism",
-                    _remaining(deadline),
-                ),
-                _get_json(
-                    session,
-                    f"{inference_urls[0]}/awex/report_parallelism",
-                    _remaining(deadline),
-                ),
-            ),
-            deadline,
-        )
-
-        train_world_size = train_par["world_size"]
-        infer_world_size = infer_par["world_size"]
+        (
+            train_world_size,
+            infer_world_size,
+            training_params_meta,
+            infer_params_meta,
+        ) = await _load_worker_metadata(session, train_urls, inference_urls, deadline)
         # Each inference URL is a separate DP replica.  The adapter
         # reports per-instance parallelism (e.g. TP size) but does not
         # know how many replicas exist, so we derive num_engines from the
@@ -461,49 +562,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         total_infer_ranks = infer_world_size * num_engines
         total_world_size = total_infer_ranks + train_world_size
 
-        train_meta_resps, infer_meta_resps = await _run_setup_stage(
-            asyncio.gather(
-                asyncio.gather(
-                    *[
-                        _post_json(
-                            session,
-                            f"{url}/awex/report_weight_meta",
-                            _remaining(deadline),
-                        )
-                        for url in train_urls
-                    ]
-                ),
-                asyncio.gather(
-                    *[
-                        _post_json(
-                            session,
-                            f"{url}/awex/report_weight_meta",
-                            _remaining(deadline),
-                        )
-                        for url in inference_urls
-                    ]
-                ),
-            ),
-            deadline,
-        )
-
-        training_params_meta = []
-        for result in train_meta_resps:
-            meta = result.get("result", result.get("meta", result))
-            if isinstance(meta, list):
-                training_params_meta.extend(meta)
-            else:
-                training_params_meta.append(meta)
-        training_params_meta = _merge_training_meta_by_name(training_params_meta)
-
-        infer_params_meta = []
-        for result in infer_meta_resps:
-            meta = result.get("result", result.get("meta", result))
-            if isinstance(meta, list):
-                infer_params_meta.extend(meta)
-            else:
-                infer_params_meta.append(meta)
-
+        await _require_current_operation(pair_info, operation, generation)
         kv_store.put(pair_name, "training_params_meta", training_params_meta)
         kv_store.put(pair_name, "infer_params_meta", infer_params_meta)
 
@@ -528,14 +587,16 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         }
 
         init_tasks = []
+        await _require_current_operation(pair_info, operation, generation)
         for i, url in enumerate(inference_urls):
             init_tasks.append(
-                _post(
+                _post_once(
                     session,
                     f"{url}/awex/init_weights_update_group",
                     _remaining(deadline),
                     json_data={
                         **init_payload_base,
+                        **_operation_payload(pair_info, deadline),
                         "transfer_rank": i,
                         "process_group_timeout_s": _process_group_timeout(deadline),
                     },
@@ -543,12 +604,13 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             )
         for i, url in enumerate(train_urls):
             init_tasks.append(
-                _post(
+                _post_once(
                     session,
                     f"{url}/awex/init_weights_update_group",
                     _remaining(deadline),
                     json_data={
                         **init_payload_base,
+                        **_operation_payload(pair_info, deadline),
                         "transfer_rank": total_infer_ranks + i,
                         "process_group_timeout_s": _process_group_timeout(deadline),
                     },
@@ -556,106 +618,62 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             )
         await _run_worker_stage(init_tasks, deadline)
 
+        await _require_current_operation(pair_info, operation, generation)
         liveness_tasks = [
-            _post(
+            _post_once(
                 session,
                 f"{url}/awex/batch_isend_irecv",
                 _remaining(deadline),
                 json_data={
                     "pair_name": pair_name,
                     "world_size": total_world_size,
+                    **_operation_payload(pair_info, deadline),
                 },
             )
             for url in inference_urls + train_urls
         ]
         await _run_worker_stage(liveness_tasks, deadline)
 
-        pair_info = registry.get_by_name(pair_name)
-        if pair_info is None:
-            raise RuntimeError(f"Pair {pair_name!r} lost gateway bookkeeping")
-        pair_info.train_world_size = train_world_size
-        pair_info.inference_world_size = infer_world_size
-        pair_info.master_addr = master_addr
-        pair_info.master_port = master_port
-        pair_info.status = "active"
+        async with operation.lock:
+            if (
+                registry.get_by_name(pair_name) is not pair_info
+                or operation.generation != generation
+                or pair_info.status != "connecting"
+            ):
+                raise RuntimeError(f"Pair {pair_name!r} connect was cancelled")
+            pair_info.train_world_size = train_world_size
+            pair_info.inference_world_size = infer_world_size
+            pair_info.master_addr = master_addr
+            pair_info.master_port = master_port
+            pair_info.status = "active"
 
         logger.info("Connected pair '%s'", pair_name)
         return ConnectResponse(pair_name=pair_name)
 
     async def _connect_colocate(
         request: Request,
-        pair_name: str,
-        train_urls: list[str],
-        inference_urls: list[str],
+        pair_info: PairInfo,
+        operation: PairOperation,
+        generation: int,
         deadline: float,
     ) -> ConnectResponse:
+        pair_name = pair_info.pair_name
+        train_urls = pair_info.train_worker_urls
+        inference_urls = pair_info.inference_worker_urls
         session = request.app.state.http_session
 
-        train_par, infer_par = await _run_setup_stage(
-            asyncio.gather(
-                _get_json(
-                    session,
-                    f"{train_urls[0]}/awex/report_parallelism",
-                    _remaining(deadline),
-                ),
-                _get_json(
-                    session,
-                    f"{inference_urls[0]}/awex/report_parallelism",
-                    _remaining(deadline),
-                ),
-            ),
-            deadline,
-        )
-
-        train_world_size = train_par["world_size"]
+        (
+            train_world_size,
+            infer_instance_world_size,
+            training_params_meta,
+            infer_params_meta,
+        ) = await _load_worker_metadata(session, train_urls, inference_urls, deadline)
         num_engines = len(inference_urls)
         # report_parallelism returns per-instance world_size (e.g. TP size).
         # The total inference world for colocate NCCL groups spans all engines.
-        infer_world_size = infer_par["world_size"] * num_engines
+        infer_world_size = infer_instance_world_size * num_engines
 
-        train_meta_resps, infer_meta_resps = await _run_setup_stage(
-            asyncio.gather(
-                asyncio.gather(
-                    *[
-                        _post_json(
-                            session,
-                            f"{url}/awex/report_weight_meta",
-                            _remaining(deadline),
-                        )
-                        for url in train_urls
-                    ]
-                ),
-                asyncio.gather(
-                    *[
-                        _post_json(
-                            session,
-                            f"{url}/awex/report_weight_meta",
-                            _remaining(deadline),
-                        )
-                        for url in inference_urls
-                    ]
-                ),
-            ),
-            deadline,
-        )
-
-        training_params_meta = []
-        for result in train_meta_resps:
-            meta = result.get("result", result.get("meta", result))
-            if isinstance(meta, list):
-                training_params_meta.extend(meta)
-            else:
-                training_params_meta.append(meta)
-        training_params_meta = _merge_training_meta_by_name(training_params_meta)
-
-        infer_params_meta = []
-        for result in infer_meta_resps:
-            meta = result.get("result", result.get("meta", result))
-            if isinstance(meta, list):
-                infer_params_meta.extend(meta)
-            else:
-                infer_params_meta.append(meta)
-
+        await _require_current_operation(pair_info, operation, generation)
         kv_store.put(pair_name, "training_params_meta", training_params_meta)
         kv_store.put(pair_name, "infer_params_meta", infer_params_meta)
 
@@ -678,14 +696,16 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         }
 
         init_tasks = []
+        await _require_current_operation(pair_info, operation, generation)
         for i, url in enumerate(inference_urls):
             init_tasks.append(
-                _post(
+                _post_once(
                     session,
                     f"{url}/awex/init_colocate_weight_update",
                     _remaining(deadline),
                     json_data={
                         **init_payload_base,
+                        **_operation_payload(pair_info, deadline),
                         "transfer_rank": i,
                         "process_group_timeout_s": _process_group_timeout(deadline),
                     },
@@ -693,12 +713,13 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             )
         for i, url in enumerate(train_urls):
             init_tasks.append(
-                _post(
+                _post_once(
                     session,
                     f"{url}/awex/init_colocate_weight_update",
                     _remaining(deadline),
                     json_data={
                         **init_payload_base,
+                        **_operation_payload(pair_info, deadline),
                         "transfer_rank": infer_world_size + i,
                         "process_group_timeout_s": _process_group_timeout(deadline),
                     },
@@ -706,13 +727,17 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             )
         await _run_worker_stage(init_tasks, deadline)
 
-        pair_info = registry.get_by_name(pair_name)
-        if pair_info is None:
-            raise RuntimeError(f"Pair {pair_name!r} lost gateway bookkeeping")
-        pair_info.train_world_size = train_world_size
-        pair_info.inference_world_size = infer_world_size
-        pair_info.colocate = True
-        pair_info.status = "active"
+        async with operation.lock:
+            if (
+                registry.get_by_name(pair_name) is not pair_info
+                or operation.generation != generation
+                or pair_info.status != "connecting"
+            ):
+                raise RuntimeError(f"Pair {pair_name!r} connect was cancelled")
+            pair_info.train_world_size = train_world_size
+            pair_info.inference_world_size = infer_world_size
+            pair_info.colocate = True
+            pair_info.status = "active"
 
         logger.info("Connected colocate pair '%s'", pair_name)
         return ConnectResponse(pair_name=pair_name)
@@ -721,81 +746,100 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         pair_info: PairInfo,
         version: int,
         session: aiohttp.ClientSession,
-        timeout_s: float,
+        deadline: float,
     ) -> None:
-        await asyncio.gather(
-            *[
-                _post(
+        await _run_worker_stage(
+            [
+                _post_once(
                     session,
                     f"{url}/awex/release_memory",
-                    timeout_s,
-                    json_data={"tags": ["optimizer"]},
-                )
-                for url in pair_info.train_worker_urls
-            ]
-        )
-
-        await asyncio.gather(
-            *[
-                _post(
-                    session,
-                    f"{url}/awex/resume_memory",
-                    timeout_s,
-                    json_data={"tags": ["weights"]},
-                )
-                for url in pair_info.inference_worker_urls
-            ]
-        )
-
-        await asyncio.gather(
-            *[
-                _post(
-                    session,
-                    f"{url}/awex/execute_colocate_weight_update",
-                    timeout_s,
+                    _remaining(deadline),
                     json_data={
-                        "pair_name": pair_info.pair_name,
-                        "version": version,
+                        "tags": ["optimizer"],
+                        "rpc_timeout_s": _remaining(deadline),
                     },
                 )
                 for url in pair_info.train_worker_urls
             ],
-            *[
-                _post(
+            deadline,
+        )
+
+        await _run_worker_stage(
+            [
+                _post_once(
                     session,
-                    f"{url}/awex/execute_colocate_weight_update",
-                    timeout_s,
+                    f"{url}/awex/resume_memory",
+                    _remaining(deadline),
                     json_data={
-                        "pair_name": pair_info.pair_name,
-                        "version": version,
+                        "tags": ["weights"],
+                        "rpc_timeout_s": _remaining(deadline),
                     },
                 )
                 for url in pair_info.inference_worker_urls
             ],
+            deadline,
         )
 
-        await asyncio.gather(
-            *[
-                _post(
+        await _run_worker_stage(
+            [
+                _post_once(
                     session,
-                    f"{url}/awex/release_memory",
-                    timeout_s,
-                    json_data={"tags": ["weights"]},
+                    f"{url}/awex/execute_colocate_weight_update",
+                    _remaining(deadline),
+                    json_data={
+                        "pair_name": pair_info.pair_name,
+                        "version": version,
+                        "rpc_timeout_s": _remaining(deadline),
+                    },
                 )
                 for url in pair_info.train_worker_urls
             ]
-        )
-
-        await asyncio.gather(
-            *[
-                _post(
+            + [
+                _post_once(
                     session,
-                    f"{url}/awex/resume_memory",
-                    timeout_s,
-                    json_data={"tags": ["kv_cache"]},
+                    f"{url}/awex/execute_colocate_weight_update",
+                    _remaining(deadline),
+                    json_data={
+                        "pair_name": pair_info.pair_name,
+                        "version": version,
+                        "rpc_timeout_s": _remaining(deadline),
+                    },
                 )
                 for url in pair_info.inference_worker_urls
-            ]
+            ],
+            deadline,
+        )
+
+        await _run_worker_stage(
+            [
+                _post_once(
+                    session,
+                    f"{url}/awex/release_memory",
+                    _remaining(deadline),
+                    json_data={
+                        "tags": ["weights"],
+                        "rpc_timeout_s": _remaining(deadline),
+                    },
+                )
+                for url in pair_info.train_worker_urls
+            ],
+            deadline,
+        )
+
+        await _run_worker_stage(
+            [
+                _post_once(
+                    session,
+                    f"{url}/awex/resume_memory",
+                    _remaining(deadline),
+                    json_data={
+                        "tags": ["kv_cache"],
+                        "rpc_timeout_s": _remaining(deadline),
+                    },
+                )
+                for url in pair_info.inference_worker_urls
+            ],
+            deadline,
         )
 
         # Flush colocate KV keys for this version to prevent accumulation
@@ -812,21 +856,23 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         pair_info: PairInfo,
         version: int,
         session: aiohttp.ClientSession,
-        timeout_s: float,
+        deadline: float,
     ) -> None:
-        await asyncio.gather(
-            *[
-                _post(
+        await _run_worker_stage(
+            [
+                _post_once(
                     session,
                     f"{url}/awex/update_weights",
-                    timeout_s,
+                    _remaining(deadline),
                     json_data={
                         "pair_name": pair_info.pair_name,
                         "version": version,
+                        "rpc_timeout_s": _remaining(deadline),
                     },
                 )
                 for url in pair_info.train_worker_urls + pair_info.inference_worker_urls
-            ]
+            ],
+            deadline,
         )
 
     async def _disk_transfer_weights(
@@ -938,52 +984,106 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
 
         session = request.app.state.http_session
         timeout_s = config.update_timeout_s
-        start = time.monotonic()
-
-        try:
-            if pair_info.colocate:
-                await _colocate_transfer_weights(
-                    pair_info, body.version, session, timeout_s
-                )
-            elif pair_info.mode == "disk":
+        if pair_info.mode == "disk":
+            start = time.monotonic()
+            try:
                 await _disk_transfer_weights(
                     pair_info, body.version, session, timeout_s
                 )
-            else:
-                await _awex_transfer_weights(
-                    pair_info, body.version, session, timeout_s
+            except Exception as e:
+                return WeightUpdateResult(
+                    status="error",
+                    version=body.version,
+                    duration_ms=(time.monotonic() - start) * 1000,
+                    error=str(e),
                 )
-        except Exception as e:
-            duration_ms = (time.monotonic() - start) * 1000
-            logger.error(
-                "Weight update failed for pair '%s': %s",
-                pair_info.pair_name,
-                e,
-            )
+            pair_info.last_version = body.version
             return WeightUpdateResult(
-                status="error",
+                status="ok",
                 version=body.version,
-                duration_ms=duration_ms,
-                error=str(e),
-                # Transfers are not transactional: a failure reported after the
-                # gateway starts dispatching may follow writes on one or more
-                # inference ranks.  Make callers recover rather than serve a
-                # mixed model.  Pre-dispatch failures can opt into ``False`` in
-                # a future typed preflight path.
-                inference_weights_may_be_mutated=True,
+                duration_ms=(time.monotonic() - start) * 1000,
             )
 
-        duration_ms = (time.monotonic() - start) * 1000
-        pair_info.last_version = body.version
-        logger.info(
-            "Weight update completed for pair '%s' v%d (%.1fms)",
-            pair_info.pair_name,
-            body.version,
-            duration_ms,
-        )
-        return WeightUpdateResult(
-            status="ok", version=body.version, duration_ms=duration_ms
-        )
+        operation = operations.get(body.pair_name)
+        if operation is None:
+            return JSONResponse(
+                status_code=500,
+                content={"error": f"Pair '{body.pair_name}' has no operation record"},
+            )
+        async with operation.lock:
+            if pair_info.status != "active":
+                return JSONResponse(
+                    status_code=409,
+                    content={"error": f"Pair '{body.pair_name}' is not active"},
+                )
+            if operation.inflight_task is not None:
+                return JSONResponse(
+                    status_code=409,
+                    content={"error": f"Pair '{body.pair_name}' is busy"},
+                )
+            generation = operation.generation
+            operation.kind = "update"
+            operation.deadline = time.monotonic() + timeout_s
+
+            async def _run_update() -> WeightUpdateResult:
+                start = time.monotonic()
+                try:
+                    await _require_current_operation(pair_info, operation, generation)
+                    if pair_info.colocate:
+                        await _colocate_transfer_weights(
+                            pair_info, body.version, session, operation.deadline
+                        )
+                    else:
+                        await _awex_transfer_weights(
+                            pair_info, body.version, session, operation.deadline
+                        )
+                    async with operation.lock:
+                        if (
+                            registry.get_by_name(body.pair_name) is not pair_info
+                            or operation.generation != generation
+                            or pair_info.status != "active"
+                        ):
+                            raise RuntimeError(
+                                f"Pair {body.pair_name!r} cleanup started during "
+                                "weight update"
+                            )
+                        pair_info.last_version = body.version
+                except BaseException as e:
+                    duration_ms = (time.monotonic() - start) * 1000
+                    logger.error(
+                        "Weight update failed for pair '%s': %s",
+                        pair_info.pair_name,
+                        e,
+                    )
+                    return WeightUpdateResult(
+                        status="error",
+                        version=body.version,
+                        duration_ms=duration_ms,
+                        error=str(e),
+                        inference_weights_may_be_mutated=True,
+                    )
+                finally:
+                    current = asyncio.current_task()
+                    async with operation.lock:
+                        if operation.inflight_task is current:
+                            operation.inflight_task = None
+                            operation.kind = None
+
+                duration_ms = (time.monotonic() - start) * 1000
+                logger.info(
+                    "Weight update completed for pair '%s' v%d (%.1fms)",
+                    pair_info.pair_name,
+                    body.version,
+                    duration_ms,
+                )
+                return WeightUpdateResult(
+                    status="ok", version=body.version, duration_ms=duration_ms
+                )
+
+            task = asyncio.create_task(_run_update())
+            operation.inflight_task = task
+
+        return await asyncio.shield(task)
 
     @app.post("/disconnect")
     async def disconnect(
@@ -996,12 +1096,59 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             return DisconnectResponse(pair_name=body.pair_name)
 
         if pair_info.mode == "awex":
+            if body.operation_id and body.operation_id != pair_info.operation_id:
+                return JSONResponse(
+                    status_code=409,
+                    content={"error": "operation_id does not own this pair"},
+                )
+            operation = operations.get(pair_info.pair_name)
+            if operation is None:
+                return JSONResponse(
+                    status_code=500,
+                    content={"error": "AWEX pair has no operation record"},
+                )
+            deadline = time.monotonic() + (
+                config.init_timeout_s
+                if body.timeout_s is None
+                else max(0.001, body.timeout_s)
+            )
+            async with operation.lock:
+                pair_info.status = "cleanup_pending"
+                operation.generation += 1
+                inflight = operation.inflight_task
+
+            if inflight is not None and inflight is not asyncio.current_task():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(inflight), timeout=_remaining(deadline)
+                    )
+                except TimeoutError:
+                    return JSONResponse(
+                        status_code=409,
+                        content={
+                            "error": (
+                                f"Pair {pair_info.pair_name!r} operation did not "
+                                "quiesce before the cleanup deadline"
+                            )
+                        },
+                    )
+                except asyncio.CancelledError:
+                    # Keep ownership and do not race worker teardown against an
+                    # operation that shield() deliberately left running.
+                    raise
+                except Exception:
+                    # The operation has stopped; teardown below owns rollback.
+                    pass
+
+            if registry.get_by_name(pair_info.pair_name) is None:
+                return DisconnectResponse(pair_name=pair_info.pair_name)
             errors = await _teardown_awex_workers(
                 request.app.state.http_session,
                 pair_info.pair_name,
+                pair_info.operation_id,
                 pair_info.train_worker_urls,
                 pair_info.inference_worker_urls,
-                config.init_timeout_s,
+                _remaining(deadline),
             )
             if errors:
                 pair_info.status = "cleanup_pending"
@@ -1016,6 +1163,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 )
         registry.unregister(pair_info.pair_name)
         kv_store.clear_pair(pair_info.pair_name)
+        operations.pop(pair_info.pair_name, None)
 
         return DisconnectResponse(pair_name=pair_info.pair_name)
 

--- a/areal/v2/weight_update/gateway/app.py
+++ b/areal/v2/weight_update/gateway/app.py
@@ -40,6 +40,8 @@ class ConnectRequest(BaseModel):
     lora_name: str = ""
     lora_keep_versions: int = 0
     colocate: bool = False
+    setup_timeout_s: float | None = None
+    rollback_timeout_s: float = 30.0
 
 
 class UpdateWeightsRequest(BaseModel):
@@ -188,6 +190,99 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
     def _auth(request: Request) -> None:
         require_admin_key(request, config.admin_api_key)
 
+    def _remaining(deadline: float) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Weight-update setup deadline exceeded")
+        return remaining
+
+    def _process_group_timeout(deadline: float) -> float:
+        remaining = _remaining(deadline)
+        response_margin = min(1.0, max(0.1, remaining * 0.1))
+        timeout_s = remaining - response_margin
+        if timeout_s <= 0:
+            raise TimeoutError("No setup time remains for process-group initialization")
+        return timeout_s
+
+    async def _run_setup_stage(awaitable, deadline: float):
+        return await asyncio.wait_for(awaitable, timeout=_remaining(deadline))
+
+    async def _run_worker_stage(awaitables, deadline: float) -> list[Any]:
+        results = await _run_setup_stage(
+            asyncio.gather(*awaitables, return_exceptions=True), deadline
+        )
+        errors = [result for result in results if isinstance(result, BaseException)]
+        if errors:
+            raise RuntimeError(
+                f"Weight-update setup failed on {len(errors)} worker(s)"
+            ) from errors[0]
+        return results
+
+    async def _teardown_awex_workers(
+        session: aiohttp.ClientSession,
+        pair_name: str,
+        train_urls: list[str],
+        inference_urls: list[str],
+        timeout_s: float,
+    ) -> list[BaseException]:
+        urls = inference_urls + train_urls
+        if not urls:
+            return []
+        results = await asyncio.gather(
+            *[
+                asyncio.wait_for(
+                    _post(
+                        session,
+                        f"{url}/awex/teardown",
+                        timeout_s,
+                        json_data={"pair_name": pair_name},
+                    ),
+                    timeout=timeout_s,
+                )
+                for url in urls
+            ],
+            return_exceptions=True,
+        )
+        return [result for result in results if isinstance(result, BaseException)]
+
+    async def _rollback_connect(
+        session: aiohttp.ClientSession,
+        pair_name: str,
+        train_urls: list[str],
+        inference_urls: list[str],
+        timeout_s: float,
+    ) -> None:
+        deadline = time.monotonic() + timeout_s
+        errors: list[BaseException] = []
+        for attempt in range(3):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            errors = await _teardown_awex_workers(
+                session,
+                pair_name,
+                train_urls,
+                inference_urls,
+                min(5.0, remaining),
+            )
+            if not errors:
+                registry.unregister(pair_name)
+                kv_store.clear_pair(pair_name)
+                return
+            if attempt < 2:
+                await asyncio.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
+
+        pair_info = registry.get_by_name(pair_name)
+        if pair_info is not None:
+            pair_info.status = "cleanup_pending"
+        logger.error(
+            "Rollback for pair '%s' did not complete (%d worker teardown "
+            "error(s)); retaining registry/KV state for a later disconnect: %s",
+            pair_name,
+            len(errors),
+            errors,
+        )
+
     @app.get("/health")
     async def health() -> HealthResponse:
         return HealthResponse()
@@ -199,9 +294,10 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         train_urls = body.train_worker_urls
         inference_urls = body.inference_worker_urls
 
-        if body.colocate:
-            return await _connect_colocate(
-                request, pair_name, train_urls, inference_urls
+        if registry.get_by_name(pair_name) is not None:
+            return JSONResponse(
+                status_code=409,
+                content={"error": f"Pair '{pair_name}' already registered"},
             )
 
         if body.mode == "disk":
@@ -259,20 +355,100 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 },
             )
 
+        setup_timeout_s = (
+            config.init_timeout_s
+            if body.setup_timeout_s is None
+            else body.setup_timeout_s
+        )
+        if setup_timeout_s <= 0 or body.rollback_timeout_s <= 0:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": "setup_timeout_s and rollback_timeout_s must be positive"
+                },
+            )
+        deadline = time.monotonic() + setup_timeout_s
         session = request.app.state.http_session
-        init_timeout_s = config.init_timeout_s
+        pair_info = PairInfo(
+            pair_name=pair_name,
+            train_worker_urls=train_urls,
+            inference_worker_urls=inference_urls,
+            mode="awex",
+            colocate=body.colocate,
+            master_addr=body.nccl_master_addr,
+            master_port=body.nccl_master_port,
+            status="connecting",
+        )
+        registry.register(pair_info)
+        try:
+            if body.colocate:
+                return await _connect_colocate(
+                    request,
+                    pair_name,
+                    train_urls,
+                    inference_urls,
+                    deadline,
+                )
+            return await _connect_awex(
+                request,
+                body,
+                train_urls,
+                inference_urls,
+                deadline,
+            )
+        except BaseException:
+            rollback_task = asyncio.create_task(
+                _rollback_connect(
+                    session,
+                    pair_name,
+                    train_urls,
+                    inference_urls,
+                    body.rollback_timeout_s,
+                )
+            )
+            try:
+                await asyncio.shield(rollback_task)
+            except asyncio.CancelledError:
+                try:
+                    await rollback_task
+                except Exception:
+                    logger.exception(
+                        "Rollback for pair %r failed while handling cancellation; "
+                        "preserving the original connect error",
+                        pair_name,
+                    )
+            except Exception:
+                logger.exception(
+                    "Rollback for pair %r raised unexpectedly; preserving the "
+                    "original connect error",
+                    pair_name,
+                )
+            raise
 
-        train_par, infer_par = await asyncio.gather(
-            _get_json(
-                session,
-                f"{train_urls[0]}/awex/report_parallelism",
-                init_timeout_s,
+    async def _connect_awex(
+        request: Request,
+        body: ConnectRequest,
+        train_urls: list[str],
+        inference_urls: list[str],
+        deadline: float,
+    ) -> ConnectResponse:
+        pair_name = body.pair_name
+        session = request.app.state.http_session
+
+        train_par, infer_par = await _run_setup_stage(
+            asyncio.gather(
+                _get_json(
+                    session,
+                    f"{train_urls[0]}/awex/report_parallelism",
+                    _remaining(deadline),
+                ),
+                _get_json(
+                    session,
+                    f"{inference_urls[0]}/awex/report_parallelism",
+                    _remaining(deadline),
+                ),
             ),
-            _get_json(
-                session,
-                f"{inference_urls[0]}/awex/report_parallelism",
-                init_timeout_s,
-            ),
+            deadline,
         )
 
         train_world_size = train_par["world_size"]
@@ -285,23 +461,30 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         total_infer_ranks = infer_world_size * num_engines
         total_world_size = total_infer_ranks + train_world_size
 
-        train_meta_resps, infer_meta_resps = await asyncio.gather(
+        train_meta_resps, infer_meta_resps = await _run_setup_stage(
             asyncio.gather(
-                *[
-                    _post_json(
-                        session, f"{url}/awex/report_weight_meta", init_timeout_s
-                    )
-                    for url in train_urls
-                ]
+                asyncio.gather(
+                    *[
+                        _post_json(
+                            session,
+                            f"{url}/awex/report_weight_meta",
+                            _remaining(deadline),
+                        )
+                        for url in train_urls
+                    ]
+                ),
+                asyncio.gather(
+                    *[
+                        _post_json(
+                            session,
+                            f"{url}/awex/report_weight_meta",
+                            _remaining(deadline),
+                        )
+                        for url in inference_urls
+                    ]
+                ),
             ),
-            asyncio.gather(
-                *[
-                    _post_json(
-                        session, f"{url}/awex/report_weight_meta", init_timeout_s
-                    )
-                    for url in inference_urls
-                ]
-            ),
+            deadline,
         )
 
         training_params_meta = []
@@ -350,8 +533,12 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 _post(
                     session,
                     f"{url}/awex/init_weights_update_group",
-                    init_timeout_s,
-                    json_data={**init_payload_base, "transfer_rank": i},
+                    _remaining(deadline),
+                    json_data={
+                        **init_payload_base,
+                        "transfer_rank": i,
+                        "process_group_timeout_s": _process_group_timeout(deadline),
+                    },
                 )
             )
         for i, url in enumerate(train_urls):
@@ -359,36 +546,38 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 _post(
                     session,
                     f"{url}/awex/init_weights_update_group",
-                    init_timeout_s,
+                    _remaining(deadline),
                     json_data={
                         **init_payload_base,
                         "transfer_rank": total_infer_ranks + i,
+                        "process_group_timeout_s": _process_group_timeout(deadline),
                     },
                 )
             )
-        await asyncio.gather(*init_tasks)
+        await _run_worker_stage(init_tasks, deadline)
 
         liveness_tasks = [
             _post(
                 session,
                 f"{url}/awex/batch_isend_irecv",
-                init_timeout_s,
-                json_data={"world_size": total_world_size},
+                _remaining(deadline),
+                json_data={
+                    "pair_name": pair_name,
+                    "world_size": total_world_size,
+                },
             )
             for url in inference_urls + train_urls
         ]
-        await asyncio.gather(*liveness_tasks)
+        await _run_worker_stage(liveness_tasks, deadline)
 
-        pair_info = PairInfo(
-            pair_name=pair_name,
-            train_worker_urls=train_urls,
-            inference_worker_urls=inference_urls,
-            train_world_size=train_world_size,
-            inference_world_size=infer_world_size,
-            master_addr=master_addr,
-            master_port=master_port,
-        )
-        registry.register(pair_info)
+        pair_info = registry.get_by_name(pair_name)
+        if pair_info is None:
+            raise RuntimeError(f"Pair {pair_name!r} lost gateway bookkeeping")
+        pair_info.train_world_size = train_world_size
+        pair_info.inference_world_size = infer_world_size
+        pair_info.master_addr = master_addr
+        pair_info.master_port = master_port
+        pair_info.status = "active"
 
         logger.info("Connected pair '%s'", pair_name)
         return ConnectResponse(pair_name=pair_name)
@@ -398,21 +587,24 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         pair_name: str,
         train_urls: list[str],
         inference_urls: list[str],
+        deadline: float,
     ) -> ConnectResponse:
         session = request.app.state.http_session
-        init_timeout_s = config.init_timeout_s
 
-        train_par, infer_par = await asyncio.gather(
-            _get_json(
-                session,
-                f"{train_urls[0]}/awex/report_parallelism",
-                init_timeout_s,
+        train_par, infer_par = await _run_setup_stage(
+            asyncio.gather(
+                _get_json(
+                    session,
+                    f"{train_urls[0]}/awex/report_parallelism",
+                    _remaining(deadline),
+                ),
+                _get_json(
+                    session,
+                    f"{inference_urls[0]}/awex/report_parallelism",
+                    _remaining(deadline),
+                ),
             ),
-            _get_json(
-                session,
-                f"{inference_urls[0]}/awex/report_parallelism",
-                init_timeout_s,
-            ),
+            deadline,
         )
 
         train_world_size = train_par["world_size"]
@@ -421,23 +613,30 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         # The total inference world for colocate NCCL groups spans all engines.
         infer_world_size = infer_par["world_size"] * num_engines
 
-        train_meta_resps, infer_meta_resps = await asyncio.gather(
+        train_meta_resps, infer_meta_resps = await _run_setup_stage(
             asyncio.gather(
-                *[
-                    _post_json(
-                        session, f"{url}/awex/report_weight_meta", init_timeout_s
-                    )
-                    for url in train_urls
-                ]
+                asyncio.gather(
+                    *[
+                        _post_json(
+                            session,
+                            f"{url}/awex/report_weight_meta",
+                            _remaining(deadline),
+                        )
+                        for url in train_urls
+                    ]
+                ),
+                asyncio.gather(
+                    *[
+                        _post_json(
+                            session,
+                            f"{url}/awex/report_weight_meta",
+                            _remaining(deadline),
+                        )
+                        for url in inference_urls
+                    ]
+                ),
             ),
-            asyncio.gather(
-                *[
-                    _post_json(
-                        session, f"{url}/awex/report_weight_meta", init_timeout_s
-                    )
-                    for url in inference_urls
-                ]
-            ),
+            deadline,
         )
 
         training_params_meta = []
@@ -475,6 +674,7 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             "num_engines": num_engines,
             "master_port": master_port,
             "admin_api_key": config.admin_api_key,
+            "timeout_s": config.update_timeout_s,
         }
 
         init_tasks = []
@@ -483,8 +683,12 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 _post(
                     session,
                     f"{url}/awex/init_colocate_weight_update",
-                    init_timeout_s,
-                    json_data={**init_payload_base, "transfer_rank": i},
+                    _remaining(deadline),
+                    json_data={
+                        **init_payload_base,
+                        "transfer_rank": i,
+                        "process_group_timeout_s": _process_group_timeout(deadline),
+                    },
                 )
             )
         for i, url in enumerate(train_urls):
@@ -492,24 +696,23 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 _post(
                     session,
                     f"{url}/awex/init_colocate_weight_update",
-                    init_timeout_s,
+                    _remaining(deadline),
                     json_data={
                         **init_payload_base,
                         "transfer_rank": infer_world_size + i,
+                        "process_group_timeout_s": _process_group_timeout(deadline),
                     },
                 )
             )
-        await asyncio.gather(*init_tasks)
+        await _run_worker_stage(init_tasks, deadline)
 
-        pair_info = PairInfo(
-            pair_name=pair_name,
-            train_worker_urls=train_urls,
-            inference_worker_urls=inference_urls,
-            train_world_size=train_world_size,
-            inference_world_size=infer_world_size,
-            colocate=True,
-        )
-        registry.register(pair_info)
+        pair_info = registry.get_by_name(pair_name)
+        if pair_info is None:
+            raise RuntimeError(f"Pair {pair_name!r} lost gateway bookkeeping")
+        pair_info.train_world_size = train_world_size
+        pair_info.inference_world_size = infer_world_size
+        pair_info.colocate = True
+        pair_info.status = "active"
 
         logger.info("Connected colocate pair '%s'", pair_name)
         return ConnectResponse(pair_name=pair_name)
@@ -550,7 +753,10 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                     session,
                     f"{url}/awex/execute_colocate_weight_update",
                     timeout_s,
-                    json_data={"version": version},
+                    json_data={
+                        "pair_name": pair_info.pair_name,
+                        "version": version,
+                    },
                 )
                 for url in pair_info.train_worker_urls
             ],
@@ -559,7 +765,10 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                     session,
                     f"{url}/awex/execute_colocate_weight_update",
                     timeout_s,
-                    json_data={"version": version},
+                    json_data={
+                        "pair_name": pair_info.pair_name,
+                        "version": version,
+                    },
                 )
                 for url in pair_info.inference_worker_urls
             ],
@@ -611,7 +820,10 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                     session,
                     f"{url}/awex/update_weights",
                     timeout_s,
-                    json_data={"version": version},
+                    json_data={
+                        "pair_name": pair_info.pair_name,
+                        "version": version,
+                    },
                 )
                 for url in pair_info.train_worker_urls + pair_info.inference_worker_urls
             ]
@@ -713,6 +925,16 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 status_code=404,
                 content={"error": f"Pair '{body.pair_name}' not found"},
             )
+        if pair_info.status != "active":
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": (
+                        f"Pair '{body.pair_name}' is {pair_info.status}; "
+                        "cleanup must finish before weight updates"
+                    )
+                },
+            )
 
         session = request.app.state.http_session
         timeout_s = config.update_timeout_s
@@ -743,6 +965,12 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 version=body.version,
                 duration_ms=duration_ms,
                 error=str(e),
+                # Transfers are not transactional: a failure reported after the
+                # gateway starts dispatching may follow writes on one or more
+                # inference ranks.  Make callers recover rather than serve a
+                # mixed model.  Pre-dispatch failures can opt into ``False`` in
+                # a future typed preflight path.
+                inference_weights_may_be_mutated=True,
             )
 
         duration_ms = (time.monotonic() - start) * 1000
@@ -765,11 +993,27 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
 
         pair_info = registry.get_by_name(body.pair_name)
         if pair_info is None:
-            return JSONResponse(
-                status_code=404,
-                content={"error": f"Pair '{body.pair_name}' not found"},
-            )
+            return DisconnectResponse(pair_name=body.pair_name)
 
+        if pair_info.mode == "awex":
+            errors = await _teardown_awex_workers(
+                request.app.state.http_session,
+                pair_info.pair_name,
+                pair_info.train_worker_urls,
+                pair_info.inference_worker_urls,
+                config.init_timeout_s,
+            )
+            if errors:
+                pair_info.status = "cleanup_pending"
+                return JSONResponse(
+                    status_code=500,
+                    content={
+                        "error": (
+                            f"Failed to teardown pair {pair_info.pair_name!r} on "
+                            f"{len(errors)} worker(s)"
+                        )
+                    },
+                )
         registry.unregister(pair_info.pair_name)
         kv_store.clear_pair(pair_info.pair_name)
 

--- a/areal/v2/weight_update/gateway/config.py
+++ b/areal/v2/weight_update/gateway/config.py
@@ -41,6 +41,10 @@ class WeightUpdateResult(BaseModel):
     version: int
     duration_ms: float
     error: str | None = None
+    # ``True`` means inference may have received a prefix of the transfer and
+    # must be restored before generation resumes.  The default keeps responses
+    # from older gateways safely fail-closed.
+    inference_weights_may_be_mutated: bool = True
 
 
 @dataclass
@@ -67,8 +71,14 @@ class PairInfo:
     # Colocated mode (training and inference share GPUs)
     colocate: bool = False
 
+    # A connecting/cleanup-pending record remains registered so retries retain
+    # the pair identity and worker endpoints needed for teardown.
+    status: str = "active"
+
     def __post_init__(self):
         if not self.pair_name:
             raise ValueError("pair_name must not be empty")
         if self.mode not in ("awex", "disk"):
             raise ValueError(f"mode must be 'awex' or 'disk', got '{self.mode}'")
+        if self.status not in ("connecting", "active", "cleanup_pending"):
+            raise ValueError(f"invalid pair status: {self.status!r}")

--- a/areal/v2/weight_update/gateway/config.py
+++ b/areal/v2/weight_update/gateway/config.py
@@ -52,6 +52,7 @@ class PairInfo:
     pair_name: str
     train_worker_urls: list[str]
     inference_worker_urls: list[str]
+    operation_id: str = ""
     train_world_size: int = 0
     inference_world_size: int = 0
     master_addr: str = ""

--- a/areal/v2/weight_update/inference_adapter.py
+++ b/areal/v2/weight_update/inference_adapter.py
@@ -42,19 +42,20 @@ class AwexInferenceAdapter(Protocol):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        process_group_timeout_s: float | None = None,
     ) -> None:
         """Pull peer meta from KV store, build local recv plan, join NCCL group."""
         ...
 
-    def execute_weight_update(self, version: int) -> None:
+    def execute_weight_update(self, pair_name: str, version: int) -> None:
         """Execute cached local P2P recv plan."""
         ...
 
-    def batch_isend_irecv(self, **kwargs) -> None:
+    def batch_isend_irecv(self, pair_name: str, **kwargs) -> None:
         """Execute awex batch P2P send/recv operations."""
         ...
 
-    def teardown_weight_update_group(self) -> None:
+    def teardown_weight_update_group(self, pair_name: str) -> None:
         """Destroy NCCL group and clear cached state."""
         ...
 
@@ -69,11 +70,12 @@ class AwexInferenceAdapter(Protocol):
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        process_group_timeout_s: float | None = None,
     ) -> None:
         """Build device mapping, inference-only NCCL group, and colocate transport."""
         ...
 
-    def execute_colocate_weight_update(self, version: int) -> None:
+    def execute_colocate_weight_update(self, pair_name: str, version: int) -> None:
         """Fetch IPC weights from KV store and apply via colocate transport."""
         ...
 

--- a/areal/v2/weight_update/nccl_group.py
+++ b/areal/v2/weight_update/nccl_group.py
@@ -2,6 +2,7 @@
 """NCCL process group initialization utilities for weight updates."""
 
 import os
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -92,6 +93,7 @@ def init_weights_update_group(
     group_name,
     backend="nccl",
     role="",
+    timeout_s: float | None = None,
 ):
     """Initialize the Torch process group for model parameter updates."""
     assert torch.distributed.is_initialized(), (
@@ -108,6 +110,9 @@ def init_weights_update_group(
         f"Local rank env {os.environ.get('LOCAL_RANK')} DEVICE env {os.environ.get('DEVICE')} "
         f"Global rank env {os.environ.get('RANK')}"
     )
+
+    if timeout_s is not None and timeout_s <= 0:
+        raise TimeoutError("Process-group initialization deadline exceeded")
 
     try:
         options = None
@@ -128,6 +133,7 @@ def init_weights_update_group(
             rank=rank,
             group_name=group_name,
             pg_options=options,
+            timeout=(timedelta(seconds=timeout_s) if timeout_s is not None else None),
         )
         logger.info(f"Initialized custom process group: {group}")
         return group

--- a/areal/v2/weight_update/training_adapter.py
+++ b/areal/v2/weight_update/training_adapter.py
@@ -42,19 +42,20 @@ class AwexTrainingAdapter(Protocol):
         infer_world_size: int,
         train_world_size: int,
         num_engines: int,
+        process_group_timeout_s: float | None = None,
     ) -> None:
         """Pull peer meta from KV store, build local send plan, join NCCL group."""
         ...
 
-    def execute_weight_update(self, version: int) -> None:
+    def execute_weight_update(self, pair_name: str, version: int) -> None:
         """Execute cached local P2P send plan."""
         ...
 
-    def batch_isend_irecv(self, **kwargs) -> None:
+    def batch_isend_irecv(self, pair_name: str, **kwargs) -> None:
         """Execute awex batch P2P send/recv operations."""
         ...
 
-    def teardown_weight_update_group(self) -> None:
+    def teardown_weight_update_group(self, pair_name: str) -> None:
         """Destroy NCCL group and clear cached state."""
         ...
 
@@ -69,11 +70,12 @@ class AwexTrainingAdapter(Protocol):
         master_port: int,
         admin_api_key: str = "areal-admin-key",
         timeout_s: float = 120.0,
+        process_group_timeout_s: float | None = None,
     ) -> None:
         """Register device info in KV store for colocated weight transfer."""
         ...
 
-    def execute_colocate_weight_update(self, version: int) -> None:
+    def execute_colocate_weight_update(self, pair_name: str, version: int) -> None:
         """Serialize weights via IPC and put to KV store."""
         ...
 

--- a/tests/infra/data_service/test_guard.py
+++ b/tests/infra/data_service/test_guard.py
@@ -77,6 +77,51 @@ def test_alloc_ports_success(mock_find, client, state: GuardState):
 
 
 @patch("areal.infra.rpc.guard.app.find_free_ports")
+def test_token_port_reservation_is_idempotent_and_releasable(
+    mock_find, client, state: GuardState
+):
+    mock_find.return_value = [9003]
+    payload = {"count": 1, "token": "pair-operation-token"}
+
+    first = client.post("/alloc_ports", json=payload)
+    repeated = client.post("/alloc_ports", json=payload)
+    conflict = client.post(
+        "/alloc_ports", json={"count": 2, "token": "pair-operation-token"}
+    )
+    released = client.post("/release_ports", json={"token": "pair-operation-token"})
+    released_again = client.post(
+        "/release_ports", json={"token": "pair-operation-token"}
+    )
+
+    assert first.get_json()["ports"] == repeated.get_json()["ports"] == [9003]
+    assert conflict.status_code == 409
+    assert released.get_json()["ports"] == [9003]
+    assert released_again.get_json()["ports"] == []
+    assert state.token_ports == {}
+    assert 9003 not in state.allocated_ports
+    mock_find.assert_called_once()
+
+
+@patch("areal.infra.rpc.guard.app.find_free_ports")
+def test_released_token_rejects_late_alloc(mock_find, client, state: GuardState):
+    token = "released-before-alloc"
+
+    released = client.post("/release_ports", json={"token": token})
+    late_alloc = client.post("/alloc_ports", json={"count": 1, "token": token})
+
+    assert released.status_code == 200
+    assert released.get_json()["ports"] == []
+    assert late_alloc.status_code == 410
+    assert token in state.released_port_tokens
+    assert token not in state.token_ports
+    assert not state.allocated_ports
+    mock_find.assert_not_called()
+
+    cleanup_forked_children(state)
+    assert not state.released_port_tokens
+
+
+@patch("areal.infra.rpc.guard.app.find_free_ports")
 def test_owned_ports_release_after_failed_fork(mock_find, client, state: GuardState):
     mock_find.return_value = [9010]
     alloc = client.post(

--- a/tests/test_awex_separation_delta.py
+++ b/tests/test_awex_separation_delta.py
@@ -40,11 +40,29 @@ def _capture_weight_update_groups(monkeypatch, mod):
     return calls
 
 
+def _prepare_pair_lifecycle(adapter):
+    """Initialize fields skipped by object.__new__ in these focused tests."""
+    adapter._pair_states = {}
+    adapter._active_pair_name = None
+    for name in (
+        "_separation_delta_transport",
+        "_separation_wire_dtypes",
+        "_world_size",
+        "_delta_tracker",
+        "_delta_detector",
+        "_rank_info",
+        "_parameters",
+    ):
+        if not hasattr(adapter, name):
+            setattr(adapter, name, None)
+    return adapter
+
+
 def test_megatron_full_transfer_initializes_gloo_control_group(monkeypatch):
     """Separated Full sync must not fall back to a NCCL control barrier."""
     mod = common._load_megatron_adapter(monkeypatch)
     calls = _capture_weight_update_groups(monkeypatch, mod)
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._dte_config = SimpleNamespace(enabled=False)
 
     adapter.init_weight_update_group(
@@ -68,7 +86,7 @@ def test_sglang_full_transfer_initializes_gloo_control_group(monkeypatch):
     """SGLang Full sync creates the same CPU control group as training."""
     mod = common._load_sglang_adapter(monkeypatch)
     calls = _capture_weight_update_groups(monkeypatch, mod)
-    adapter = object.__new__(mod.AwexSGLangAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexSGLangAdapter))
     adapter._dte_config = SimpleNamespace(enabled=False)
     adapter._get_model_context = lambda: {
         "tp_size": 4,
@@ -104,7 +122,7 @@ def test_megatron_dte_init_caches_global_wire_dtypes_once(monkeypatch):
         "synchronize_wire_dtypes",
         lambda plan, group: calls.append((plan, group)) or expected,
     )
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._dte_config = SimpleNamespace(enabled=True)
 
     adapter.init_weight_update_group(
@@ -133,7 +151,7 @@ def test_sglang_dte_init_caches_global_wire_dtypes_once(monkeypatch):
         "synchronize_wire_dtypes",
         lambda plan, group: calls.append((plan, group)) or expected,
     )
-    adapter = object.__new__(mod.AwexSGLangAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexSGLangAdapter))
     adapter._dte_config = SimpleNamespace(enabled=True)
     adapter._get_model_context = lambda: {
         "tp_size": 4,
@@ -186,7 +204,7 @@ def test_dte_world_size_fails_before_group_or_metadata_init(
         "init_weights_update_group",
         lambda **kwargs: events.append(("group", kwargs)),
     )
-    adapter = object.__new__(getattr(mod, adapter_name))
+    adapter = _prepare_pair_lifecycle(object.__new__(getattr(mod, adapter_name)))
     adapter._dte_config = SimpleNamespace(enabled=True)
 
     with pytest.raises(ValueError, match="combined=5"):
@@ -213,7 +231,7 @@ def test_non_dte_megatron_keeps_odd_world_size_compatibility(monkeypatch):
         "validate_dte_world_size",
         lambda *args: pytest.fail("dense AWEX must not use the DTE world-size gate"),
     )
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._dte_config = SimpleNamespace(enabled=False)
 
     adapter.init_weight_update_group(
@@ -251,7 +269,7 @@ def test_megatron_enters_empty_local_dtype_round(monkeypatch):
         lambda ops, masks, params: {"operation_count": len(ops)},
     )
     monkeypatch.setattr(mod.torch.cuda, "current_device", lambda: 0)
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._transfer_plan = SimpleNamespace(operations={0: [op]})
     adapter._weights_update_group = object()
     adapter._transfer_rank = 1
@@ -287,7 +305,7 @@ def test_sglang_enters_empty_local_dtype_round(monkeypatch):
         lambda **kwargs: calls.append(kwargs),
     )
     monkeypatch.setattr(mod.torch.cuda, "current_device", lambda: 0)
-    adapter = object.__new__(mod.AwexSGLangAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexSGLangAdapter))
     adapter._transfer_plan = SimpleNamespace(operations={1: [op]})
     adapter._weights_update_group = object()
     adapter._transfer_rank = 0
@@ -316,7 +334,7 @@ def test_megatron_full_transfer_uses_gloo_completion_barrier(monkeypatch):
     monkeypatch.setattr(mod, "batch_send_recv", lambda **kwargs: None)
     barriers = []
     monkeypatch.setattr(mod.dist, "barrier", lambda *, group: barriers.append(group))
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._dte_config = SimpleNamespace(enabled=False)
     adapter._transfer_plan = object()
     adapter._weights_update_group = "nccl"
@@ -325,7 +343,8 @@ def test_megatron_full_transfer_uses_gloo_completion_barrier(monkeypatch):
     adapter._world_size = 16
     adapter.get_local_shard_parameters = lambda: {}
 
-    adapter.execute_weight_update(version=1)
+    adapter._active_pair_name = "pair"
+    adapter.execute_weight_update("pair", version=1)
 
     assert barriers == ["gloo"]
 
@@ -339,7 +358,7 @@ def test_sglang_full_transfer_uses_gloo_completion_barrier(monkeypatch):
     monkeypatch.setattr(mod, "batch_send_recv", lambda **kwargs: None)
     barriers = []
     monkeypatch.setattr(mod.dist, "barrier", lambda *, group: barriers.append(group))
-    adapter = object.__new__(mod.AwexSGLangAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexSGLangAdapter))
     adapter._dte_config = SimpleNamespace(enabled=False)
     adapter._transfer_plan = object()
     adapter._weights_update_group = "nccl"
@@ -347,7 +366,8 @@ def test_sglang_full_transfer_uses_gloo_completion_barrier(monkeypatch):
     adapter._transfer_rank = 0
     adapter.get_local_shard_parameters = lambda: {}
 
-    adapter.execute_weight_update(version=1)
+    adapter._active_pair_name = "pair"
+    adapter.execute_weight_update("pair", version=1)
 
     assert barriers == ["gloo"]
 
@@ -369,7 +389,7 @@ def test_megatron_separation_delta_commits_tracker_after_receiver_barrier(
         "barrier",
         lambda *, group: events.append(("barrier", group)),
     )
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._transfer_plan = object()
     adapter._weights_update_group = "nccl"
     adapter._weights_update_group_gloo = "gloo"
@@ -415,7 +435,7 @@ def test_megatron_separation_failed_delta_does_not_advance_tracker(monkeypatch):
         "barrier",
         lambda **kwargs: pytest.fail("failed transfer must not reach barrier"),
     )
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._transfer_plan = object()
     adapter._weights_update_group = "nccl"
     adapter._weights_update_group_gloo = "gloo"
@@ -471,7 +491,7 @@ def test_reconstructed_override_preserves_tensor_parallel_metadata(monkeypatch):
         sys.modules, "areal.engine.megatron_utils.megatron", megatron_mod
     )
 
-    adapter = object.__new__(mod.AwexMegatronAdapter)
+    adapter = _prepare_pair_lifecycle(object.__new__(mod.AwexMegatronAdapter))
     adapter._engine = SimpleNamespace(
         model=object(),
         tf_config=SimpleNamespace(num_moe_experts=None),

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -3,7 +3,8 @@
 import dataclasses
 import os
 import tempfile
-from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -238,26 +239,43 @@ class TestRecoverHandler:
         return GatewayTrainController.__new__(GatewayTrainController)
 
     @pytest.mark.parametrize("mode", ["on", "auto"])
-    def test_load_rejects_gateway_train_controller(self, mode):
+    def test_load_accepts_gateway_train_controller(self, mode):
         with tempfile.TemporaryDirectory() as tmpdir:
             handler = self._make_handler(tmpdir, mode)
+            handler.freq_ctl = Mock()
+            controller = self._make_gateway_controller()
+            recover_info = SimpleNamespace(
+                last_step_info=SimpleNamespace(global_step=0, next=lambda: "step-1"),
+                saver_info={},
+                evaluator_info={},
+                stats_logger_info={},
+                dataloader_info={},
+                checkpoint_info={},
+            )
+            saver = Mock()
+            evaluator = Mock()
+            stats_logger = Mock()
+            dataloader = Mock()
+            handler._load_checkpoint = Mock()
 
-            with pytest.raises(NotImplementedError) as exc_info:
-                handler.load(
-                    self._make_gateway_controller(),
-                    Mock(),
-                    Mock(),
-                    Mock(),
-                    Mock(),
+            with patch(
+                "areal.utils.recover.RecoverInfo.load", return_value=recover_info
+            ):
+                result = handler.load(
+                    controller, saver, evaluator, stats_logger, dataloader
                 )
 
-            assert "GatewayTrainController" in str(exc_info.value)
-            assert '`_version="v2"`' in str(exc_info.value)
+            assert result is recover_info
+            handler._load_checkpoint.assert_called_once_with(controller, name="default")
 
     @pytest.mark.parametrize("mode", ["on", "auto"])
-    def test_dump_rejects_gateway_train_controller(self, mode):
+    def test_dump_accepts_gateway_train_controller(self, mode):
         with tempfile.TemporaryDirectory() as tmpdir:
             handler = self._make_handler(tmpdir, mode)
+            handler.freq_ctl.check = Mock(return_value=True)
+            handler.freq_ctl.state_dict = Mock(return_value={})
+            handler._save_checkpoint = Mock()
+            controller = self._make_gateway_controller()
             step_info = StepInfo(
                 epoch=0,
                 epoch_step=0,
@@ -265,18 +283,105 @@ class TestRecoverHandler:
                 steps_per_epoch=handler.ft_spec.steps_per_epoch,
             )
 
-            with pytest.raises(NotImplementedError) as exc_info:
+            with patch("areal.utils.recover.RecoverInfo.dump") as dump_info:
                 handler.dump(
-                    self._make_gateway_controller(),
+                    controller,
                     step_info,
-                    Mock(),
-                    Mock(),
-                    Mock(),
-                    Mock(),
+                    Mock(state_dict=Mock(return_value={})),
+                    Mock(state_dict=Mock(return_value={})),
+                    Mock(state_dict=Mock(return_value={})),
+                    Mock(state_dict=Mock(return_value={})),
                 )
 
-            assert "GatewayTrainController" in str(exc_info.value)
-            assert "recover.mode" in str(exc_info.value)
+            handler._save_checkpoint.assert_called_once()
+            dump_info.assert_called_once()
+
+    def test_failed_weight_sync_does_not_advance_versions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handler = self._make_handler(tmpdir, "auto")
+            handler.freq_ctl = Mock()
+            handler._load_checkpoint = Mock()
+            controller = self._make_gateway_controller()
+            controller.connect_engine = Mock()
+            controller.update_weights = Mock(
+                side_effect=RuntimeError("weight transfer failed")
+            )
+            controller.set_version = Mock()
+            recover_info = SimpleNamespace(
+                last_step_info=SimpleNamespace(global_step=2, next=lambda: "step-3"),
+                saver_info={},
+                evaluator_info={},
+                stats_logger_info={},
+                dataloader_info={},
+                checkpoint_info={},
+            )
+            inference_engine = Mock()
+            weight_update_meta = Mock(type="awex")
+            weight_update_meta.with_version.return_value = Mock(version=3)
+
+            with (
+                patch(
+                    "areal.utils.recover.RecoverInfo.load", return_value=recover_info
+                ),
+                pytest.raises(RuntimeError, match="weight transfer failed"),
+            ):
+                handler.load(
+                    controller,
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                    inference_engine=inference_engine,
+                    weight_update_meta=weight_update_meta,
+                )
+
+            inference_engine.resume.assert_not_called()
+            controller.set_version.assert_not_called()
+            inference_engine.set_version.assert_not_called()
+
+    def test_colocate_checkpoint_failure_resumes_before_transfer(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handler = self._make_handler(tmpdir, "auto")
+            handler.freq_ctl = Mock()
+            handler._require_colocate_rollout_protocol = Mock()
+            handler._load_checkpoint = Mock(side_effect=RuntimeError("load failed"))
+            controller = self._make_gateway_controller()
+            controller.connect_engine = Mock()
+            controller.update_weights = Mock()
+            controller.set_version = Mock()
+            recover_info = SimpleNamespace(
+                last_step_info=SimpleNamespace(global_step=2, next=lambda: "step-3"),
+                saver_info={},
+                evaluator_info={},
+                stats_logger_info={},
+                dataloader_info={},
+                checkpoint_info={},
+            )
+            inference_engine = Mock()
+            weight_update_meta = Mock(type="awex")
+            weight_update_meta.with_version.return_value = Mock(version=3)
+
+            with (
+                patch(
+                    "areal.utils.recover.RecoverInfo.load", return_value=recover_info
+                ),
+                pytest.raises(RuntimeError, match="load failed"),
+            ):
+                handler.load(
+                    controller,
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                    inference_engine=inference_engine,
+                    weight_update_meta=weight_update_meta,
+                    colocated_rollout=True,
+                )
+
+            inference_engine.resume.assert_called_once_with()
+            controller.update_weights.assert_not_called()
+            controller.set_version.assert_not_called()
+            inference_engine.set_version.assert_not_called()
 
     @pytest.mark.parametrize("no_save_optim", [False, True])
     def test_save_checkpoint_passes_with_optim_from_config(self, no_save_optim):

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -4,18 +4,19 @@ import dataclasses
 import os
 import tempfile
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
 from areal.api.cli_args import RecoverConfig
-from areal.api.io_struct import FinetuneSpec, StepInfo
+from areal.api.io_struct import FinetuneSpec
 from areal.utils.recover import (
     RecoverHandler,
     check_if_auto_recover,
     check_if_recover,
 )
 from areal.utils.saver import Saver
+from areal.v2.inference_service.controller.controller import RolloutControllerV2
 from areal.v2.training_service.controller.controller import (
     GatewayTrainController,
 )
@@ -238,63 +239,18 @@ class TestRecoverHandler:
     def _make_gateway_controller() -> GatewayTrainController:
         return GatewayTrainController.__new__(GatewayTrainController)
 
-    @pytest.mark.parametrize("mode", ["on", "auto"])
-    def test_load_accepts_gateway_train_controller(self, mode):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            handler = self._make_handler(tmpdir, mode)
-            handler.freq_ctl = Mock()
-            controller = self._make_gateway_controller()
-            recover_info = SimpleNamespace(
-                last_step_info=SimpleNamespace(global_step=0, next=lambda: "step-1"),
-                saver_info={},
-                evaluator_info={},
-                stats_logger_info={},
-                dataloader_info={},
-                checkpoint_info={},
-            )
-            saver = Mock()
-            evaluator = Mock()
-            stats_logger = Mock()
-            dataloader = Mock()
-            handler._load_checkpoint = Mock()
-
-            with patch(
-                "areal.utils.recover.RecoverInfo.load", return_value=recover_info
-            ):
-                result = handler.load(
-                    controller, saver, evaluator, stats_logger, dataloader
-                )
-
-            assert result is recover_info
-            handler._load_checkpoint.assert_called_once_with(controller, name="default")
-
-    @pytest.mark.parametrize("mode", ["on", "auto"])
-    def test_dump_accepts_gateway_train_controller(self, mode):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            handler = self._make_handler(tmpdir, mode)
-            handler.freq_ctl.check = Mock(return_value=True)
-            handler.freq_ctl.state_dict = Mock(return_value={})
-            handler._save_checkpoint = Mock()
-            controller = self._make_gateway_controller()
-            step_info = StepInfo(
-                epoch=0,
-                epoch_step=0,
-                global_step=0,
-                steps_per_epoch=handler.ft_spec.steps_per_epoch,
-            )
-
-            with patch("areal.utils.recover.RecoverInfo.dump") as dump_info:
-                handler.dump(
-                    controller,
-                    step_info,
-                    Mock(state_dict=Mock(return_value={})),
-                    Mock(state_dict=Mock(return_value={})),
-                    Mock(state_dict=Mock(return_value={})),
-                    Mock(state_dict=Mock(return_value={})),
-                )
-
-            handler._save_checkpoint.assert_called_once()
-            dump_info.assert_called_once()
+    @staticmethod
+    def _recover_info(global_step: int = 2):
+        return SimpleNamespace(
+            last_step_info=SimpleNamespace(
+                global_step=global_step, next=lambda: f"step-{global_step + 1}"
+            ),
+            saver_info={},
+            evaluator_info={},
+            stats_logger_info={},
+            dataloader_info={},
+            checkpoint_info={},
+        )
 
     def test_failed_weight_sync_does_not_advance_versions(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -307,14 +263,7 @@ class TestRecoverHandler:
                 side_effect=RuntimeError("weight transfer failed")
             )
             controller.set_version = Mock()
-            recover_info = SimpleNamespace(
-                last_step_info=SimpleNamespace(global_step=2, next=lambda: "step-3"),
-                saver_info={},
-                evaluator_info={},
-                stats_logger_info={},
-                dataloader_info={},
-                checkpoint_info={},
-            )
+            recover_info = self._recover_info()
             inference_engine = Mock()
             weight_update_meta = Mock(type="awex")
             weight_update_meta.with_version.return_value = Mock(version=3)
@@ -339,33 +288,91 @@ class TestRecoverHandler:
             controller.set_version.assert_not_called()
             inference_engine.set_version.assert_not_called()
 
-    def test_colocate_checkpoint_failure_resumes_before_transfer(self):
+    def test_publish_retry_does_not_repeat_transfer_and_commits_last(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             handler = self._make_handler(tmpdir, "auto")
             handler.freq_ctl = Mock()
-            handler._require_colocate_rollout_protocol = Mock()
-            handler._load_checkpoint = Mock(side_effect=RuntimeError("load failed"))
+            handler._load_checkpoint = Mock()
+            order = []
+            controller = self._make_gateway_controller()
+            controller.connect_engine = Mock()
+            controller.update_weights = Mock(
+                side_effect=lambda *_args, **_kwargs: order.append("transfer")
+            )
+            controller.broadcast_version = Mock(
+                side_effect=lambda *_args, **_kwargs: order.append("train-broadcast")
+            )
+            controller.commit_local_version = Mock(
+                side_effect=lambda *_args: order.append("train-commit")
+            )
+            inference_engine = Mock()
+            inference_engine.pause.side_effect = lambda: order.append(
+                "pause-dispatcher"
+            )
+            infer_publish_attempts = 0
+
+            def infer_broadcast(*_args, **_kwargs):
+                nonlocal infer_publish_attempts
+                infer_publish_attempts += 1
+                order.append("infer-broadcast")
+                if infer_publish_attempts == 1:
+                    raise RuntimeError("publish response lost")
+
+            inference_engine.broadcast_version.side_effect = infer_broadcast
+            inference_engine.commit_local_version.side_effect = (
+                lambda *_args: order.append("infer-commit")
+            )
+            inference_engine.continue_generation.side_effect = lambda: order.append(
+                "continue"
+            )
+            inference_engine.resume.side_effect = lambda: order.append("resume")
+            weight_update_meta = Mock(type="awex")
+            versioned_meta = Mock(version=3)
+            weight_update_meta.with_version.return_value = versioned_meta
+            recover_info = self._recover_info()
+
+            with patch(
+                "areal.utils.recover.RecoverInfo.load", return_value=recover_info
+            ):
+                handler.load(
+                    controller,
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                    inference_engine=inference_engine,
+                    weight_update_meta=weight_update_meta,
+                )
+
+            controller.update_weights.assert_called_once_with(
+                versioned_meta, resume_generation=False
+            )
+            assert controller.broadcast_version.call_args_list == [
+                call(3, timeout=pytest.approx(30.0, abs=1.0)),
+                call(3, timeout=pytest.approx(30.0, abs=1.0)),
+            ]
+            assert order.count("transfer") == 1
+            assert order[-4:] == [
+                "train-commit",
+                "infer-commit",
+                "continue",
+                "resume",
+            ]
+
+    def test_v2_colocate_recovery_rejected_before_side_effects(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handler = self._make_handler(tmpdir, "auto")
+            handler._load_checkpoint = Mock()
             controller = self._make_gateway_controller()
             controller.connect_engine = Mock()
             controller.update_weights = Mock()
-            controller.set_version = Mock()
-            recover_info = SimpleNamespace(
-                last_step_info=SimpleNamespace(global_step=2, next=lambda: "step-3"),
-                saver_info={},
-                evaluator_info={},
-                stats_logger_info={},
-                dataloader_info={},
-                checkpoint_info={},
-            )
-            inference_engine = Mock()
+            inference_engine = RolloutControllerV2.__new__(RolloutControllerV2)
+            inference_engine.pause = Mock()
             weight_update_meta = Mock(type="awex")
-            weight_update_meta.with_version.return_value = Mock(version=3)
 
             with (
-                patch(
-                    "areal.utils.recover.RecoverInfo.load", return_value=recover_info
-                ),
-                pytest.raises(RuntimeError, match="load failed"),
+                patch("areal.utils.recover.RecoverInfo.load") as load_info,
+                pytest.raises(NotImplementedError, match="not supported"),
             ):
                 handler.load(
                     controller,
@@ -378,10 +385,11 @@ class TestRecoverHandler:
                     colocated_rollout=True,
                 )
 
-            inference_engine.resume.assert_called_once_with()
+            load_info.assert_not_called()
+            handler._load_checkpoint.assert_not_called()
+            inference_engine.pause.assert_not_called()
+            controller.connect_engine.assert_not_called()
             controller.update_weights.assert_not_called()
-            controller.set_version.assert_not_called()
-            inference_engine.set_version.assert_not_called()
 
     @pytest.mark.parametrize("no_save_optim", [False, True])
     def test_save_checkpoint_passes_with_optim_from_config(self, no_save_optim):
@@ -415,75 +423,3 @@ class TestRecoverHandler:
 
             meta = engine.load.call_args[0][0]
             assert meta.with_optim is (not no_load_optim)
-
-
-class TestAwexColocateGate:
-    """The AWEX pre-transfer sequence must run only for colocated rollouts."""
-
-    @staticmethod
-    def _awex_meta():
-        return Mock(type="awex")
-
-    def test_awex_transport_without_colocation_is_not_colocate(self):
-        assert not RecoverHandler._should_run_awex_colocate_transfer(
-            inference_engine=Mock(),
-            weight_update_meta=self._awex_meta(),
-            colocated_rollout=False,
-        )
-
-    def test_awex_transport_with_colocation_is_colocate(self):
-        assert RecoverHandler._should_run_awex_colocate_transfer(
-            inference_engine=Mock(),
-            weight_update_meta=self._awex_meta(),
-            colocated_rollout=True,
-        )
-
-    @pytest.mark.parametrize("meta_type", ["disk", "xccl"])
-    def test_non_awex_transport_is_never_colocate(self, meta_type):
-        assert not RecoverHandler._should_run_awex_colocate_transfer(
-            inference_engine=Mock(),
-            weight_update_meta=Mock(type=meta_type),
-            colocated_rollout=True,
-        )
-
-    def test_missing_inference_engine_is_not_colocate(self):
-        assert not RecoverHandler._should_run_awex_colocate_transfer(
-            inference_engine=None,
-            weight_update_meta=self._awex_meta(),
-            colocated_rollout=True,
-        )
-
-    def test_meta_without_type_attribute_is_not_colocate(self):
-        assert not RecoverHandler._should_run_awex_colocate_transfer(
-            inference_engine=Mock(),
-            weight_update_meta=None,
-            colocated_rollout=True,
-        )
-
-
-class TestColocateRolloutProtocol:
-    """Engines lacking the colocate protocol must fail before any side effect."""
-
-    def test_engine_with_full_protocol_is_accepted(self):
-        engine = Mock(spec=["pause_generation_sync", "offload"])
-        engine.offload = lambda tags=None: None
-
-        RecoverHandler._require_colocate_rollout_protocol(engine)
-
-    def test_engine_without_pause_generation_sync_is_rejected(self):
-        engine = Mock(spec=["offload"])
-        engine.offload = lambda tags=None: None
-
-        with pytest.raises(NotImplementedError) as exc_info:
-            RecoverHandler._require_colocate_rollout_protocol(engine)
-
-        assert "pause_generation_sync" in str(exc_info.value)
-
-    def test_engine_with_untagged_offload_is_rejected(self):
-        engine = Mock(spec=["pause_generation_sync", "offload"])
-        engine.offload = lambda: None
-
-        with pytest.raises(NotImplementedError) as exc_info:
-            RecoverHandler._require_colocate_rollout_protocol(engine)
-
-        assert "tags" in str(exc_info.value)

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -321,6 +321,43 @@ class TestRolloutControllerV2APISurface:
         assert bases == (object,), f"Unexpected bases: {bases}"
 
 
+class TestGenerationPauseResumeSafety:
+    @staticmethod
+    def _controller() -> RolloutControllerV2:
+        controller = RolloutControllerV2(
+            config=InferenceEngineConfig(backend="sglang:d1", admin_api_key="test-key"),
+            scheduler=MagicMock(n_gpus_per_node=8),
+        )
+        controller._data_proxy_addrs = ["http://worker-0", "http://worker-1"]
+        return controller
+
+    @pytest.mark.asyncio
+    async def test_partial_pause_rolls_back_successful_worker_and_raises(self):
+        controller = self._controller()
+        controller._async_data_proxy_post = AsyncMock(
+            side_effect=[None, RuntimeError("pause failed"), None]
+        )
+
+        with pytest.raises(RuntimeError, match="failed on 1/2 workers"):
+            await controller._async_pause_generation()
+
+        assert controller._async_data_proxy_post.call_args_list == [
+            call("http://worker-0", "/pause_generation", {}),
+            call("http://worker-1", "/pause_generation", {}),
+            call("http://worker-0", "/continue_generation", {}),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_partial_continue_is_reported_as_failure(self):
+        controller = self._controller()
+        controller._async_data_proxy_post = AsyncMock(
+            side_effect=[None, RuntimeError("resume failed")]
+        )
+
+        with pytest.raises(RuntimeError, match="failed on 1/2 workers"):
+            await controller._async_continue_generation()
+
+
 # =============================================================================
 # RolloutControllerV2 — construction + state
 # =============================================================================

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -335,16 +335,18 @@ class TestGenerationPauseResumeSafety:
     async def test_partial_pause_rolls_back_successful_worker_and_raises(self):
         controller = self._controller()
         controller._async_data_proxy_post = AsyncMock(
-            side_effect=[None, RuntimeError("pause failed"), None]
+            side_effect=[None, RuntimeError("pause failed"), None, None]
         )
 
-        with pytest.raises(RuntimeError, match="failed on 1/2 workers"):
+        with pytest.raises(RuntimeError, match="failed on 1/2 workers") as exc_info:
             await controller._async_pause_generation()
+        assert exc_info.value.generation_pause_state_unresolved is False
 
         assert controller._async_data_proxy_post.call_args_list == [
             call("http://worker-0", "/pause_generation", {}),
             call("http://worker-1", "/pause_generation", {}),
             call("http://worker-0", "/continue_generation", {}),
+            call("http://worker-1", "/continue_generation", {}),
         ]
 
     @pytest.mark.asyncio
@@ -356,6 +358,19 @@ class TestGenerationPauseResumeSafety:
 
         with pytest.raises(RuntimeError, match="failed on 1/2 workers"):
             await controller._async_continue_generation()
+
+    def test_set_version_does_not_commit_after_partial_broadcast_failure(self):
+        controller = self._controller()
+        controller._gateway_addr = "http://gateway"
+        controller._version = 2
+        controller._async_data_proxy_post = AsyncMock(
+            side_effect=[None, RuntimeError("publish failed")]
+        )
+
+        with pytest.raises(RuntimeError, match="failed on 1/2 workers"):
+            controller.set_version(3)
+
+        assert controller.get_version() == 2
 
 
 # =============================================================================

--- a/tests/v2/inference_service/test_sglang_awex_rpc.py
+++ b/tests/v2/inference_service/test_sglang_awex_rpc.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+io_struct = pytest.importorskip("sglang.srt.managers.io_struct")
+from areal.v2.inference_service.sglang.rpc_proxy import RpcProxy  # noqa: E402
+from areal.v2.inference_service.sglang.scheduler import (  # noqa: E402
+    AwexSchedulerBridge,
+)
+
+RpcReqInput = io_struct.RpcReqInput
+RpcReqOutput = io_struct.RpcReqOutput
+
+
+class _FakeSocket:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.sent = []
+
+    async def send_pyobj(self, value):
+        self.sent.append(value)
+
+    async def recv_pyobj(self):
+        await asyncio.sleep(0)
+        return self.messages.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_rpc_discards_late_ack_and_result(monkeypatch):
+    proxy = RpcProxy.__new__(RpcProxy)
+    proxy._lock = asyncio.Lock()
+    proxy._default_timeout_s = 1.0
+    proxy._rpc_socket = _FakeSocket(
+        [
+            RpcReqOutput(True, "", rid="old-rid"),
+            RpcReqOutput(True, "", rid="new-rid"),
+        ]
+    )
+    proxy._result_pull = _FakeSocket(
+        [
+            {"rid": "old-rid", "value": "old"},
+            {"rid": "new-rid", "value": "new"},
+        ]
+    )
+    monkeypatch.setattr(
+        "areal.v2.inference_service.sglang.rpc_proxy.uuid4",
+        lambda: SimpleNamespace(hex="new-rid"),
+    )
+
+    result = await proxy.collective_rpc_with_result("method", timeout_s=1.0)
+
+    assert result == "new"
+    assert proxy._rpc_socket.sent[0].rid == "new-rid"
+
+
+def test_scheduler_dispatcher_copies_request_rid(monkeypatch):
+    monkeypatch.delenv("AREAL_AWEX_RESULT_IPC", raising=False)
+    scheduler = MagicMock(tp_rank=0, dp_rank=0)
+    scheduler.handle_rpc_request.return_value = RpcReqOutput(True, "")
+    bridge = AwexSchedulerBridge(scheduler)
+
+    bridge.bind()
+    response = scheduler.handle_rpc_request(
+        RpcReqInput(method="awex_randomize_parameters", rid="request-rid")
+    )
+
+    assert response.rid == "request-rid"
+    scheduler.init_request_dispatcher.assert_called_once_with()
+
+
+def test_scheduler_deducts_queue_time_from_pg_timeout(monkeypatch):
+    monkeypatch.delenv("AREAL_AWEX_RESULT_IPC", raising=False)
+    monkeypatch.setattr(
+        "areal.v2.inference_service.sglang.scheduler.time.monotonic", lambda: 14.0
+    )
+    bridge = AwexSchedulerBridge(MagicMock(tp_rank=0, dp_rank=0))
+    bridge._adapter = MagicMock()
+
+    bridge.awex_init_weights_update_group(
+        pair_name="pair",
+        operation_id="operation",
+        operation_expiry_monotonic=20.0,
+        process_group_timeout_s=9.0,
+    )
+
+    assert (
+        bridge._adapter.init_weight_update_group.call_args.kwargs[
+            "process_group_timeout_s"
+        ]
+        == 6.0
+    )
+
+
+def test_scheduler_tombstone_blocks_late_init(monkeypatch):
+    monkeypatch.delenv("AREAL_AWEX_RESULT_IPC", raising=False)
+    bridge = AwexSchedulerBridge(MagicMock(tp_rank=0, dp_rank=0))
+    bridge.awex_teardown_weight_update_group("pair", "operation")
+
+    with pytest.raises(RuntimeError, match="was cancelled"):
+        bridge.awex_init_weights_update_group(
+            pair_name="pair", operation_id="operation"
+        )
+    assert bridge._adapter is None

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,8 +11,10 @@ import torch
 
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
 from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
+from areal.trainer.rl_trainer import PPOTrainer
 from areal.v2.training_service.controller.controller import (
     GatewayTrainController,
+    WeightUpdateCleanupPending,
 )
 
 MODULE = "areal.v2.training_service.controller.controller"
@@ -361,8 +364,12 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
 
         candidate = MagicMock()
         candidate.pair_name = "actor-rollout-v1"
+        candidate.operation_id = "candidate-op"
+        candidate.train_worker_urls = ["http://train-0"]
+        candidate.inference_worker_urls = ["http://inference-0"]
+        candidate.workers_cleaned = False
         candidate.connect.side_effect = RuntimeError("candidate init failed")
-        candidate.destroy.side_effect = RuntimeError("rollback incomplete")
+        candidate.disconnect.side_effect = RuntimeError("rollback incomplete")
         port_response = MagicMock()
         port_response.json.return_value = {"host": "inference-host", "ports": [12345]}
 
@@ -372,6 +379,9 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
                 return_value=candidate,
             ),
             patch("requests.post", return_value=port_response),
+            patch.object(
+                controller, "_direct_teardown_weight_update_pair", return_value=False
+            ),
             pytest.raises(RuntimeError, match="candidate init failed"),
         ):
             controller.connect_engine(
@@ -379,7 +389,6 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
                 SimpleNamespace(type="awex", version=1),
             )
 
-        candidate.destroy.assert_called_once_with(raise_on_error=True)
         assert controller._weight_update_ctrl is old_ctrl
         assert controller.rollout is old_rollout
         assert controller._stale_weight_update_ctrls == [candidate]
@@ -390,6 +399,7 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
         controller._worker_addrs = ["http://train-0"]
         old_ctrl = MagicMock()
         old_ctrl.pair_name = "actor-rollout-v1"
+        old_ctrl.workers_cleaned = False
         old_ctrl.disconnect.side_effect = RuntimeError("keep stale")
         controller._weight_update_ctrl = old_ctrl
         candidate = MagicMock()
@@ -403,6 +413,9 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
                 return_value=candidate,
             ),
             patch("requests.post", return_value=port_response),
+            patch.object(
+                controller, "_direct_teardown_weight_update_pair", return_value=False
+            ),
         ):
             controller.connect_engine(
                 self._rollout(),
@@ -415,45 +428,6 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
         assert controller._weight_update_ctrl is candidate
         assert controller._stale_weight_update_ctrls == [old_ctrl]
 
-    def test_mutating_update_failure_leaves_generation_paused(self):
-        controller = _make_controller()
-        controller.rollout = MagicMock()
-        controller._weight_update_ctrl = MagicMock()
-        controller._weight_update_ctrl.update_weights.side_effect = RuntimeError(
-            "transfer failed"
-        )
-
-        with pytest.raises(RuntimeError, match="transfer failed"):
-            controller.update_weights(SimpleNamespace(version=3))
-
-        controller.rollout.pause_generation.assert_called_once_with()
-        controller.rollout.continue_generation.assert_not_called()
-
-    def test_pause_failure_is_marked_pre_mutation_and_skips_transfer(self):
-        controller = _make_controller()
-        controller.rollout = MagicMock()
-        controller.rollout.pause_generation.side_effect = RuntimeError("partial pause")
-        controller._weight_update_ctrl = MagicMock()
-
-        with pytest.raises(RuntimeError, match="partial pause") as exc_info:
-            controller.update_weights(SimpleNamespace(version=3))
-
-        assert exc_info.value.inference_weights_may_be_mutated is False
-        controller._weight_update_ctrl.update_weights.assert_not_called()
-
-    def test_pre_mutation_failure_resumes_generation(self):
-        controller = _make_controller()
-        controller.rollout = MagicMock()
-        controller._weight_update_ctrl = MagicMock()
-        error = RuntimeError("preflight failed")
-        error.inference_weights_may_be_mutated = False
-        controller._weight_update_ctrl.update_weights.side_effect = error
-
-        with pytest.raises(RuntimeError, match="preflight failed"):
-            controller.update_weights(SimpleNamespace(version=3))
-
-        controller.rollout.continue_generation.assert_called_once_with()
-
     def test_shutdown_fallback_covers_active_and_stale_pairs(self):
         controller = _make_controller()
 
@@ -462,19 +436,32 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
                 self.pair_name = pair_name
                 self.train_worker_urls = [f"http://train-{pair_name}"]
                 self.inference_worker_urls = [f"http://infer-{pair_name}"]
+                self.operation_id = f"op-{pair_name}"
+                self.workers_cleaned = False
+                self.port_token = None
                 self.failures = failures
-                self.destroy_calls = 0
+                self.terminate_calls = 0
 
             def disconnect(self, timeout: float) -> None:
-                assert timeout == 30.0
+                assert timeout > 0
                 if self.failures:
                     self.failures -= 1
                     raise RuntimeError("gateway disconnect failed")
+                self.mark_workers_cleaned()
+
+            def mark_workers_cleaned(self) -> None:
+                self.workers_cleaned = True
                 self.pair_name = None
 
-            def destroy(self, *, raise_on_error: bool) -> None:
+            def release_port_reservation(self, timeout: float) -> None:
+                assert timeout > 0
+
+            def terminate_private_gateway(
+                self, *, timeout: float, raise_on_error: bool
+            ) -> None:
                 assert raise_on_error
-                self.destroy_calls += 1
+                assert timeout > 0
+                self.terminate_calls += 1
 
         active = FakeWeightController("active", failures=1)
         stale_a = FakeWeightController("stale-a", failures=1)
@@ -485,72 +472,35 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
             "_direct_teardown_weight_update_pair",
             return_value=True,
         ) as direct_teardown:
-            unresolved = controller._teardown_weight_update_controllers(
-                [active, stale_a, stale_b]
-            )
-            repeated = controller._teardown_weight_update_controllers(
-                [active, stale_a, stale_b]
+            unresolved = controller._cleanup_weight_update_controllers(
+                [active, stale_a, stale_b], time.monotonic() + 30.0
             )
 
-        assert unresolved == repeated == []
+        assert unresolved == []
         assert [item.args[0] for item in direct_teardown.call_args_list] == [
             "active",
             "stale-a",
         ]
-        assert all(item.destroy_calls == 2 for item in (active, stale_a, stale_b))
-
-    def test_direct_shutdown_fallback_sends_pair_json_to_all_endpoints(self):
-        controller = _make_controller()
-        calls = []
-
-        class FakeResponse:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *_args):
-                return None
-
-            def raise_for_status(self):
-                return None
-
-        class FakeSession:
-            def __init__(self, **_kwargs):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *_args):
-                return None
-
-            def post(self, url, json):
-                calls.append((url, json))
-                return FakeResponse()
-
-        with patch(f"{MODULE}.aiohttp.ClientSession", FakeSession):
-            assert controller._direct_teardown_weight_update_pair(
-                "pair-a",
-                ["http://train-0"],
-                ["http://infer-0", "http://infer-1"],
-            )
-
-        assert calls == [
-            ("http://train-0/awex/teardown", {"pair_name": "pair-a"}),
-            ("http://infer-0/awex/teardown", {"pair_name": "pair-a"}),
-            ("http://infer-1/awex/teardown", {"pair_name": "pair-a"}),
+        assert [item.args[1] for item in direct_teardown.call_args_list] == [
+            "op-active",
+            "op-stale-a",
         ]
+        assert all(item.terminate_calls == 1 for item in (active, stale_a, stale_b))
 
     def test_destroy_keeps_workers_alive_until_stale_pair_cleanup_succeeds(self):
         controller = _make_controller()
         stale = MagicMock()
         stale.pair_name = "stale"
+        stale.operation_id = "stale-op"
+        stale.workers_cleaned = False
+        stale.port_token = None
         stale.train_worker_urls = ["http://train"]
         stale.inference_worker_urls = ["http://infer"]
         attempts = 0
 
         def disconnect(*, timeout):
             nonlocal attempts
-            assert timeout == 30.0
+            assert timeout > 0
             attempts += 1
             if attempts == 1:
                 raise RuntimeError("busy")
@@ -565,7 +515,8 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
             "_direct_teardown_weight_update_pair",
             return_value=False,
         ):
-            controller.destroy()
+            with pytest.raises(WeightUpdateCleanupPending):
+                controller.destroy()
 
         controller._cleanup_runtime_state.assert_not_called()
         assert controller._stale_weight_update_ctrls == [stale]
@@ -573,3 +524,21 @@ class TestGatewayTrainControllerWeightUpdateReconnect:
         controller.destroy()
 
         controller._cleanup_runtime_state.assert_called_once_with()
+
+
+def test_ppo_close_preserves_pair_workers_when_cleanup_is_unresolved():
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.actor = MagicMock()
+    trainer.rollout = MagicMock()
+    trainer.actor.cleanup_weight_update_pairs.side_effect = WeightUpdateCleanupPending(
+        ["active"]
+    )
+
+    with (
+        patch("areal.trainer.rl_trainer.perf_tracer.save"),
+        pytest.raises(WeightUpdateCleanupPending),
+    ):
+        trainer.close()
+
+    trainer.rollout.destroy.assert_not_called()
+    trainer.actor.destroy.assert_not_called()

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -334,3 +335,241 @@ class TestGatewayTrainControllerClearBatches:
             "cancel-node": {"s-cancel": 0},
         }
         mock_gateway_post.assert_not_called()
+
+
+class TestGatewayTrainControllerWeightUpdateReconnect:
+    @staticmethod
+    def _rollout():
+        from areal.v2.inference_service.controller.controller import (
+            RolloutControllerV2,
+        )
+
+        rollout = MagicMock(spec=RolloutControllerV2)
+        rollout.inference_worker_urls = ["http://inference-0"]
+        rollout.inference_guard_addrs = ["http://guard-0"]
+        return rollout
+
+    def test_failed_candidate_keeps_old_active_and_pending_cleanup(self):
+        controller = _make_controller()
+        controller._role = "actor"
+        controller._worker_addrs = ["http://train-0"]
+        old_ctrl = MagicMock()
+        old_ctrl.pair_name = "actor-rollout"
+        old_rollout = self._rollout()
+        controller._weight_update_ctrl = old_ctrl
+        controller.rollout = old_rollout
+
+        candidate = MagicMock()
+        candidate.pair_name = "actor-rollout-v1"
+        candidate.connect.side_effect = RuntimeError("candidate init failed")
+        candidate.destroy.side_effect = RuntimeError("rollback incomplete")
+        port_response = MagicMock()
+        port_response.json.return_value = {"host": "inference-host", "ports": [12345]}
+
+        with (
+            patch(
+                "areal.v2.weight_update.controller.controller.WeightUpdateController",
+                return_value=candidate,
+            ),
+            patch("requests.post", return_value=port_response),
+            pytest.raises(RuntimeError, match="candidate init failed"),
+        ):
+            controller.connect_engine(
+                self._rollout(),
+                SimpleNamespace(type="awex", version=1),
+            )
+
+        candidate.destroy.assert_called_once_with(raise_on_error=True)
+        assert controller._weight_update_ctrl is old_ctrl
+        assert controller.rollout is old_rollout
+        assert controller._stale_weight_update_ctrls == [candidate]
+
+    def test_same_recovery_version_uses_unique_candidate_pair_name(self):
+        controller = _make_controller()
+        controller._role = "actor"
+        controller._worker_addrs = ["http://train-0"]
+        old_ctrl = MagicMock()
+        old_ctrl.pair_name = "actor-rollout-v1"
+        old_ctrl.disconnect.side_effect = RuntimeError("keep stale")
+        controller._weight_update_ctrl = old_ctrl
+        candidate = MagicMock()
+        candidate.pair_name = "candidate"
+        port_response = MagicMock()
+        port_response.json.return_value = {"host": "inference-host", "ports": [12345]}
+
+        with (
+            patch(
+                "areal.v2.weight_update.controller.controller.WeightUpdateController",
+                return_value=candidate,
+            ),
+            patch("requests.post", return_value=port_response),
+        ):
+            controller.connect_engine(
+                self._rollout(),
+                SimpleNamespace(type="awex", version=1),
+            )
+
+        pair_name = candidate.connect.call_args.kwargs["pair_name"]
+        assert pair_name.startswith("actor-rollout-v1-")
+        assert pair_name != old_ctrl.pair_name
+        assert controller._weight_update_ctrl is candidate
+        assert controller._stale_weight_update_ctrls == [old_ctrl]
+
+    def test_mutating_update_failure_leaves_generation_paused(self):
+        controller = _make_controller()
+        controller.rollout = MagicMock()
+        controller._weight_update_ctrl = MagicMock()
+        controller._weight_update_ctrl.update_weights.side_effect = RuntimeError(
+            "transfer failed"
+        )
+
+        with pytest.raises(RuntimeError, match="transfer failed"):
+            controller.update_weights(SimpleNamespace(version=3))
+
+        controller.rollout.pause_generation.assert_called_once_with()
+        controller.rollout.continue_generation.assert_not_called()
+
+    def test_pause_failure_is_marked_pre_mutation_and_skips_transfer(self):
+        controller = _make_controller()
+        controller.rollout = MagicMock()
+        controller.rollout.pause_generation.side_effect = RuntimeError("partial pause")
+        controller._weight_update_ctrl = MagicMock()
+
+        with pytest.raises(RuntimeError, match="partial pause") as exc_info:
+            controller.update_weights(SimpleNamespace(version=3))
+
+        assert exc_info.value.inference_weights_may_be_mutated is False
+        controller._weight_update_ctrl.update_weights.assert_not_called()
+
+    def test_pre_mutation_failure_resumes_generation(self):
+        controller = _make_controller()
+        controller.rollout = MagicMock()
+        controller._weight_update_ctrl = MagicMock()
+        error = RuntimeError("preflight failed")
+        error.inference_weights_may_be_mutated = False
+        controller._weight_update_ctrl.update_weights.side_effect = error
+
+        with pytest.raises(RuntimeError, match="preflight failed"):
+            controller.update_weights(SimpleNamespace(version=3))
+
+        controller.rollout.continue_generation.assert_called_once_with()
+
+    def test_shutdown_fallback_covers_active_and_stale_pairs(self):
+        controller = _make_controller()
+
+        class FakeWeightController:
+            def __init__(self, pair_name: str, failures: int):
+                self.pair_name = pair_name
+                self.train_worker_urls = [f"http://train-{pair_name}"]
+                self.inference_worker_urls = [f"http://infer-{pair_name}"]
+                self.failures = failures
+                self.destroy_calls = 0
+
+            def disconnect(self, timeout: float) -> None:
+                assert timeout == 30.0
+                if self.failures:
+                    self.failures -= 1
+                    raise RuntimeError("gateway disconnect failed")
+                self.pair_name = None
+
+            def destroy(self, *, raise_on_error: bool) -> None:
+                assert raise_on_error
+                self.destroy_calls += 1
+
+        active = FakeWeightController("active", failures=1)
+        stale_a = FakeWeightController("stale-a", failures=1)
+        stale_b = FakeWeightController("stale-b", failures=0)
+
+        with patch.object(
+            controller,
+            "_direct_teardown_weight_update_pair",
+            return_value=True,
+        ) as direct_teardown:
+            unresolved = controller._teardown_weight_update_controllers(
+                [active, stale_a, stale_b]
+            )
+            repeated = controller._teardown_weight_update_controllers(
+                [active, stale_a, stale_b]
+            )
+
+        assert unresolved == repeated == []
+        assert [item.args[0] for item in direct_teardown.call_args_list] == [
+            "active",
+            "stale-a",
+        ]
+        assert all(item.destroy_calls == 2 for item in (active, stale_a, stale_b))
+
+    def test_direct_shutdown_fallback_sends_pair_json_to_all_endpoints(self):
+        controller = _make_controller()
+        calls = []
+
+        class FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def post(self, url, json):
+                calls.append((url, json))
+                return FakeResponse()
+
+        with patch(f"{MODULE}.aiohttp.ClientSession", FakeSession):
+            assert controller._direct_teardown_weight_update_pair(
+                "pair-a",
+                ["http://train-0"],
+                ["http://infer-0", "http://infer-1"],
+            )
+
+        assert calls == [
+            ("http://train-0/awex/teardown", {"pair_name": "pair-a"}),
+            ("http://infer-0/awex/teardown", {"pair_name": "pair-a"}),
+            ("http://infer-1/awex/teardown", {"pair_name": "pair-a"}),
+        ]
+
+    def test_destroy_keeps_workers_alive_until_stale_pair_cleanup_succeeds(self):
+        controller = _make_controller()
+        stale = MagicMock()
+        stale.pair_name = "stale"
+        stale.train_worker_urls = ["http://train"]
+        stale.inference_worker_urls = ["http://infer"]
+        attempts = 0
+
+        def disconnect(*, timeout):
+            nonlocal attempts
+            assert timeout == 30.0
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("busy")
+            stale.pair_name = None
+
+        stale.disconnect.side_effect = disconnect
+        controller._weight_update_ctrl = stale
+        controller._cleanup_runtime_state = MagicMock()
+
+        with patch.object(
+            controller,
+            "_direct_teardown_weight_update_pair",
+            return_value=False,
+        ):
+            controller.destroy()
+
+        controller._cleanup_runtime_state.assert_not_called()
+        assert controller._stale_weight_update_ctrls == [stale]
+
+        controller.destroy()
+
+        controller._cleanup_runtime_state.assert_called_once_with()

--- a/tests/v2/weight_update/test_awex_lifecycle.py
+++ b/tests/v2/weight_update/test_awex_lifecycle.py
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
+import flask
+import httpx
 import pytest
-from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from areal.v2.inference_service.sglang.awex import register_awex_endpoints
+from areal.v2.training_service.worker.awex import create_awex_blueprint
 from areal.v2.weight_update.awex import megatron_adapter, sglang_adapter
-from areal.v2.weight_update.awex.state import SGLangColocatePairState
 from areal.v2.weight_update.gateway import app as gateway_app
 from areal.v2.weight_update.gateway.config import WeightUpdateConfig
 
@@ -18,6 +19,7 @@ ADMIN_HEADERS = {"Authorization": "Bearer test-key"}
 PAIR_NAME = "actor-rollout-v1"
 CONNECT_BODY = {
     "pair_name": PAIR_NAME,
+    "operation_id": "connect-op-1",
     "train_worker_urls": ["http://train-0", "http://train-1"],
     "inference_worker_urls": ["http://infer-0", "http://infer-1"],
     "mode": "awex",
@@ -33,8 +35,7 @@ def _install_gateway_rpc_stubs(
     *,
     fail_init_url: str | None = None,
 ):
-    calls: list[tuple[str, dict | None]] = []
-    state = {"fail_teardown": False, "fail_update": False}
+    state = {"fail_teardown": False}
 
     async def fake_get_json(_session, _url, _timeout_s):
         return {"world_size": 1}
@@ -43,18 +44,16 @@ def _install_gateway_rpc_stubs(
         return {"result": []}
 
     async def fake_post(_session, url, _timeout_s, json_data=None):
-        calls.append((url, json_data))
         if fail_init_url is not None and url == fail_init_url:
             raise RuntimeError("partial init failed")
         if state["fail_teardown"] and url.endswith("/awex/teardown"):
             raise RuntimeError("teardown failed")
-        if state["fail_update"] and url.endswith("/awex/update_weights"):
-            raise RuntimeError("inference rank wrote a partial payload")
 
     monkeypatch.setattr(gateway_app, "_get_json", fake_get_json)
     monkeypatch.setattr(gateway_app, "_post_json", fake_post_json)
     monkeypatch.setattr(gateway_app, "_post", fake_post)
-    return calls, state
+    monkeypatch.setattr(gateway_app, "_post_once", fake_post)
+    return state
 
 
 def _create_gateway_client(*, raise_server_exceptions: bool = True):
@@ -68,8 +67,32 @@ def _create_gateway_client(*, raise_server_exceptions: bool = True):
     return app, TestClient(app, raise_server_exceptions=raise_server_exceptions)
 
 
+def _create_training_worker(monkeypatch):
+    queued = []
+    adapter = MagicMock()
+    factory = MagicMock(return_value=adapter)
+
+    def run_endpoint(_name, submitter, **_kwargs):
+        submitter()
+        return flask.jsonify({"status": "ok"})
+
+    monkeypatch.setattr(
+        "areal.v2.training_service.worker.awex._create_training_adapter", factory
+    )
+    app = flask.Flask(__name__)
+    app.register_blueprint(
+        create_awex_blueprint(
+            flask_module=flask,
+            get_engine=lambda: MagicMock(),
+            submit_to_engine_thread=lambda _name, action: queued.append(action),
+            run_endpoint=run_endpoint,
+        )
+    )
+    return app.test_client(), queued, factory, adapter
+
+
 def test_partial_connect_rollback_keeps_bookkeeping_until_retry(monkeypatch):
-    _, state = _install_gateway_rpc_stubs(
+    state = _install_gateway_rpc_stubs(
         monkeypatch,
         fail_init_url="http://infer-1/awex/init_weights_update_group",
     )
@@ -96,71 +119,244 @@ def test_partial_connect_rollback_keeps_bookkeeping_until_retry(monkeypatch):
     assert app.state.kv_store.get(PAIR_NAME, "training_params_meta") is None
 
 
-def test_disconnect_tears_down_all_workers_and_is_idempotent(monkeypatch):
-    calls, _ = _install_gateway_rpc_stubs(monkeypatch)
-    app, client = _create_gateway_client()
+@pytest.mark.asyncio
+async def test_disconnect_invalidates_blocked_connect_before_publish(monkeypatch):
+    init_started = asyncio.Event()
+    release_init = asyncio.Event()
+    teardown_calls = []
 
-    with client:
-        assert (
-            client.post(
-                "/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS
-            ).status_code
-            == 200
-        )
-        first = client.post(
-            "/disconnect", json={"pair_name": PAIR_NAME}, headers=ADMIN_HEADERS
-        )
-        second = client.post(
-            "/disconnect", json={"pair_name": PAIR_NAME}, headers=ADMIN_HEADERS
-        )
+    async def fake_get_json(_session, _url, _timeout_s):
+        return {"world_size": 1}
 
-    assert first.status_code == second.status_code == 200
-    teardown_calls = {
-        (url, payload["pair_name"])
-        for url, payload in calls
-        if url.endswith("/awex/teardown") and payload is not None
-    }
-    assert teardown_calls == {
-        ("http://train-0/awex/teardown", PAIR_NAME),
-        ("http://train-1/awex/teardown", PAIR_NAME),
-        ("http://infer-0/awex/teardown", PAIR_NAME),
-        ("http://infer-1/awex/teardown", PAIR_NAME),
-    }
-    assert app.state.registry.get_by_name(PAIR_NAME) is None
-    process_group_timeouts = [
-        payload["process_group_timeout_s"]
-        for url, payload in calls
-        if "/awex/init_" in url and payload is not None
-    ]
-    assert process_group_timeouts
-    assert all(
-        0 < timeout < CONNECT_BODY["setup_timeout_s"]
-        for timeout in process_group_timeouts
+    async def fake_post_json(_session, _url, _timeout_s, json_data=None):
+        return {"result": []}
+
+    async def fake_post_once(_session, url, _timeout_s, json_data=None):
+        if url.endswith("/init_weights_update_group"):
+            init_started.set()
+            await release_init.wait()
+        elif url.endswith("/teardown"):
+            teardown_calls.append((url, json_data))
+
+    monkeypatch.setattr(gateway_app, "_get_json", fake_get_json)
+    monkeypatch.setattr(gateway_app, "_post_json", fake_post_json)
+    monkeypatch.setattr(gateway_app, "_post_once", fake_post_once)
+    app = gateway_app.create_app(
+        WeightUpdateConfig(admin_api_key="test-key", init_timeout_s=5)
     )
-
-
-def test_partial_transfer_error_is_marked_unsafe_via_worker_rpc(monkeypatch):
-    _, state = _install_gateway_rpc_stubs(monkeypatch)
-    app, client = _create_gateway_client()
-
-    with client:
-        assert (
-            client.post(
-                "/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS
-            ).status_code
-            == 200
+    app.state.http_session = object()
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        connect_task = asyncio.create_task(
+            client.post("/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS)
         )
-        state["fail_update"] = True
-        response = client.post(
-            "/update_weights",
-            json={"pair_name": PAIR_NAME, "version": 1},
+        await asyncio.wait_for(init_started.wait(), timeout=1)
+        disconnect_task = asyncio.create_task(
+            client.post(
+                "/disconnect",
+                json={
+                    "pair_name": PAIR_NAME,
+                    "operation_id": CONNECT_BODY["operation_id"],
+                    "timeout_s": 2.0,
+                },
+                headers=ADMIN_HEADERS,
+            )
+        )
+        for _ in range(100):
+            pair = app.state.registry.get_by_name(PAIR_NAME)
+            if pair is not None and pair.status == "cleanup_pending":
+                break
+            await asyncio.sleep(0.01)
+        assert app.state.registry.get_by_name(PAIR_NAME).status == "cleanup_pending"
+        release_init.set()
+        connect_response, disconnect_response = await asyncio.gather(
+            connect_task, disconnect_task
+        )
+
+    assert connect_response.status_code == 500
+    assert disconnect_response.status_code == 200
+    assert app.state.registry.get_by_name(PAIR_NAME) is None
+    assert teardown_calls
+
+
+@pytest.mark.asyncio
+async def test_cancelled_disconnect_preserves_inflight_operation(monkeypatch):
+    update_started = asyncio.Event()
+    release_update = asyncio.Event()
+    teardown_calls = []
+
+    async def fake_get_json(_session, _url, _timeout_s):
+        return {"world_size": 1}
+
+    async def fake_post_json(_session, _url, _timeout_s, json_data=None):
+        return {"result": []}
+
+    async def fake_post_once(_session, url, _timeout_s, json_data=None):
+        if url.endswith("/update_weights"):
+            update_started.set()
+            await release_update.wait()
+        elif url.endswith("/teardown"):
+            teardown_calls.append((url, json_data))
+
+    monkeypatch.setattr(gateway_app, "_get_json", fake_get_json)
+    monkeypatch.setattr(gateway_app, "_post_json", fake_post_json)
+    monkeypatch.setattr(gateway_app, "_post_once", fake_post_once)
+    app = gateway_app.create_app(WeightUpdateConfig(admin_api_key="test-key"))
+    app.state.http_session = object()
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        assert (
+            await client.post("/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS)
+        ).is_success
+        update = asyncio.create_task(
+            client.post(
+                "/update_weights",
+                json={"pair_name": PAIR_NAME, "version": 1},
+                headers=ADMIN_HEADERS,
+            )
+        )
+        await asyncio.wait_for(update_started.wait(), timeout=1)
+        disconnect = asyncio.create_task(
+            client.post(
+                "/disconnect",
+                json={"pair_name": PAIR_NAME, "timeout_s": 2.0},
+                headers=ADMIN_HEADERS,
+            )
+        )
+        for _ in range(100):
+            pair = app.state.registry.get_by_name(PAIR_NAME)
+            if pair is not None and pair.status == "cleanup_pending":
+                break
+            await asyncio.sleep(0.01)
+
+        disconnect.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await disconnect
+
+        assert not teardown_calls
+        assert app.state.registry.get_by_name(PAIR_NAME) is pair
+        assert pair.status == "cleanup_pending"
+        assert PAIR_NAME in app.state.operations
+        assert app.state.kv_store.get(PAIR_NAME, "training_params_meta") == []
+
+        release_update.set()
+        update_response = await update
+        assert update_response.json()["status"] == "error"
+        retried = await client.post(
+            "/disconnect",
+            json={"pair_name": PAIR_NAME, "timeout_s": 2.0},
             headers=ADMIN_HEADERS,
         )
 
+    assert retried.is_success
+    assert teardown_calls
+    assert app.state.registry.get_by_name(PAIR_NAME) is None
+    assert PAIR_NAME not in app.state.operations
+
+
+@pytest.mark.asyncio
+async def test_disconnect_waits_for_all_dispatched_update_requests(monkeypatch):
+    blocked = asyncio.Event()
+    release = asyncio.Event()
+    teardown_started = asyncio.Event()
+
+    async def fake_get_json(_session, _url, _timeout_s):
+        return {"world_size": 1}
+
+    async def fake_post_json(_session, _url, _timeout_s, json_data=None):
+        return {"result": []}
+
+    async def fake_post_once(_session, url, _timeout_s, json_data=None):
+        if url == "http://train-0/awex/update_weights":
+            raise RuntimeError("rank failed")
+        if url.endswith("/update_weights"):
+            blocked.set()
+            await release.wait()
+        if url.endswith("/teardown"):
+            teardown_started.set()
+
+    monkeypatch.setattr(gateway_app, "_get_json", fake_get_json)
+    monkeypatch.setattr(gateway_app, "_post_json", fake_post_json)
+    monkeypatch.setattr(gateway_app, "_post_once", fake_post_once)
+    app = gateway_app.create_app(WeightUpdateConfig(admin_api_key="test-key"))
+    app.state.http_session = object()
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        assert (
+            await client.post("/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS)
+        ).is_success
+        update = asyncio.create_task(
+            client.post(
+                "/update_weights",
+                json={"pair_name": PAIR_NAME, "version": 1},
+                headers=ADMIN_HEADERS,
+            )
+        )
+        await asyncio.wait_for(blocked.wait(), timeout=1)
+        disconnect = asyncio.create_task(
+            client.post(
+                "/disconnect",
+                json={"pair_name": PAIR_NAME, "timeout_s": 2.0},
+                headers=ADMIN_HEADERS,
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert not teardown_started.is_set()
+        release.set()
+        update_response, disconnect_response = await asyncio.gather(update, disconnect)
+
+    assert update_response.json()["status"] == "error"
+    assert disconnect_response.is_success
+    assert teardown_started.is_set()
+
+
+def test_training_worker_teardown_tombstone_blocks_queued_init(monkeypatch):
+    client, queued, adapter_factory, _ = _create_training_worker(monkeypatch)
+    init = {
+        "pair_name": PAIR_NAME,
+        "operation_id": "late-op",
+        "operation_ttl_s": 30.0,
+    }
+    assert client.post("/awex/init_weights_update_group", json=init).status_code == 200
+    assert (
+        client.post(
+            "/awex/teardown",
+            json={"pair_name": PAIR_NAME, "operation_id": "late-op"},
+        ).status_code
+        == 200
+    )
+
+    with pytest.raises(RuntimeError, match="was cancelled"):
+        queued[0]()
+    queued[1]()
+    assert client.post("/awex/init_weights_update_group", json=init).status_code == 200
+    with pytest.raises(RuntimeError, match="was cancelled"):
+        queued[2]()
+    adapter_factory.assert_not_called()
+
+
+def test_training_worker_deducts_queue_time_from_pg_timeout(monkeypatch):
+    client, queued, _, adapter = _create_training_worker(monkeypatch)
+    clock = iter([100.0, 104.0])
+    monkeypatch.setattr(
+        "areal.v2.training_service.worker.awex.time.monotonic", lambda: next(clock)
+    )
+
+    response = client.post(
+        "/awex/init_weights_update_group",
+        json={
+            "pair_name": PAIR_NAME,
+            "operation_id": "queued-op",
+            "operation_ttl_s": 10.0,
+            "process_group_timeout_s": 9.0,
+        },
+    )
     assert response.status_code == 200
-    assert response.json()["status"] == "error"
-    assert response.json()["inference_weights_may_be_mutated"] is True
-    assert app.state.registry.get_by_name(PAIR_NAME).last_version == 0
+    queued[0]()
+
+    assert adapter.init_weight_update_group.call_args.kwargs[
+        "process_group_timeout_s"
+    ] == pytest.approx(6.0)
 
 
 @pytest.mark.parametrize(
@@ -219,64 +415,3 @@ def test_candidate_init_failure_retains_group_until_teardown_retry(
     adapter.teardown_weight_update_group(PAIR_NAME)
     assert PAIR_NAME not in adapter._pair_states
     assert destroy.call_args_list == [call(payload_group), call(payload_group)]
-
-
-def test_sglang_colocate_teardown_retries_failed_transport(monkeypatch):
-    adapter = sglang_adapter.AwexSGLangAdapter(MagicMock())
-    group = MagicMock(name="colocate_group")
-    client = MagicMock(name="http_client")
-    transport = MagicMock(name="transport")
-    transport.close.side_effect = [RuntimeError("transport busy"), None]
-    adapter._colocate_pair_states[PAIR_NAME] = SGLangColocatePairState(
-        weights_update_group=group,
-        transfer_rank=0,
-        kv_store_url="http://kv-store",
-        infer_world_size=1,
-        train_world_size=1,
-        admin_api_key="test-key",
-        timeout_s=5.0,
-        http_client=client,
-        transport=transport,
-        train_to_infer_device_mapping={1: 0},
-        infer_to_train_device_mapping={0: 1},
-        send_transfer_plan=MagicMock(),
-        recv_transfer_plan=MagicMock(),
-    )
-    monkeypatch.setattr(sglang_adapter.dist, "is_initialized", lambda: True)
-    monkeypatch.setattr(sglang_adapter.dist, "destroy_process_group", MagicMock())
-
-    with pytest.raises(RuntimeError, match="Failed to teardown"):
-        adapter.teardown_weight_update_group(PAIR_NAME)
-
-    state = adapter._colocate_pair_states[PAIR_NAME]
-    assert state.weights_update_group is None
-    assert state.http_client is None
-    assert state.transport is transport
-
-    with pytest.raises(RuntimeError, match="partially initialized"):
-        adapter.init_colocate_weight_update(
-            pair_name=PAIR_NAME,
-            kv_store_url="http://kv-store",
-            transfer_rank=0,
-            infer_world_size=1,
-            train_world_size=1,
-            num_engines=1,
-            master_port=29500,
-        )
-
-    adapter.teardown_weight_update_group(PAIR_NAME)
-    assert PAIR_NAME not in adapter._colocate_pair_states
-
-
-def test_inference_teardown_endpoint_dispatches_collectively():
-    app = FastAPI()
-    rpc_proxy = MagicMock()
-    register_awex_endpoints(app, rpc_proxy)
-
-    response = TestClient(app).post("/awex/teardown", json={"pair_name": PAIR_NAME})
-
-    assert response.status_code == 200
-    rpc_proxy.collective_rpc.assert_called_once_with(
-        "awex_teardown_weight_update_group",
-        pair_name=PAIR_NAME,
-    )

--- a/tests/v2/weight_update/test_awex_lifecycle.py
+++ b/tests/v2/weight_update/test_awex_lifecycle.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from areal.v2.inference_service.sglang.awex import register_awex_endpoints
+from areal.v2.weight_update.awex import megatron_adapter, sglang_adapter
+from areal.v2.weight_update.awex.state import SGLangColocatePairState
+from areal.v2.weight_update.gateway import app as gateway_app
+from areal.v2.weight_update.gateway.config import WeightUpdateConfig
+
+ADMIN_HEADERS = {"Authorization": "Bearer test-key"}
+PAIR_NAME = "actor-rollout-v1"
+CONNECT_BODY = {
+    "pair_name": PAIR_NAME,
+    "train_worker_urls": ["http://train-0", "http://train-1"],
+    "inference_worker_urls": ["http://infer-0", "http://infer-1"],
+    "mode": "awex",
+    "nccl_master_addr": "127.0.0.1",
+    "nccl_master_port": 29500,
+    "setup_timeout_s": 5.0,
+    "rollback_timeout_s": 1.0,
+}
+
+
+def _install_gateway_rpc_stubs(
+    monkeypatch,
+    *,
+    fail_init_url: str | None = None,
+):
+    calls: list[tuple[str, dict | None]] = []
+    state = {"fail_teardown": False, "fail_update": False}
+
+    async def fake_get_json(_session, _url, _timeout_s):
+        return {"world_size": 1}
+
+    async def fake_post_json(_session, _url, _timeout_s, json_data=None):
+        return {"result": []}
+
+    async def fake_post(_session, url, _timeout_s, json_data=None):
+        calls.append((url, json_data))
+        if fail_init_url is not None and url == fail_init_url:
+            raise RuntimeError("partial init failed")
+        if state["fail_teardown"] and url.endswith("/awex/teardown"):
+            raise RuntimeError("teardown failed")
+        if state["fail_update"] and url.endswith("/awex/update_weights"):
+            raise RuntimeError("inference rank wrote a partial payload")
+
+    monkeypatch.setattr(gateway_app, "_get_json", fake_get_json)
+    monkeypatch.setattr(gateway_app, "_post_json", fake_post_json)
+    monkeypatch.setattr(gateway_app, "_post", fake_post)
+    return calls, state
+
+
+def _create_gateway_client(*, raise_server_exceptions: bool = True):
+    app = gateway_app.create_app(
+        WeightUpdateConfig(
+            admin_api_key="test-key",
+            init_timeout_s=5,
+            update_timeout_s=5,
+        )
+    )
+    return app, TestClient(app, raise_server_exceptions=raise_server_exceptions)
+
+
+def test_partial_connect_rollback_keeps_bookkeeping_until_retry(monkeypatch):
+    _, state = _install_gateway_rpc_stubs(
+        monkeypatch,
+        fail_init_url="http://infer-1/awex/init_weights_update_group",
+    )
+    state["fail_teardown"] = True
+    app, client = _create_gateway_client(raise_server_exceptions=False)
+
+    with client:
+        response = client.post("/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS)
+        pair_info = app.state.registry.get_by_name(PAIR_NAME)
+        assert response.status_code == 500
+        assert pair_info is not None
+        assert pair_info.status == "cleanup_pending"
+        assert app.state.kv_store.get(PAIR_NAME, "training_params_meta") == []
+
+        state["fail_teardown"] = False
+        retried = client.post(
+            "/disconnect",
+            json={"pair_name": PAIR_NAME},
+            headers=ADMIN_HEADERS,
+        )
+
+    assert retried.status_code == 200
+    assert app.state.registry.get_by_name(PAIR_NAME) is None
+    assert app.state.kv_store.get(PAIR_NAME, "training_params_meta") is None
+
+
+def test_disconnect_tears_down_all_workers_and_is_idempotent(monkeypatch):
+    calls, _ = _install_gateway_rpc_stubs(monkeypatch)
+    app, client = _create_gateway_client()
+
+    with client:
+        assert (
+            client.post(
+                "/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS
+            ).status_code
+            == 200
+        )
+        first = client.post(
+            "/disconnect", json={"pair_name": PAIR_NAME}, headers=ADMIN_HEADERS
+        )
+        second = client.post(
+            "/disconnect", json={"pair_name": PAIR_NAME}, headers=ADMIN_HEADERS
+        )
+
+    assert first.status_code == second.status_code == 200
+    teardown_calls = {
+        (url, payload["pair_name"])
+        for url, payload in calls
+        if url.endswith("/awex/teardown") and payload is not None
+    }
+    assert teardown_calls == {
+        ("http://train-0/awex/teardown", PAIR_NAME),
+        ("http://train-1/awex/teardown", PAIR_NAME),
+        ("http://infer-0/awex/teardown", PAIR_NAME),
+        ("http://infer-1/awex/teardown", PAIR_NAME),
+    }
+    assert app.state.registry.get_by_name(PAIR_NAME) is None
+    process_group_timeouts = [
+        payload["process_group_timeout_s"]
+        for url, payload in calls
+        if "/awex/init_" in url and payload is not None
+    ]
+    assert process_group_timeouts
+    assert all(
+        0 < timeout < CONNECT_BODY["setup_timeout_s"]
+        for timeout in process_group_timeouts
+    )
+
+
+def test_partial_transfer_error_is_marked_unsafe_via_worker_rpc(monkeypatch):
+    _, state = _install_gateway_rpc_stubs(monkeypatch)
+    app, client = _create_gateway_client()
+
+    with client:
+        assert (
+            client.post(
+                "/connect", json=CONNECT_BODY, headers=ADMIN_HEADERS
+            ).status_code
+            == 200
+        )
+        state["fail_update"] = True
+        response = client.post(
+            "/update_weights",
+            json={"pair_name": PAIR_NAME, "version": 1},
+            headers=ADMIN_HEADERS,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "error"
+    assert response.json()["inference_weights_may_be_mutated"] is True
+    assert app.state.registry.get_by_name(PAIR_NAME).last_version == 0
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "module", "adapter_setup"),
+    [
+        (
+            megatron_adapter.AwexMegatronAdapter,
+            megatron_adapter,
+            lambda adapter: None,
+        ),
+        (
+            sglang_adapter.AwexSGLangAdapter,
+            sglang_adapter,
+            lambda adapter: setattr(
+                adapter,
+                "_get_model_context",
+                lambda: {"tp_size": 1, "tp_rank": 0, "pp_size": 1, "pp_rank": 0},
+            ),
+        ),
+    ],
+)
+def test_candidate_init_failure_retains_group_until_teardown_retry(
+    adapter_cls, module, adapter_setup, monkeypatch
+):
+    adapter = adapter_cls(MagicMock())
+    adapter._dte_config = SimpleNamespace(enabled=False)
+    adapter_setup(adapter)
+    payload_group = MagicMock(name="payload_group")
+    initializer = MagicMock(side_effect=[payload_group, RuntimeError("gloo failed")])
+    destroy = MagicMock(side_effect=[RuntimeError("first destroy failed"), None])
+
+    monkeypatch.setattr(
+        module, "fetch_kv_metadata", lambda *args, **kwargs: (MagicMock(), MagicMock())
+    )
+    builder = MagicMock()
+    builder.build_local_transfer_plan.return_value = MagicMock()
+    monkeypatch.setattr(module, "TransferPlanBuilder", lambda **kwargs: builder)
+    monkeypatch.setattr(module, "init_weights_update_group", initializer)
+    monkeypatch.setattr(module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(module.dist, "destroy_process_group", destroy)
+
+    with pytest.raises(RuntimeError, match="gloo failed"):
+        adapter.init_weight_update_group(
+            pair_name=PAIR_NAME,
+            master_addr="127.0.0.1",
+            master_port=29500,
+            transfer_rank=1,
+            world_size=2,
+            kv_store_url="http://kv-store",
+            infer_world_size=1,
+            train_world_size=1,
+            num_engines=1,
+        )
+
+    assert adapter._pair_states[PAIR_NAME].weights_update_group is payload_group
+    adapter.teardown_weight_update_group(PAIR_NAME)
+    assert PAIR_NAME not in adapter._pair_states
+    assert destroy.call_args_list == [call(payload_group), call(payload_group)]
+
+
+def test_sglang_colocate_teardown_retries_failed_transport(monkeypatch):
+    adapter = sglang_adapter.AwexSGLangAdapter(MagicMock())
+    group = MagicMock(name="colocate_group")
+    client = MagicMock(name="http_client")
+    transport = MagicMock(name="transport")
+    transport.close.side_effect = [RuntimeError("transport busy"), None]
+    adapter._colocate_pair_states[PAIR_NAME] = SGLangColocatePairState(
+        weights_update_group=group,
+        transfer_rank=0,
+        kv_store_url="http://kv-store",
+        infer_world_size=1,
+        train_world_size=1,
+        admin_api_key="test-key",
+        timeout_s=5.0,
+        http_client=client,
+        transport=transport,
+        train_to_infer_device_mapping={1: 0},
+        infer_to_train_device_mapping={0: 1},
+        send_transfer_plan=MagicMock(),
+        recv_transfer_plan=MagicMock(),
+    )
+    monkeypatch.setattr(sglang_adapter.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(sglang_adapter.dist, "destroy_process_group", MagicMock())
+
+    with pytest.raises(RuntimeError, match="Failed to teardown"):
+        adapter.teardown_weight_update_group(PAIR_NAME)
+
+    state = adapter._colocate_pair_states[PAIR_NAME]
+    assert state.weights_update_group is None
+    assert state.http_client is None
+    assert state.transport is transport
+
+    with pytest.raises(RuntimeError, match="partially initialized"):
+        adapter.init_colocate_weight_update(
+            pair_name=PAIR_NAME,
+            kv_store_url="http://kv-store",
+            transfer_rank=0,
+            infer_world_size=1,
+            train_world_size=1,
+            num_engines=1,
+            master_port=29500,
+        )
+
+    adapter.teardown_weight_update_group(PAIR_NAME)
+    assert PAIR_NAME not in adapter._colocate_pair_states
+
+
+def test_inference_teardown_endpoint_dispatches_collectively():
+    app = FastAPI()
+    rpc_proxy = MagicMock()
+    register_awex_endpoints(app, rpc_proxy)
+
+    response = TestClient(app).post("/awex/teardown", json={"pair_name": PAIR_NAME})
+
+    assert response.status_code == 200
+    rpc_proxy.collective_rpc.assert_called_once_with(
+        "awex_teardown_weight_update_group",
+        pair_name=PAIR_NAME,
+    )

--- a/tests/v2/weight_update/test_nccl_group.py
+++ b/tests/v2/weight_update/test_nccl_group.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -7,6 +9,27 @@ import torch
 
 from areal.v2.weight_update import nccl_group
 from areal.v2.weight_update.awex import fsdp_adapter, megatron_adapter, sglang_adapter
+from areal.v2.weight_update.awex.state import AwexPairState
+
+PAIR_NAME = "test-pair"
+
+
+def _install_pair_state(adapter, payload_group, sidecar_group, transfer_rank):
+    if isinstance(adapter, fsdp_adapter.AwexFSDPAdapter):
+        adapter._pair_states[PAIR_NAME] = AwexPairState(
+            payload_group,
+            sidecar_group,
+            MagicMock(),
+            transfer_rank,
+        )
+        return
+
+    adapter._active_pair_name = PAIR_NAME
+    adapter._transfer_plan = MagicMock()
+    adapter._weights_update_group = payload_group
+    adapter._weights_update_group_gloo = sidecar_group
+    adapter._transfer_rank = transfer_rank
+    adapter._dte_config = SimpleNamespace(enabled=False)
 
 
 def test_setup_batch_isend_irecv_uses_sidecar_for_final_barrier(monkeypatch):
@@ -53,6 +76,58 @@ def test_setup_batch_isend_irecv_defaults_to_payload_group(monkeypatch):
     barrier.assert_called_once_with(group=process_group, device_ids=[0])
 
 
+def test_process_group_timeout_is_forwarded_as_timedelta(monkeypatch):
+    group = MagicMock()
+    init_group = MagicMock(return_value=group)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(nccl_group, "init_custom_process_group", init_group)
+
+    result = nccl_group.init_weights_update_group(
+        "127.0.0.1",
+        29500,
+        rank=0,
+        world_size=1,
+        group_name="timeout-test",
+        timeout_s=2.5,
+    )
+
+    assert result is group
+    assert init_group.call_args.kwargs["timeout"] == timedelta(seconds=2.5)
+
+
+def test_adapter_uses_decreasing_setup_budget(monkeypatch):
+    adapter = fsdp_adapter.AwexFSDPAdapter(MagicMock())
+    builder = MagicMock()
+    builder.build_local_transfer_plan.return_value = MagicMock()
+    metadata = MagicMock(return_value=(MagicMock(), MagicMock()))
+    initializer = MagicMock(side_effect=[MagicMock(), MagicMock()])
+    clock = iter([100.0, 101.0, 102.0, 103.0])
+
+    monkeypatch.setattr(fsdp_adapter.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(fsdp_adapter, "fetch_kv_metadata", metadata)
+    monkeypatch.setattr(fsdp_adapter, "TransferPlanBuilder", lambda **kwargs: builder)
+    monkeypatch.setattr(fsdp_adapter, "init_weights_update_group", initializer)
+
+    adapter.init_weight_update_group(
+        pair_name=PAIR_NAME,
+        master_addr="127.0.0.1",
+        master_port=29500,
+        transfer_rank=0,
+        world_size=2,
+        kv_store_url="http://kv-store",
+        infer_world_size=1,
+        train_world_size=1,
+        num_engines=1,
+        process_group_timeout_s=10.0,
+    )
+
+    metadata.assert_called_once_with("http://kv-store", PAIR_NAME, timeout_s=9.0)
+    assert [item.kwargs["timeout_s"] for item in initializer.call_args_list] == [
+        8.0,
+        7.0,
+    ]
+
+
 def test_megatron_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
     """The training adapter creates matching payload and sidecar groups."""
     adapter = megatron_adapter.AwexMegatronAdapter(MagicMock())
@@ -61,7 +136,9 @@ def test_megatron_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
     initializer = MagicMock(side_effect=[MagicMock(), MagicMock()])
 
     monkeypatch.setattr(
-        megatron_adapter, "fetch_kv_metadata", lambda *args: (MagicMock(), MagicMock())
+        megatron_adapter,
+        "fetch_kv_metadata",
+        lambda *args, **kwargs: (MagicMock(), MagicMock()),
     )
     monkeypatch.setattr(
         megatron_adapter, "TransferPlanBuilder", lambda **kwargs: builder
@@ -88,6 +165,7 @@ def test_megatron_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
             world_size=4,
             group_name="awex_actor-rollout",
             role="training",
+            timeout_s=None,
         ),
         call(
             master_address="127.0.0.1",
@@ -97,6 +175,7 @@ def test_megatron_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
             group_name="awex_actor-rollout_gloo",
             backend="gloo",
             role="training",
+            timeout_s=None,
         ),
     ]
 
@@ -109,7 +188,9 @@ def test_fsdp_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
     initializer = MagicMock(side_effect=[MagicMock(), MagicMock()])
 
     monkeypatch.setattr(
-        fsdp_adapter, "fetch_kv_metadata", lambda *args: (MagicMock(), MagicMock())
+        fsdp_adapter,
+        "fetch_kv_metadata",
+        lambda *args, **kwargs: (MagicMock(), MagicMock()),
     )
     monkeypatch.setattr(fsdp_adapter, "TransferPlanBuilder", lambda **kwargs: builder)
     monkeypatch.setattr(fsdp_adapter, "init_weights_update_group", initializer)
@@ -134,6 +215,7 @@ def test_fsdp_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
             world_size=4,
             group_name="awex_actor-rollout",
             role="training",
+            timeout_s=None,
         ),
         call(
             master_address="127.0.0.1",
@@ -143,6 +225,7 @@ def test_fsdp_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
             group_name="awex_actor-rollout_gloo",
             backend="gloo",
             role="training",
+            timeout_s=None,
         ),
     ]
 
@@ -160,7 +243,9 @@ def test_sglang_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
         lambda: {"tp_size": 1, "tp_rank": 0, "pp_size": 1, "pp_rank": 0},
     )
     monkeypatch.setattr(
-        sglang_adapter, "fetch_kv_metadata", lambda *args: (MagicMock(), MagicMock())
+        sglang_adapter,
+        "fetch_kv_metadata",
+        lambda *args, **kwargs: (MagicMock(), MagicMock()),
     )
     monkeypatch.setattr(sglang_adapter, "TransferPlanBuilder", lambda **kwargs: builder)
     monkeypatch.setattr(sglang_adapter, "init_weights_update_group", initializer)
@@ -185,6 +270,7 @@ def test_sglang_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
             world_size=4,
             group_name="awex_actor-rollout",
             role="inference",
+            timeout_s=None,
         ),
         call(
             master_address="127.0.0.1",
@@ -194,6 +280,7 @@ def test_sglang_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
             group_name="awex_actor-rollout_gloo",
             backend="gloo",
             role="inference",
+            timeout_s=None,
         ),
     ]
 
@@ -208,16 +295,14 @@ def test_sglang_adapter_initializes_nccl_and_gloo_groups(monkeypatch):
 )
 def test_awex_adapters_use_sidecar_for_setup_barrier(adapter_cls, module, monkeypatch):
     """Both AWEX adapters retain NCCL payloads and select the Gloo barrier."""
-    adapter = object.__new__(adapter_cls)
+    adapter = adapter_cls(MagicMock())
     payload_group = MagicMock(name="nccl_group")
     sidecar_group = MagicMock(name="gloo_group")
-    adapter._weights_update_group = payload_group
-    adapter._weights_update_group_gloo = sidecar_group
-    adapter._transfer_rank = 3
+    _install_pair_state(adapter, payload_group, sidecar_group, 3)
     setup = MagicMock()
     monkeypatch.setattr(module, "setup_batch_isend_irecv", setup)
 
-    adapter.batch_isend_irecv(world_size=4)
+    adapter.batch_isend_irecv(PAIR_NAME, world_size=4)
 
     setup.assert_called_once_with(
         payload_group,
@@ -254,10 +339,7 @@ def test_awex_adapters_use_sidecar_for_completion_barrier(
     adapter = adapter_cls(MagicMock())
     payload_group = MagicMock(name="nccl_group")
     sidecar_group = MagicMock(name="gloo_group")
-    adapter._transfer_plan = MagicMock()
-    adapter._weights_update_group = payload_group
-    adapter._weights_update_group_gloo = sidecar_group
-    adapter._transfer_rank = 0
+    _install_pair_state(adapter, payload_group, sidecar_group, 0)
     adapter.get_local_shard_parameters = MagicMock(return_value={})
     monkeypatch.setattr(module, build_ops_name, lambda *args, **kwargs: ([], [], None))
     monkeypatch.setattr(module, "batch_send_recv", MagicMock())
@@ -265,7 +347,7 @@ def test_awex_adapters_use_sidecar_for_completion_barrier(
     distributed = getattr(module, "dist", module.torch.distributed)
     monkeypatch.setattr(distributed, "barrier", barrier)
 
-    adapter.execute_weight_update(version=1)
+    adapter.execute_weight_update(PAIR_NAME, version=1)
 
     barrier.assert_called_once_with(group=sidecar_group)
 
@@ -273,10 +355,12 @@ def test_awex_adapters_use_sidecar_for_completion_barrier(
 def test_sglang_synchronizes_weight_copies_before_gloo_barrier(monkeypatch):
     """The success barrier runs only after inference weights reach the device."""
     adapter = sglang_adapter.AwexSGLangAdapter(MagicMock())
-    adapter._transfer_plan = MagicMock()
-    adapter._weights_update_group = MagicMock(name="nccl_group")
-    adapter._weights_update_group_gloo = MagicMock(name="gloo_group")
-    adapter._transfer_rank = 0
+    _install_pair_state(
+        adapter,
+        MagicMock(name="nccl_group"),
+        MagicMock(name="gloo_group"),
+        0,
+    )
     adapter.get_local_shard_parameters = MagicMock(return_value={})
 
     events = []
@@ -298,7 +382,7 @@ def test_sglang_synchronizes_weight_copies_before_gloo_barrier(monkeypatch):
         lambda **kwargs: events.append("barrier"),
     )
 
-    adapter.execute_weight_update(version=1)
+    adapter.execute_weight_update(PAIR_NAME, version=1)
 
     original.copy_.assert_called_once_with(contiguous)
     assert events == ["copy", "synchronize", "barrier"]
@@ -319,18 +403,21 @@ def test_awex_adapters_destroy_payload_and_sidecar_groups(
     adapter = adapter_cls(MagicMock())
     payload_group = MagicMock(name="nccl_group")
     sidecar_group = MagicMock(name="gloo_group")
-    adapter._weights_update_group = payload_group
-    adapter._weights_update_group_gloo = sidecar_group
+    _install_pair_state(adapter, payload_group, sidecar_group, 0)
     destroy = MagicMock()
     distributed = getattr(module, "dist", module.torch.distributed)
     monkeypatch.setattr(distributed, "is_initialized", lambda: True)
     monkeypatch.setattr(distributed, "destroy_process_group", destroy)
 
-    adapter.teardown_weight_update_group()
+    adapter.teardown_weight_update_group(PAIR_NAME)
+    adapter.teardown_weight_update_group(PAIR_NAME)
 
     assert destroy.call_args_list == [call(payload_group), call(sidecar_group)]
-    assert adapter._weights_update_group is None
-    assert adapter._weights_update_group_gloo is None
+    if adapter_cls is fsdp_adapter.AwexFSDPAdapter:
+        assert PAIR_NAME not in adapter._pair_states
+    else:
+        assert adapter._weights_update_group is None
+        assert adapter._weights_update_group_gloo is None
     if adapter_cls in (
         megatron_adapter.AwexMegatronAdapter,
         sglang_adapter.AwexSGLangAdapter,

--- a/tests/v2/weight_update/test_nccl_group.py
+++ b/tests/v2/weight_update/test_nccl_group.py
@@ -423,3 +423,27 @@ def test_awex_adapters_destroy_payload_and_sidecar_groups(
         sglang_adapter.AwexSGLangAdapter,
     ):
         assert adapter._separation_wire_dtypes is None
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [megatron_adapter.AwexMegatronAdapter, sglang_adapter.AwexSGLangAdapter],
+)
+def test_parked_pair_can_be_reactivated_without_crossing_state(adapter_cls):
+    adapter = adapter_cls(MagicMock())
+    a_payload, a_control = MagicMock(), MagicMock()
+    b_payload, b_control = MagicMock(), MagicMock()
+    adapter._active_pair_name = "pair-a"
+    adapter._weights_update_group = a_payload
+    adapter._weights_update_group_gloo = a_control
+    adapter._transfer_plan = MagicMock(name="plan-a")
+    adapter._transfer_rank = 1
+    adapter._pair_states["pair-b"] = AwexPairState(
+        b_payload, b_control, MagicMock(name="plan-b"), 2
+    )
+
+    adapter._activate_pair("pair-b")
+    assert (adapter._weights_update_group, adapter._transfer_rank) == (b_payload, 2)
+    adapter._activate_pair("pair-a")
+    assert (adapter._weights_update_group, adapter._transfer_rank) == (a_payload, 1)
+    assert adapter._pair_states["pair-b"].control_group is b_control

--- a/tests/v2/weight_update/test_wu_controller.py
+++ b/tests/v2/weight_update/test_wu_controller.py
@@ -12,6 +12,7 @@ from areal.v2.weight_update.controller.config import (
 )
 from areal.v2.weight_update.controller.controller import (
     WeightUpdateController,
+    WeightUpdateError,
 )
 from areal.v2.weight_update.gateway.config import WeightUpdateResult
 
@@ -85,6 +86,8 @@ class TestConnect:
                 "colocate": False,
                 "nccl_master_addr": "",
                 "nccl_master_port": 0,
+                "setup_timeout_s": None,
+                "rollback_timeout_s": 30.0,
             },
             timeout=10.0,
         )
@@ -118,6 +121,8 @@ class TestConnect:
                 "colocate": False,
                 "nccl_master_addr": "",
                 "nccl_master_port": 0,
+                "setup_timeout_s": None,
+                "rollback_timeout_s": 30.0,
             },
             timeout=10.0,
         )
@@ -144,6 +149,41 @@ class TestUpdateWeights:
             timeout=10.0,
         )
 
+    def test_update_weights_raises_on_error_status(self, ctrl):
+        ctrl._pair_name = "pair0"
+        ctrl._session.post.return_value = _mock_response(
+            200,
+            {
+                "status": "error",
+                "version": 5,
+                "duration_ms": 12.0,
+                "error": "collective failed",
+            },
+        )
+
+        with pytest.raises(WeightUpdateError, match="collective failed") as exc_info:
+            ctrl.update_weights(version=5)
+
+        assert exc_info.value.inference_weights_may_be_mutated is True
+
+    def test_update_weights_preserves_safe_pre_mutation_status(self, ctrl):
+        ctrl._pair_name = "pair0"
+        ctrl._session.post.return_value = _mock_response(
+            200,
+            {
+                "status": "error",
+                "version": 5,
+                "duration_ms": 12.0,
+                "error": "preflight failed",
+                "inference_weights_may_be_mutated": False,
+            },
+        )
+
+        with pytest.raises(WeightUpdateError) as exc_info:
+            ctrl.update_weights(version=5)
+
+        assert exc_info.value.inference_weights_may_be_mutated is False
+
     def test_update_weights_raises_when_not_connected(self, ctrl):
         with pytest.raises(RuntimeError, match="Not connected"):
             ctrl.update_weights(version=1)
@@ -168,6 +208,16 @@ class TestDisconnect:
     def test_disconnect_noop_when_not_connected(self, ctrl):
         ctrl.disconnect()
         assert ctrl._pair_name is None
+
+    def test_disconnect_failure_preserves_pending_identity_and_endpoints(self, ctrl):
+        ctrl._session.post.return_value = _mock_response(500, {"error": "busy"})
+
+        with pytest.raises(requests.HTTPError):
+            ctrl.connect("pair0", ["http://train"], ["http://infer"])
+
+        assert ctrl.pair_name == "pair0"
+        assert ctrl.train_worker_urls == ["http://train"]
+        assert ctrl.inference_worker_urls == ["http://infer"]
 
 
 class TestLifecycle:

--- a/tests/v2/weight_update/test_wu_controller.py
+++ b/tests/v2/weight_update/test_wu_controller.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -70,12 +71,13 @@ class TestConnect:
         train_urls = ["http://train1:8000", "http://train2:8000"]
         infer_urls = ["http://infer1:8000"]
 
-        ctrl.connect("pair0", train_urls, infer_urls)
+        ctrl.connect("pair0", train_urls, infer_urls, operation_id="op-1")
 
         ctrl._session.post.assert_called_once_with(
             f"{GATEWAY_URL}/connect",
             json={
                 "pair_name": "pair0",
+                "operation_id": "op-1",
                 "train_worker_urls": train_urls,
                 "inference_worker_urls": infer_urls,
                 "mode": "awex",
@@ -105,12 +107,14 @@ class TestConnect:
             save_path="/shared/weights",
             use_lora=True,
             lora_name="my-lora",
+            operation_id="op-1",
         )
 
         ctrl._session.post.assert_called_once_with(
             f"{GATEWAY_URL}/connect",
             json={
                 "pair_name": "pair0",
+                "operation_id": "op-1",
                 "train_worker_urls": train_urls,
                 "inference_worker_urls": infer_urls,
                 "mode": "disk",
@@ -149,7 +153,8 @@ class TestUpdateWeights:
             timeout=10.0,
         )
 
-    def test_update_weights_raises_on_error_status(self, ctrl):
+    @pytest.mark.parametrize("may_be_mutated", [True, False])
+    def test_update_weights_raises_on_error_status(self, ctrl, may_be_mutated):
         ctrl._pair_name = "pair0"
         ctrl._session.post.return_value = _mock_response(
             200,
@@ -158,31 +163,14 @@ class TestUpdateWeights:
                 "version": 5,
                 "duration_ms": 12.0,
                 "error": "collective failed",
+                "inference_weights_may_be_mutated": may_be_mutated,
             },
         )
 
         with pytest.raises(WeightUpdateError, match="collective failed") as exc_info:
             ctrl.update_weights(version=5)
 
-        assert exc_info.value.inference_weights_may_be_mutated is True
-
-    def test_update_weights_preserves_safe_pre_mutation_status(self, ctrl):
-        ctrl._pair_name = "pair0"
-        ctrl._session.post.return_value = _mock_response(
-            200,
-            {
-                "status": "error",
-                "version": 5,
-                "duration_ms": 12.0,
-                "error": "preflight failed",
-                "inference_weights_may_be_mutated": False,
-            },
-        )
-
-        with pytest.raises(WeightUpdateError) as exc_info:
-            ctrl.update_weights(version=5)
-
-        assert exc_info.value.inference_weights_may_be_mutated is False
+        assert exc_info.value.inference_weights_may_be_mutated is may_be_mutated
 
     def test_update_weights_raises_when_not_connected(self, ctrl):
         with pytest.raises(RuntimeError, match="Not connected"):
@@ -192,6 +180,7 @@ class TestUpdateWeights:
 class TestDisconnect:
     def test_disconnect_clears_state(self, ctrl):
         ctrl._pair_name = "pair0"
+        ctrl._operation_id = "op-1"
         ctrl._session.post.return_value = _mock_response(
             200, {"status": "ok", "pair_name": "pair0"}
         )
@@ -201,7 +190,11 @@ class TestDisconnect:
         assert ctrl._pair_name is None
         ctrl._session.post.assert_called_once_with(
             f"{GATEWAY_URL}/disconnect",
-            json={"pair_name": "pair0"},
+            json={
+                "pair_name": "pair0",
+                "operation_id": "op-1",
+                "timeout_s": None,
+            },
             timeout=10.0,
         )
 
@@ -245,3 +238,56 @@ class TestLifecycle:
 
         with pytest.raises(requests.HTTPError):
             ctrl.update_weights(version=1)
+
+
+class TestDestroy:
+    def test_disconnect_failure_preserves_private_gateway_for_retry(self, ctrl):
+        ctrl.retain_pending_connection(
+            "pair0", "op-1", ["http://train"], ["http://infer"]
+        )
+        ctrl._gateway_proc = MagicMock(spec=subprocess.Popen)
+        session = ctrl._session
+        process = ctrl._gateway_proc
+        ctrl._session.post.side_effect = [
+            _mock_response(500, {"error": "busy"}),
+            _mock_response(200, {"status": "ok", "pair_name": "pair0"}),
+        ]
+
+        with patch.object(ctrl, "terminate_private_gateway") as terminate:
+            ctrl.destroy(timeout=1.0)
+
+            terminate.assert_not_called()
+            assert ctrl.pair_name == "pair0"
+            assert ctrl.operation_id == "op-1"
+            assert ctrl._session is session
+            assert ctrl._gateway_proc is process
+
+            ctrl.destroy(timeout=1.0)
+
+        terminate.assert_called_once()
+        assert ctrl.pair_name is None
+
+    def test_initialize_failure_terminates_without_disconnect(self):
+        ctrl = WeightUpdateController(
+            WeightUpdateControllerConfig(port=7080, setup_timeout=30.0)
+        )
+        gateway_process = MagicMock(spec=subprocess.Popen)
+
+        with (
+            patch(
+                "areal.v2.weight_update.controller.controller.subprocess.Popen",
+                return_value=gateway_process,
+            ),
+            patch.object(
+                ctrl,
+                "_wait_for_health",
+                side_effect=TimeoutError("gateway health timeout"),
+            ),
+            patch.object(ctrl, "disconnect") as disconnect,
+            patch.object(ctrl, "terminate_private_gateway") as terminate,
+            pytest.raises(TimeoutError, match="gateway health timeout"),
+        ):
+            ctrl.initialize(timeout=0.25)
+
+        disconnect.assert_not_called()
+        terminate.assert_called_once_with(timeout=0.25, raise_on_error=False)


### PR DESCRIPTION
## Summary

  This PR hardens V2 separated-device AWEX reconnect and checkpoint recovery.

  - Reconnects through a versioned candidate pair while preserving the previous active pair until  candidate setup succeeds.
  - Serializes connect, update, and disconnect operations per pair. Disconnect invalidates the active generation and waits for in-flight collective work to quiesce before teardown.
  - Propagates bounded setup deadlines through worker queues, metadata fetches, and NCCL/Gloo process-group initialization.
  - Retains partially initialized payload/control process groups, gateway registry/KV state, private  gateway processes, and port reservations until cleanup is confirmed.
  - Uses connection-scoped operation IDs and worker cancellation tombstones so delayed init requests cannot recreate process groups after rollback.
  - Cleans active, candidate, and stale pairs before destroying rollout or training runtimes, with pair-
  scoped direct worker teardown as a fallback.
  - Fails closed when pause, transfer, version publication, continue, or cleanup is incomplete.
  - Publishes the recovered version to all training and inference workers before committing controller-local versions and resuming generation.
  - Correlates SGLang ACK/result RPC messages by request ID under one bounded asynchronous transaction.

  This PR intentionally does not include deterministic rollout recovery or AWEX memory diagnostics. V2  colocated AWEX recovery remains unsupported and fails fast before recovery side effects; existing non-recovery colocated weight-update APIs remain available.

  ## Validation

  - Focused AWEX/recovery suite: 142 passed, 17 skipped.
  - Final cancellation, destroy-retry, initialization-failure, and released-token fault-injection tests: 4  passed.
  - AWEX lifecycle/controller and Guard port-related subset: 32 passed.
  - SGLang RPC tests with the SGLang image and GPU access: 4 passed.
  - vLLM-image collection check: 24 tests collected without an SGLang import failure.
  - Full `pre-commit run --all-files` passed. `uv-lock` was skipped because dependency manifests were  unchanged.
  - Python compilation and `git diff --check` passed.

  Checks attached to head `17c308bc` are green:

  - Pre-commit Checks
  - Ubuntu Python 3.12 installation
  - macOS Python 3.12 installation
  - Linux CUDA extras with SGLang
  - Linux CUDA extras with vLLM

  The Docker matrix installation job was conditionally skipped.

  Fault-injection tests use mocked process-group and transport boundaries. Real multi-GPU NCCL/Gloo and  end-to-end checkpoint recovery were not run locally.

  Supersedes #1590.