### PR TITLE
fix(infra): bind forked workers to reserved ports

### DIFF
--- a/areal/infra/data_service/controller/controller.py
+++ b/areal/infra/data_service/controller/controller.py
@@ -497,7 +497,7 @@ class DataController:
     ) -> tuple[str, int]:
         async with session.post(
             f"{guard_addr}/alloc_ports",
-            json={"count": 1},
+            json={"count": 1, "role": role, "worker_index": worker_index},
             timeout=aiohttp.ClientTimeout(total=10),
         ) as resp:
             resp.raise_for_status()
@@ -507,21 +507,33 @@ class DataController:
 
         cmd = list(raw_cmd) + ["--host", host, "--port", str(port)]
 
-        async with session.post(
-            f"{guard_addr}/fork",
-            json={
-                "role": role,
-                "worker_index": worker_index,
-                "raw_cmd": cmd,
-            },
-            timeout=aiohttp.ClientTimeout(total=30),
-        ) as resp:
-            resp.raise_for_status()
+        try:
+            async with session.post(
+                f"{guard_addr}/fork",
+                json={
+                    "role": role,
+                    "worker_index": worker_index,
+                    "raw_cmd": cmd,
+                },
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                resp.raise_for_status()
 
-        self._forked_services.append((guard_addr, role, worker_index))
+            self._forked_services.append((guard_addr, role, worker_index))
 
-        addr = f"http://{format_hostport(host, port)}"
-        await self._async_wait_for_service(session, f"{addr}{health_path}", role)
+            addr = f"http://{format_hostport(host, port)}"
+            await self._async_wait_for_service(session, f"{addr}{health_path}", role)
+        except BaseException:
+            for endpoint in ("kill_forked_worker", "release_ports"):
+                try:
+                    async with session.post(
+                        f"{guard_addr}/{endpoint}",
+                        json={"role": role, "worker_index": worker_index},
+                    ):
+                        pass
+                except Exception:
+                    pass
+            raise
 
         return host, port
 

--- a/areal/infra/rpc/guard/app.py
+++ b/areal/infra/rpc/guard/app.py
@@ -19,10 +19,12 @@ Key components:
 from __future__ import annotations
 
 import argparse
+import fcntl
 import getpass
 import os
 import signal
 import subprocess
+import tempfile
 import traceback
 from collections.abc import Callable
 from pathlib import Path
@@ -72,6 +74,8 @@ class GuardState:
 
         # Port tracking (thread-safe)
         self.allocated_ports: set[int] = set()
+        self.owned_ports: dict[tuple[str, int], set[int]] = {}
+        self.port_lock_files: dict[int, Any] = {}
         self.allocated_ports_lock = Lock()
 
         # Forked child processes (thread-safe)
@@ -132,8 +136,6 @@ def cleanup_forked_children(state: GuardState) -> None:
     kills (avoids holding the lock for up to 4s × N children).
     """
     with state.forked_children_lock:
-        if not state.forked_children:
-            return
         children_to_kill = list(state.forked_children)
         state.forked_children.clear()
         state.forked_children_map.clear()
@@ -146,6 +148,51 @@ def cleanup_forked_children(state: GuardState) -> None:
                 logger.info(f"Killed forked child process {child.pid}")
         except Exception as e:
             logger.error(f"Error killing forked child {child.pid}: {e}")
+    with state.allocated_ports_lock:
+        lock_files = list(state.port_lock_files.values())
+        state.port_lock_files.clear()
+        state.allocated_ports.clear()
+        state.owned_ports.clear()
+    for lock_file in lock_files:
+        lock_file.close()
+
+
+def _release_owned_ports(state: GuardState, key: tuple[str, int]) -> list[int]:
+    """Release one fork owner's reserved ports. Caller need not hold a lock."""
+    with state.allocated_ports_lock:
+        ports = state.owned_ports.pop(key, set())
+        state.allocated_ports.difference_update(ports)
+        lock_files = [state.port_lock_files.pop(port, None) for port in ports]
+    for lock_file in lock_files:
+        if lock_file is not None:
+            lock_file.close()
+    return sorted(ports)
+
+
+def _reserve_node_ports(
+    state: GuardState, count: int, exclude_ports: set[int] | None = None
+) -> list[int]:
+    """Reserve free ports across all same-user Guards on this node."""
+    lock_dir = Path(tempfile.gettempdir()) / f"areal-port-locks-{os.getuid()}"
+    lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    ports: list[int] = []
+    skipped: set[int] = set(exclude_ports or ())
+    while len(ports) < count:
+        candidates = find_free_ports(
+            count - len(ports),
+            exclude_ports=state.allocated_ports | skipped,
+        )
+        for port in candidates:
+            lock_file = (lock_dir / str(port)).open("a+")
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                lock_file.close()
+                skipped.add(port)
+                continue
+            ports.append(port)
+            state.port_lock_files[port] = lock_file
+    return ports
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +243,7 @@ def create_app(state: GuardState) -> Flask:
 
         Expected JSON payload::
 
-            {"count": 5}
+            {"count": 5, "role": "actor", "worker_index": 0}
         """
         try:
             data = request.get_json(silent=True)
@@ -213,16 +260,53 @@ def create_app(state: GuardState) -> Flask:
                     400,
                 )
 
+            role = data.get("role")
+            worker_index = data.get("worker_index")
+            exclude_ports_raw = data.get("exclude_ports", [])
+            if not isinstance(exclude_ports_raw, list) or not all(
+                isinstance(port, int) for port in exclude_ports_raw
+            ):
+                return jsonify({"error": "'exclude_ports' must be a list of ints"}), 400
+            if (role is None) != (worker_index is None):
+                return (
+                    jsonify(
+                        {"error": "'role' and 'worker_index' must be set together"}
+                    ),
+                    400,
+                )
+            owner = None if role is None else (str(role), int(worker_index))
+
             s = get_state()
             with s.allocated_ports_lock:
-                ports = find_free_ports(count, exclude_ports=s.allocated_ports)
+                if owner is not None and (
+                    owner in s.owned_ports or owner in s.forked_children_map
+                ):
+                    return jsonify({"error": f"Port owner {owner} already exists"}), 409
+                ports = _reserve_node_ports(s, count, set(exclude_ports_raw))
                 s.allocated_ports.update(ports)
+                if owner is not None:
+                    s.owned_ports[owner] = set(ports)
 
             return jsonify({"status": "success", "ports": ports, "host": s.server_host})
 
         except Exception as e:
             logger.error(f"Error in alloc_ports: {e}\n{traceback.format_exc()}")
             return jsonify({"error": f"Internal server error: {str(e)}"}), 500
+
+    @app.route("/release_ports", methods=["POST"])
+    def release_ports():
+        """Release a failed fork's owner-bound port reservation."""
+        data = request.get_json(silent=True) or {}
+        role = data.get("role")
+        worker_index = data.get("worker_index")
+        if role is None or worker_index is None:
+            return jsonify({"error": "Missing role or worker_index"}), 400
+        key = (str(role), int(worker_index))
+        with state.forked_children_lock:
+            if key in state.forked_children_map:
+                return jsonify({"error": f"Forked worker {key} is still running"}), 409
+        ports = _release_owned_ports(state, key)
+        return jsonify({"status": "success", "ports": ports})
 
     @app.route("/fork", methods=["POST"])
     def fork_worker():
@@ -272,6 +356,16 @@ def create_app(state: GuardState) -> Flask:
                     400,
                 )
 
+            key = (str(role), int(worker_index))
+            with s.forked_children_lock:
+                if key in s.forked_children_map:
+                    return jsonify(
+                        {"error": f"Forked worker {key} already exists"}
+                    ), 409
+            with s.allocated_ports_lock:
+                if key not in s.owned_ports:
+                    return jsonify({"error": f"No port reservation for {key}"}), 409
+
             cmd = list(raw_cmd)
 
             # Optional per-process environment overrides
@@ -308,7 +402,7 @@ def create_app(state: GuardState) -> Flask:
 
             with s.forked_children_lock:
                 s.forked_children.append(child_process)
-                s.forked_children_map[(role, worker_index)] = child_process
+                s.forked_children_map[key] = child_process
 
             logger.info(
                 f"Forked worker for role '{role}' index "
@@ -324,6 +418,8 @@ def create_app(state: GuardState) -> Flask:
             )
 
         except Exception as e:
+            if "key" in locals():
+                _release_owned_ports(s, key)
             logger.error(f"Error in fork: {e}\n{traceback.format_exc()}")
             return jsonify({"error": f"Internal server error: {str(e)}"}), 500
 
@@ -358,17 +454,10 @@ def create_app(state: GuardState) -> Flask:
 
             key = (role, worker_index)
 
-            # Remove from tracking structures (hold lock only for dict/list ops)
+            # Keep tracking until the process is confirmed dead. If the kill
+            # fails, a retry must still be able to find the child and its ports.
             with s.forked_children_lock:
-                child_process = s.forked_children_map.pop(key, None)
-                if child_process:
-                    try:
-                        s.forked_children.remove(child_process)
-                    except ValueError:
-                        logger.warning(
-                            f"Process for {role}/{worker_index} was in map "
-                            "but not in list"
-                        )
+                child_process = s.forked_children_map.get(key)
 
             if child_process is None:
                 return (
@@ -402,12 +491,23 @@ def create_app(state: GuardState) -> Flask:
                     500,
                 )
 
+            with s.forked_children_lock:
+                s.forked_children_map.pop(key, None)
+                try:
+                    s.forked_children.remove(child_process)
+                except ValueError:
+                    logger.warning(
+                        f"Process for {role}/{worker_index} was in map but not in list"
+                    )
+            released_ports = _release_owned_ports(s, key)
+
             return jsonify(
                 {
                     "status": "success",
                     "message": (
                         f"Killed forked worker {role}/{worker_index} (pid={pid})"
                     ),
+                    "released_ports": released_ports,
                 }
             )
 

--- a/areal/infra/rpc/guard/app.py
+++ b/areal/infra/rpc/guard/app.py
@@ -169,6 +169,26 @@ def _release_owned_ports(state: GuardState, key: tuple[str, int]) -> list[int]:
     return sorted(ports)
 
 
+def _normalize_owner_key(
+    role: Any,
+    worker_index: Any,
+    *,
+    optional: bool = False,
+) -> tuple[str, int] | None:
+    """Build the canonical owner key used by all Guard lifecycle routes."""
+    if role is None and worker_index is None and optional:
+        return None
+    if role is None or worker_index is None:
+        raise ValueError("'role' and 'worker_index' must be set together")
+    if isinstance(worker_index, bool) or not isinstance(worker_index, (int, str)):
+        raise ValueError("'worker_index' must be an integer")
+    try:
+        normalized_index = int(worker_index)
+    except ValueError as e:
+        raise ValueError("'worker_index' must be an integer") from e
+    return str(role), normalized_index
+
+
 def _reserve_node_ports(
     state: GuardState, count: int, exclude_ports: set[int] | None = None
 ) -> list[int]:
@@ -177,22 +197,32 @@ def _reserve_node_ports(
     lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     ports: list[int] = []
     skipped: set[int] = set(exclude_ports or ())
-    while len(ports) < count:
-        candidates = find_free_ports(
-            count - len(ports),
-            exclude_ports=state.allocated_ports | skipped,
-        )
-        for port in candidates:
-            lock_file = (lock_dir / str(port)).open("a+")
-            try:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
+    try:
+        while len(ports) < count:
+            candidates = find_free_ports(
+                count - len(ports),
+                exclude_ports=state.allocated_ports | skipped | set(ports),
+            )
+            for port in candidates:
+                lock_file = (lock_dir / str(port)).open("a+")
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    lock_file.close()
+                    skipped.add(port)
+                    continue
+                except BaseException:
+                    lock_file.close()
+                    raise
+                ports.append(port)
+                state.port_lock_files[port] = lock_file
+        return ports
+    except BaseException:
+        lock_files = [state.port_lock_files.pop(port, None) for port in ports]
+        for lock_file in lock_files:
+            if lock_file is not None:
                 lock_file.close()
-                skipped.add(port)
-                continue
-            ports.append(port)
-            state.port_lock_files[port] = lock_file
-    return ports
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -267,24 +297,26 @@ def create_app(state: GuardState) -> Flask:
                 isinstance(port, int) for port in exclude_ports_raw
             ):
                 return jsonify({"error": "'exclude_ports' must be a list of ints"}), 400
-            if (role is None) != (worker_index is None):
-                return (
-                    jsonify(
-                        {"error": "'role' and 'worker_index' must be set together"}
-                    ),
-                    400,
-                )
-            owner = None if role is None else (str(role), int(worker_index))
+            try:
+                owner = _normalize_owner_key(role, worker_index, optional=True)
+            except ValueError as e:
+                return jsonify({"error": str(e)}), 400
 
             s = get_state()
-            with s.allocated_ports_lock:
-                if owner is not None and (
-                    owner in s.owned_ports or owner in s.forked_children_map
-                ):
-                    return jsonify({"error": f"Port owner {owner} already exists"}), 409
-                ports = _reserve_node_ports(s, count, set(exclude_ports_raw))
-                s.allocated_ports.update(ports)
-                if owner is not None:
+            if owner is None:
+                with s.allocated_ports_lock:
+                    ports = _reserve_node_ports(s, count, set(exclude_ports_raw))
+                    s.allocated_ports.update(ports)
+            else:
+                # Cross-map transitions always acquire child state before port state.
+                with s.forked_children_lock, s.allocated_ports_lock:
+                    if owner in s.owned_ports or owner in s.forked_children_map:
+                        return (
+                            jsonify({"error": f"Port owner {owner} already exists"}),
+                            409,
+                        )
+                    ports = _reserve_node_ports(s, count, set(exclude_ports_raw))
+                    s.allocated_ports.update(ports)
                     s.owned_ports[owner] = set(ports)
 
             return jsonify({"status": "success", "ports": ports, "host": s.server_host})
@@ -299,13 +331,15 @@ def create_app(state: GuardState) -> Flask:
         data = request.get_json(silent=True) or {}
         role = data.get("role")
         worker_index = data.get("worker_index")
-        if role is None or worker_index is None:
-            return jsonify({"error": "Missing role or worker_index"}), 400
-        key = (str(role), int(worker_index))
+        try:
+            key = _normalize_owner_key(role, worker_index)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+        assert key is not None
         with state.forked_children_lock:
             if key in state.forked_children_map:
                 return jsonify({"error": f"Forked worker {key} is still running"}), 409
-        ports = _release_owned_ports(state, key)
+            ports = _release_owned_ports(state, key)
         return jsonify({"status": "success", "ports": ports})
 
     @app.route("/fork", methods=["POST"])
@@ -356,53 +390,69 @@ def create_app(state: GuardState) -> Flask:
                     400,
                 )
 
-            key = (str(role), int(worker_index))
+            try:
+                key = _normalize_owner_key(role, worker_index)
+            except ValueError as e:
+                return jsonify({"error": str(e)}), 400
+            assert key is not None
+
+            # Hold the lifecycle lock from reservation validation through process
+            # registration so duplicate forks and releases cannot interleave.
             with s.forked_children_lock:
                 if key in s.forked_children_map:
                     return jsonify(
                         {"error": f"Forked worker {key} already exists"}
                     ), 409
-            with s.allocated_ports_lock:
-                if key not in s.owned_ports:
-                    return jsonify({"error": f"No port reservation for {key}"}), 409
+                with s.allocated_ports_lock:
+                    if key not in s.owned_ports:
+                        return (
+                            jsonify({"error": f"No port reservation for {key}"}),
+                            409,
+                        )
 
-            cmd = list(raw_cmd)
+                try:
+                    cmd = list(raw_cmd)
 
-            # Optional per-process environment overrides
-            env_overrides: dict[str, str] = data.get("env", {})
+                    # Optional per-process environment overrides
+                    env_overrides: dict[str, str] = data.get("env", {})
 
-            logger.info(
-                f"Forking new worker process for role '{role}' index {worker_index}"
-            )
+                    logger.info(
+                        f"Forking new worker process for role '{role}' "
+                        f"index {worker_index}"
+                    )
 
-            # Build log paths
-            log_dir = (
-                Path(s.fileroot or "/tmp")
-                / "logs"
-                / getpass.getuser()
-                / (s.experiment_name or "default")
-                / (s.trial_name or "default")
-            )
-            log_dir.mkdir(parents=True, exist_ok=True)
-            log_file = log_dir / f"{role}.log"
-            merged_log = log_dir / "merged.log"
+                    # Build log paths
+                    log_dir = (
+                        Path(s.fileroot or "/tmp")
+                        / "logs"
+                        / getpass.getuser()
+                        / (s.experiment_name or "default")
+                        / (s.trial_name or "default")
+                    )
+                    log_dir.mkdir(parents=True, exist_ok=True)
+                    log_file = log_dir / f"{role}.log"
+                    merged_log = log_dir / "merged.log"
 
-            logger.info(f"Forked worker logs will be written to: {log_file}")
+                    logger.info(f"Forked worker logs will be written to: {log_file}")
 
-            child_env = os.environ.copy()
-            child_env.update(env_overrides)
+                    child_env = os.environ.copy()
+                    child_env.update(env_overrides)
 
-            child_process = run_with_streaming_logs(
-                cmd,
-                log_file,
-                merged_log,
-                role,
-                env=child_env,
-            )
+                    child_process = run_with_streaming_logs(
+                        cmd,
+                        log_file,
+                        merged_log,
+                        role,
+                        env=child_env,
+                    )
 
-            with s.forked_children_lock:
-                s.forked_children.append(child_process)
-                s.forked_children_map[key] = child_process
+                    s.forked_children.append(child_process)
+                    s.forked_children_map[key] = child_process
+                except Exception:
+                    # Release the reservation before another request for the same
+                    # owner can pass lifecycle validation.
+                    _release_owned_ports(s, key)
+                    raise
 
             logger.info(
                 f"Forked worker for role '{role}' index "
@@ -418,8 +468,6 @@ def create_app(state: GuardState) -> Flask:
             )
 
         except Exception as e:
-            if "key" in locals():
-                _release_owned_ports(s, key)
             logger.error(f"Error in fork: {e}\n{traceback.format_exc()}")
             return jsonify({"error": f"Internal server error: {str(e)}"}), 500
 
@@ -452,7 +500,11 @@ def create_app(state: GuardState) -> Flask:
                     400,
                 )
 
-            key = (role, worker_index)
+            try:
+                key = _normalize_owner_key(role, worker_index)
+            except ValueError as e:
+                return jsonify({"error": str(e)}), 400
+            assert key is not None
 
             # Keep tracking until the process is confirmed dead. If the kill
             # fails, a retry must still be able to find the child and its ports.
@@ -492,14 +544,19 @@ def create_app(state: GuardState) -> Flask:
                 )
 
             with s.forked_children_lock:
-                s.forked_children_map.pop(key, None)
-                try:
-                    s.forked_children.remove(child_process)
-                except ValueError:
-                    logger.warning(
-                        f"Process for {role}/{worker_index} was in map but not in list"
-                    )
-            released_ports = _release_owned_ports(s, key)
+                # A concurrent kill may already have cleaned up this process and
+                # allowed a new owner generation to reuse the same key.
+                if s.forked_children_map.get(key) is child_process:
+                    s.forked_children_map.pop(key, None)
+                    try:
+                        s.forked_children.remove(child_process)
+                    except ValueError:
+                        logger.warning(
+                            f"Process for {role}/{worker_index} was in map but not in list"
+                        )
+                    released_ports = _release_owned_ports(s, key)
+                else:
+                    released_ports = []
 
             return jsonify(
                 {

--- a/areal/infra/scheduler/local.py
+++ b/areal/infra/scheduler/local.py
@@ -319,12 +319,19 @@ class LocalScheduler(Scheduler):
         """
         worker_id = f"{role}/{idx}"
         guard_url = f"http://{format_hostport(target_wi.worker.ip, int(target_wi.worker.worker_ports[0]))}"
+        port_cnt = len(target_wi.worker.worker_ports)
+        ports_reserved = False
 
         try:
             # 1. Allocate a port on the target guard
             async with session.post(
                 f"{guard_url}/alloc_ports",
-                json={"count": 1},
+                json={
+                    "count": port_cnt,
+                    "role": role,
+                    "worker_index": idx,
+                    "exclude_ports": list(self._allocated_ports),
+                },
             ) as alloc_resp:
                 if alloc_resp.status != 200:
                     error_text = await alloc_resp.text()
@@ -335,7 +342,10 @@ class LocalScheduler(Scheduler):
                     )
                 alloc_data = await alloc_resp.json()
                 forked_host = alloc_data["host"]
-                forked_port = alloc_data["ports"][0]
+                forked_ports = alloc_data["ports"]
+                forked_port = forked_ports[0]
+                ports_reserved = True
+                self._allocated_ports.update(forked_ports)
 
             # 2. Build the full raw command
             module_path = command or "areal.infra.rpc.rpc_server"
@@ -418,22 +428,32 @@ class LocalScheduler(Scheduler):
                 f"(pid={forked_pid}) from {target_role}/{idx}"
             )
 
-        except aiohttp.ClientError as e:
-            raise WorkerCreationError(
-                role,
-                f"Failed to fork worker {idx} from {target_role}/{idx}",
-                str(e),
-            ) from e
+        except BaseException as e:
+            if ports_reserved:
+                for endpoint in ("kill_forked_worker", "release_ports"):
+                    try:
+                        async with session.post(
+                            f"{guard_url}/{endpoint}",
+                            json={"role": role, "worker_index": idx},
+                        ):
+                            pass
+                    except Exception:
+                        pass
+                self._release_ports([int(port) for port in forked_ports])
+            if isinstance(e, aiohttp.ClientError):
+                raise WorkerCreationError(
+                    role,
+                    f"Failed to fork worker {idx} from {target_role}/{idx}",
+                    str(e),
+                ) from e
+            raise
 
         worker = Worker(
             id=worker_id,
             ip=forked_host,
-            worker_ports=[str(forked_port)],
+            worker_ports=list(map(str, forked_ports)),
             engine_ports=[],
         )
-        port_cnt = len(self._workers[target_role][0].worker.worker_ports)
-        if port_cnt > 1:
-            worker.worker_ports += self._allocate_ports(port_cnt - 1)
 
         return WorkerInfo(
             worker=worker,
@@ -504,6 +524,8 @@ class LocalScheduler(Scheduler):
                         )
                     )
             await asyncio.gather(*tasks, return_exceptions=True)
+        for worker_info in workers:
+            self._release_ports([int(port) for port in worker_info.worker.worker_ports])
 
     async def _create_forked_workers_async(
         self,
@@ -574,9 +596,15 @@ class LocalScheduler(Scheduler):
         )
 
         # Configure forked workers if exp_config is available
-        if self.exp_config is not None:
-            for worker_rank, worker_info in enumerate(workers):
-                self._configure_worker(worker_info, worker_rank)
+        try:
+            if self.exp_config is not None:
+                for worker_rank, worker_info in enumerate(workers):
+                    self._configure_worker(worker_info, worker_rank)
+        except BaseException:
+            await self._cleanup_forked_workers_async(role, target_role, workers)
+            self._workers.pop(role, None)
+            self._colocated_roles.pop(role, None)
+            raise
 
         return worker_ids
 
@@ -940,6 +968,7 @@ class LocalScheduler(Scheduler):
         """
         # Handle colocated/forked roles
         if role in self._colocated_roles:
+            target_role = self._colocated_roles[role]
             # Forked roles have their own workers in _workers
             if role not in self._workers:
                 # Colocated roles delegate to target role's workers
@@ -1111,15 +1140,22 @@ class LocalScheduler(Scheduler):
 
         # Handle colocated/forked role
         if role in self._colocated_roles:
+            target_role = self._colocated_roles[role]
             # Forked roles have their own workers that need port cleanup
             if role in self._workers:
                 logger.info(f"Removing forked role '{role}' (managed by parent worker)")
                 workers = self._workers[role]
                 if reverse_order:
                     workers = list(reversed(workers))
-                self._cleanup_workers(
-                    workers
-                )  # Release ports, but process=None skips kill
+                try:
+                    run_async_task(
+                        self._cleanup_forked_workers_async,
+                        role,
+                        target_role,
+                        workers,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to cleanup forked role '{role}': {e}")
                 del self._workers[role]
             else:
                 # Colocated roles don't have their own workers

--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -1013,12 +1013,21 @@ class RayScheduler(Scheduler):
         """
         worker_id = f"{role}/{idx}"
         guard_url = f"http://{format_hostport(target_wi.worker.ip, int(target_wi.worker.worker_ports[0]))}"
+        port_cnt = len(target_wi.worker.worker_ports)
+        ports_reserved = False
 
         try:
             # 1. Allocate a port on the target guard
             async with session.post(
                 f"{guard_url}/alloc_ports",
-                json={"count": 1},
+                json={
+                    "count": port_cnt,
+                    "role": role,
+                    "worker_index": idx,
+                    "exclude_ports": [
+                        int(port) for port in target_wi.worker.worker_ports
+                    ],
+                },
             ) as alloc_resp:
                 if alloc_resp.status != 200:
                     error_text = await alloc_resp.text()
@@ -1029,7 +1038,9 @@ class RayScheduler(Scheduler):
                     )
                 alloc_data = await alloc_resp.json()
                 forked_host = alloc_data["host"]
-                forked_port = alloc_data["ports"][0]
+                forked_ports = alloc_data["ports"]
+                forked_port = forked_ports[0]
+                ports_reserved = True
 
             # 2. Build the full raw command
             module_path = command or "areal.infra.rpc.rpc_server"
@@ -1111,34 +1122,31 @@ class RayScheduler(Scheduler):
                 f"(pid={forked_pid}) from {target_role}/{idx}"
             )
 
-        except aiohttp.ClientError as e:
-            raise WorkerCreationError(
-                role,
-                f"Failed to fork worker {idx} from {target_role}/{idx}",
-                str(e),
-            ) from e
+        except BaseException as e:
+            if ports_reserved:
+                for endpoint in ("kill_forked_worker", "release_ports"):
+                    try:
+                        async with session.post(
+                            f"{guard_url}/{endpoint}",
+                            json={"role": role, "worker_index": idx},
+                        ):
+                            pass
+                    except Exception:
+                        pass
+            if isinstance(e, aiohttp.ClientError):
+                raise WorkerCreationError(
+                    role,
+                    f"Failed to fork worker {idx} from {target_role}/{idx}",
+                    str(e),
+                ) from e
+            raise
 
         worker = Worker(
             id=worker_id,
             ip=forked_host,
-            worker_ports=[str(forked_port)],
+            worker_ports=list(map(str, forked_ports)),
             engine_ports=[],
         )
-        port_cnt = len(self._workers[target_role][0].worker.worker_ports)
-        if port_cnt > 1:
-            async with session.post(
-                f"http://{format_hostport(forked_host, forked_port)}/alloc_ports",
-                json=dict(count=port_cnt - 1),
-            ) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    raise WorkerCreationError(
-                        role,
-                        f"Fork failed for worker {idx}",
-                        f"HTTP {response.status}: {error_text}",
-                    )
-                new_ports = (await response.json())["ports"]
-                worker.worker_ports += list(map(str, new_ports))
 
         return RayWorkerInfo(
             worker=worker,
@@ -1277,8 +1285,14 @@ class RayScheduler(Scheduler):
         )
 
         # Configure forked workers if exp_config is available
-        if self.exp_config is not None:
-            await self._configure_workers(workers)
+        try:
+            if self.exp_config is not None:
+                await self._configure_workers(workers)
+        except BaseException:
+            await self._cleanup_forked_workers_async(role, target_role, workers)
+            self._workers.pop(role, None)
+            self._colocated_roles.pop(role, None)
+            raise
 
         return worker_ids
 

--- a/areal/infra/scheduler/slurm.py
+++ b/areal/infra/scheduler/slurm.py
@@ -504,12 +504,21 @@ class SlurmScheduler(Scheduler):
         """
         worker_id = f"{role}/{idx}"
         guard_url = f"http://{format_hostport(target_wi.worker.ip, int(target_wi.worker.worker_ports[0]))}"
+        port_cnt = len(target_wi.worker.worker_ports)
+        ports_reserved = False
 
         try:
             # 1. Allocate a port on the target guard
             async with session.post(
                 f"{guard_url}/alloc_ports",
-                json={"count": 1},
+                json={
+                    "count": port_cnt,
+                    "role": role,
+                    "worker_index": idx,
+                    "exclude_ports": [
+                        int(port) for port in target_wi.worker.worker_ports
+                    ],
+                },
             ) as alloc_resp:
                 if alloc_resp.status != 200:
                     error_text = await alloc_resp.text()
@@ -520,7 +529,9 @@ class SlurmScheduler(Scheduler):
                     )
                 alloc_data = await alloc_resp.json()
                 forked_host = alloc_data["host"]
-                forked_port = alloc_data["ports"][0]
+                forked_ports = alloc_data["ports"]
+                forked_port = forked_ports[0]
+                ports_reserved = True
 
             # 2. Build the full raw command
             module_path = command or "areal.infra.rpc.rpc_server"
@@ -602,34 +613,31 @@ class SlurmScheduler(Scheduler):
                 f"(pid={forked_pid}) from {target_role}/{idx}"
             )
 
-        except aiohttp.ClientError as e:
-            raise WorkerCreationError(
-                role,
-                f"Failed to fork worker {idx} from {target_role}/{idx}",
-                str(e),
-            ) from e
+        except BaseException as e:
+            if ports_reserved:
+                for endpoint in ("kill_forked_worker", "release_ports"):
+                    try:
+                        async with session.post(
+                            f"{guard_url}/{endpoint}",
+                            json={"role": role, "worker_index": idx},
+                        ):
+                            pass
+                    except Exception:
+                        pass
+            if isinstance(e, aiohttp.ClientError):
+                raise WorkerCreationError(
+                    role,
+                    f"Failed to fork worker {idx} from {target_role}/{idx}",
+                    str(e),
+                ) from e
+            raise
 
         worker = Worker(
             id=worker_id,
             ip=forked_host,
-            worker_ports=[str(forked_port)],
+            worker_ports=list(map(str, forked_ports)),
             engine_ports=[],
         )
-        port_cnt = len(self._workers[target_role][0].worker.worker_ports)
-        if port_cnt > 1:
-            async with session.post(
-                f"http://{format_hostport(forked_host, forked_port)}/alloc_ports",
-                json=dict(count=port_cnt - 1),
-            ) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    raise WorkerCreationError(
-                        role,
-                        f"Fork failed for worker {idx}",
-                        f"HTTP {response.status}: {error_text}",
-                    )
-                new_ports = (await response.json())["ports"]
-                worker.worker_ports += list(map(str, new_ports))
 
         return SlurmWorkerInfo(
             worker=worker,
@@ -770,9 +778,15 @@ class SlurmScheduler(Scheduler):
         )
 
         # Configure forked workers if exp_config is available
-        if self.exp_config is not None:
-            for worker_rank, worker_info in enumerate(workers):
-                self._configure_worker(worker_info, worker_rank)
+        try:
+            if self.exp_config is not None:
+                for worker_rank, worker_info in enumerate(workers):
+                    self._configure_worker(worker_info, worker_rank)
+        except BaseException:
+            await self._cleanup_forked_workers_async(role, target_role, workers)
+            self._workers.pop(role, None)
+            self._colocated_roles.pop(role, None)
+            raise
 
         return worker_ids
 
@@ -1186,6 +1200,7 @@ class SlurmScheduler(Scheduler):
         """
         # Handle colocated/forked roles
         if role in self._colocated_roles:
+            target_role = self._colocated_roles[role]
             # Forked roles have their own workers in _workers
             if role in self._workers:
                 workers = self._workers[role]
@@ -1375,9 +1390,19 @@ class SlurmScheduler(Scheduler):
 
         # Handle colocated/forked role
         if role in self._colocated_roles:
+            target_role = self._colocated_roles[role]
             # Forked roles have their own workers that need cleanup
             if role in self._workers:
                 logger.info(f"Removing forked role '{role}' (managed by parent worker)")
+                try:
+                    run_async_task(
+                        self._cleanup_forked_workers_async,
+                        role,
+                        target_role,
+                        self._workers[role],
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to cleanup forked role '{role}': {e}")
                 del self._workers[role]
             else:
                 logger.info(f"Removing colocated role '{role}' mapping")

--- a/areal/v2/agent_service/controller/controller.py
+++ b/areal/v2/agent_service/controller/controller.py
@@ -392,7 +392,7 @@ class AgentController:
     ) -> tuple[str, int]:
         resp = requests.post(
             f"{guard_addr}/alloc_ports",
-            json={"count": 1},
+            json={"count": 1, "role": role, "worker_index": worker_index},
             timeout=30,
         )
         resp.raise_for_status()
@@ -412,17 +412,27 @@ class AgentController:
         if merged_env:
             fork_payload["env"] = merged_env
 
-        resp = requests.post(
-            f"{guard_addr}/fork",
-            json=fork_payload,
-            timeout=30,
-        )
-        resp.raise_for_status()
-
-        self._forked_services.append((guard_addr, role, worker_index))
-
-        addr = f"http://{format_hostport(host, port)}"
-        self._wait_for_service(f"{addr}{health_path}", role)
+        try:
+            resp = requests.post(
+                f"{guard_addr}/fork",
+                json=fork_payload,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            self._forked_services.append((guard_addr, role, worker_index))
+            addr = f"http://{format_hostport(host, port)}"
+            self._wait_for_service(f"{addr}{health_path}", role)
+        except BaseException:
+            for endpoint in ("kill_forked_worker", "release_ports"):
+                try:
+                    requests.post(
+                        f"{guard_addr}/{endpoint}",
+                        json={"role": role, "worker_index": worker_index},
+                        timeout=10,
+                    )
+                except Exception:
+                    pass
+            raise
 
         return host, port
 

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -576,41 +576,94 @@ class RolloutControllerV2:
         else:
             raise ValueError(f"Unsupported inference backend: {inf_backend!r}")
 
+        async def _cleanup_forks(
+            owners: list[tuple[str, int]],
+        ) -> None:
+            """Best-effort rollback for owner-bound inference reservations."""
+            client = await self._get_async_client()
+
+            async def _cleanup_owner(guard_addr: str, worker_index: int) -> None:
+                payload = {"role": "inf-server", "worker_index": worker_index}
+                for endpoint in ("kill_forked_worker", "release_ports"):
+                    try:
+                        await client.post(
+                            f"{guard_addr}/{endpoint}",
+                            json=payload,
+                            timeout=10.0,
+                        )
+                    except Exception:
+                        pass
+
+            await asyncio.gather(
+                *[_cleanup_owner(guard, index) for guard, index in owners]
+            )
+
         async def _fork_group(
             group_idx: int,
         ) -> tuple[str, int, list[tuple[str, str, int]]]:
             group_workers = inf_workers[
                 group_idx * nnodes_per_instance : (group_idx + 1) * nnodes_per_instance
             ]
-            head_worker = group_workers[0]
-            head_guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
             client = await self._get_async_client()
 
-            dist_init_addr = None
-            if nnodes_per_instance > 1:
-                resp = await client.post(
-                    f"{head_guard_addr}/alloc_ports",
-                    json={"count": 1},
-                    timeout=30.0,
+            owners = [
+                (
+                    f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}",
+                    group_idx * nnodes_per_instance + node_rank,
                 )
-                resp.raise_for_status()
-                rendezvous_data = resp.json()
-                rendezvous_host = rendezvous_data["host"]
-                rendezvous_port = rendezvous_data["ports"][0]
-                dist_init_addr = format_hostport(rendezvous_host, rendezvous_port)
+                for node_rank, worker in enumerate(group_workers)
+            ]
 
-            async def _fork_node(node_rank: int, worker: Any) -> tuple[str, int, str]:
-                guard_addr = (
-                    f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
-                )
-
+            async def _alloc_node(
+                node_rank: int, guard_addr: str, worker_index: int
+            ) -> dict[str, Any]:
+                # The group head owns both its inference port and the distributed
+                # rendezvous port. Guard permits one reservation per owner.
+                count = 2 if node_rank == 0 and nnodes_per_instance > 1 else 1
                 resp = await client.post(
                     f"{guard_addr}/alloc_ports",
-                    json={"count": 1},
+                    json={
+                        "count": count,
+                        "role": "inf-server",
+                        "worker_index": worker_index,
+                    },
                     timeout=30.0,
                 )
                 resp.raise_for_status()
-                port_data = resp.json()
+                return resp.json()
+
+            allocation_results = await asyncio.gather(
+                *[
+                    _alloc_node(rank, guard, worker_index)
+                    for rank, (guard, worker_index) in enumerate(owners)
+                ],
+                return_exceptions=True,
+            )
+            allocation_error = next(
+                (
+                    result
+                    for result in allocation_results
+                    if isinstance(result, BaseException)
+                ),
+                None,
+            )
+            if allocation_error is not None:
+                await _cleanup_forks(owners)
+                raise allocation_error
+
+            port_data_by_node = cast(list[dict[str, Any]], allocation_results)
+            dist_init_addr = None
+            if nnodes_per_instance > 1:
+                rendezvous_host = port_data_by_node[0]["host"]
+                rendezvous_port = port_data_by_node[0]["ports"][1]
+                dist_init_addr = format_hostport(rendezvous_host, rendezvous_port)
+
+            async def _fork_node(
+                node_rank: int,
+                worker_index: int,
+                guard_addr: str,
+                port_data: dict[str, Any],
+            ) -> tuple[str, int, str]:
                 inf_host: str = port_data["host"]
                 inf_port: int = port_data["ports"][0]
 
@@ -626,7 +679,7 @@ class RolloutControllerV2:
 
                 fork_payload: dict[str, Any] = {
                     "role": "inf-server",
-                    "worker_index": group_idx * nnodes_per_instance + node_rank,
+                    "worker_index": worker_index,
                     "raw_cmd": cmd,
                 }
                 if inf_backend == "sglang":
@@ -682,20 +735,88 @@ class RolloutControllerV2:
                 return inf_host, inf_port, guard_addr
 
             node_results = await asyncio.gather(
-                *[_fork_node(rank, w) for rank, w in enumerate(group_workers)]
+                *[
+                    _fork_node(rank, worker_index, guard, port_data_by_node[rank])
+                    for rank, (guard, worker_index) in enumerate(owners)
+                ],
+                return_exceptions=True,
             )
 
-            head_inf_host, head_inf_port, _ = node_results[0]
+            fork_error = next(
+                (
+                    result
+                    for result in node_results
+                    if isinstance(result, BaseException)
+                ),
+                None,
+            )
+            if fork_error is not None:
+                await _cleanup_forks(owners)
+                raise fork_error
+
+            successful_nodes = cast(list[tuple[str, int, str]], node_results)
+            head_inf_host, head_inf_port, _ = successful_nodes[0]
             forked: list[tuple[str, str, int]] = [
                 (guard_addr, "inf-server", group_idx * nnodes_per_instance + rank)
-                for rank, (_, _, guard_addr) in enumerate(node_results)
+                for rank, (_, _, guard_addr) in enumerate(successful_nodes)
             ]
             return (head_inf_host, head_inf_port, forked)
 
-        group_results = await asyncio.gather(*[_fork_group(i) for i in range(dp_size)])
+        raw_group_results = await asyncio.gather(
+            *[_fork_group(i) for i in range(dp_size)], return_exceptions=True
+        )
+        group_error = next(
+            (
+                result
+                for result in raw_group_results
+                if isinstance(result, BaseException)
+            ),
+            None,
+        )
+        successful_groups = [
+            result
+            for result in raw_group_results
+            if not isinstance(result, BaseException)
+        ]
+        if group_error is not None:
+            await _cleanup_forks(
+                [
+                    (guard_addr, worker_index)
+                    for _, _, forked in successful_groups
+                    for guard_addr, _, worker_index in forked
+                ]
+            )
+            raise group_error
 
-        for host, port, forked in group_results:
-            addr = f"http://{format_hostport(host, port)}"
+        group_results = cast(
+            list[tuple[str, int, list[tuple[str, str, int]]]], successful_groups
+        )
+
+        inf_addrs = [
+            f"http://{format_hostport(host, port)}" for host, port, _ in group_results
+        ]
+
+        try:
+            # Wait for all inference servers to be healthy in parallel.
+            await asyncio.gather(
+                *[
+                    self._async_wait_for_service(
+                        f"{addr}/health", f"InfServer-{i}", timeout=cfg.setup_timeout
+                    )
+                    for i, addr in enumerate(inf_addrs)
+                ]
+            )
+        except BaseException:
+            await _cleanup_forks(
+                [
+                    (guard_addr, worker_index)
+                    for _, _, forked in group_results
+                    for guard_addr, _, worker_index in forked
+                ]
+            )
+            raise
+
+        for addr, (host, port, forked) in zip(inf_addrs, group_results, strict=True):
             self._inf_addrs.append(addr)
             self._server_infos.append(
                 LocalInfServerInfo(
@@ -705,16 +826,6 @@ class RolloutControllerV2:
                 )
             )
             self._forked_services.extend(forked)
-
-        # Wait for all inference servers to be healthy in parallel
-        await asyncio.gather(
-            *[
-                self._async_wait_for_service(
-                    f"{addr}/health", f"InfServer-{i}", timeout=cfg.setup_timeout
-                )
-                for i, addr in enumerate(self._inf_addrs)
-            ]
-        )
 
     # -- Service health checks & registration ------------------------------
 
@@ -1763,7 +1874,7 @@ class RolloutControllerV2:
         """
         resp = self._sync_client.post(
             f"{guard_addr}/alloc_ports",
-            json={"count": 1},
+            json={"count": 1, "role": role, "worker_index": worker_index},
         )
         resp.raise_for_status()
         port_data = resp.json()
@@ -1772,20 +1883,29 @@ class RolloutControllerV2:
 
         cmd = list(raw_cmd) + ["--host", host, "--port", str(port)]
 
-        resp = self._sync_client.post(
-            f"{guard_addr}/fork",
-            json={
-                "role": role,
-                "worker_index": worker_index,
-                "raw_cmd": cmd,
-            },
-        )
-        resp.raise_for_status()
-
-        self._forked_services.append((guard_addr, role, worker_index))
-
-        addr = f"http://{format_hostport(host, port)}"
-        self._wait_for_service(f"{addr}{health_path}", role)
+        try:
+            resp = self._sync_client.post(
+                f"{guard_addr}/fork",
+                json={
+                    "role": role,
+                    "worker_index": worker_index,
+                    "raw_cmd": cmd,
+                },
+            )
+            resp.raise_for_status()
+            self._forked_services.append((guard_addr, role, worker_index))
+            addr = f"http://{format_hostport(host, port)}"
+            self._wait_for_service(f"{addr}{health_path}", role)
+        except BaseException:
+            for endpoint in ("kill_forked_worker", "release_ports"):
+                try:
+                    self._sync_client.post(
+                        f"{guard_addr}/{endpoint}",
+                        json={"role": role, "worker_index": worker_index},
+                    )
+                except Exception:
+                    pass
+            raise
 
         return host, port
 
@@ -1805,7 +1925,9 @@ class RolloutControllerV2:
         """
         client = await self._get_async_client()
         resp = await client.post(
-            f"{guard_addr}/alloc_ports", json={"count": 1}, timeout=30.0
+            f"{guard_addr}/alloc_ports",
+            json={"count": 1, "role": role, "worker_index": worker_index},
+            timeout=30.0,
         )
         resp.raise_for_status()
         port_data = resp.json()
@@ -1819,11 +1941,24 @@ class RolloutControllerV2:
             "raw_cmd": cmd,
         }
 
-        resp = await client.post(f"{guard_addr}/fork", json=fork_payload, timeout=30.0)
-        resp.raise_for_status()
-
-        addr = f"http://{format_hostport(host, port)}"
-        await self._async_wait_for_service(f"{addr}{health_path}", role)
+        try:
+            resp = await client.post(
+                f"{guard_addr}/fork", json=fork_payload, timeout=30.0
+            )
+            resp.raise_for_status()
+            addr = f"http://{format_hostport(host, port)}"
+            await self._async_wait_for_service(f"{addr}{health_path}", role)
+        except BaseException:
+            for endpoint in ("kill_forked_worker", "release_ports"):
+                try:
+                    await client.post(
+                        f"{guard_addr}/{endpoint}",
+                        json={"role": role, "worker_index": worker_index},
+                        timeout=10.0,
+                    )
+                except Exception:
+                    pass
+            raise
 
         return host, port
 

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -523,7 +523,11 @@ class GatewayTrainController:
     ) -> tuple[str, int]:
         import requests
 
-        resp = requests.post(f"{guard_addr}/alloc_ports", json={"count": 1}, timeout=30)
+        resp = requests.post(
+            f"{guard_addr}/alloc_ports",
+            json={"count": 1, "role": role, "worker_index": worker_index},
+            timeout=30,
+        )
         resp.raise_for_status()
         port_data = resp.json()
         host = port_data["host"]
@@ -539,13 +543,23 @@ class GatewayTrainController:
         if env:
             fork_payload["env"] = env
 
-        resp = requests.post(f"{guard_addr}/fork", json=fork_payload, timeout=30)
-        resp.raise_for_status()
-
-        self._forked_services.append((guard_addr, role, worker_index))
-
-        addr = f"http://{format_hostport(host, port)}"
-        self._wait_for_service(f"{addr}{health_path}", role)
+        try:
+            resp = requests.post(f"{guard_addr}/fork", json=fork_payload, timeout=30)
+            resp.raise_for_status()
+            self._forked_services.append((guard_addr, role, worker_index))
+            addr = f"http://{format_hostport(host, port)}"
+            self._wait_for_service(f"{addr}{health_path}", role)
+        except BaseException:
+            for endpoint in ("kill_forked_worker", "release_ports"):
+                try:
+                    requests.post(
+                        f"{guard_addr}/{endpoint}",
+                        json={"role": role, "worker_index": worker_index},
+                        timeout=10,
+                    )
+                except Exception:
+                    pass
+            raise
 
         return host, port
 
@@ -560,7 +574,9 @@ class GatewayTrainController:
     ) -> tuple[str, int]:
         client = await self._get_async_client()
         resp = await client.post(
-            f"{guard_addr}/alloc_ports", json={"count": 1}, timeout=30.0
+            f"{guard_addr}/alloc_ports",
+            json={"count": 1, "role": role, "worker_index": worker_index},
+            timeout=30.0,
         )
         resp.raise_for_status()
         port_data = resp.json()
@@ -576,13 +592,25 @@ class GatewayTrainController:
         if env:
             fork_payload["env"] = env
 
-        resp = await client.post(f"{guard_addr}/fork", json=fork_payload, timeout=30.0)
-        resp.raise_for_status()
-
-        self._forked_services.append((guard_addr, role, worker_index))
-
-        addr = f"http://{format_hostport(host, port)}"
-        await self._async_wait_for_service(f"{addr}{health_path}", role)
+        try:
+            resp = await client.post(
+                f"{guard_addr}/fork", json=fork_payload, timeout=30.0
+            )
+            resp.raise_for_status()
+            self._forked_services.append((guard_addr, role, worker_index))
+            addr = f"http://{format_hostport(host, port)}"
+            await self._async_wait_for_service(f"{addr}{health_path}", role)
+        except BaseException:
+            for endpoint in ("kill_forked_worker", "release_ports"):
+                try:
+                    await client.post(
+                        f"{guard_addr}/{endpoint}",
+                        json={"role": role, "worker_index": worker_index},
+                        timeout=10.0,
+                    )
+                except Exception:
+                    pass
+            raise
 
         return host, port
 

--- a/tests/infra/data_service/test_guard.py
+++ b/tests/infra/data_service/test_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -38,6 +39,22 @@ def _make_mock_process(pid: int = 12345, running: bool = True) -> MagicMock:
     proc.pid = pid
     proc.poll.return_value = None if running else 0
     return proc
+
+
+class _ObservableLock:
+    def __init__(self, lock, thread_name: str, attempted: threading.Event):
+        self._lock = lock
+        self._thread_name = thread_name
+        self._attempted = attempted
+
+    def __enter__(self):
+        if threading.current_thread().name == self._thread_name:
+            self._attempted.set()
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._lock.release()
 
 
 def test_health_returns_200(client):
@@ -89,6 +106,97 @@ def test_alloc_ports_duplicate_owner_returns_conflict(
     assert first.status_code == 200
     assert second.status_code == 409
     assert state.owned_ports[("worker", 3)] == {9011}
+
+
+@pytest.mark.parametrize("bad_index", ["bad", 1.5, True])
+@pytest.mark.parametrize(
+    ("endpoint", "payload"),
+    [
+        ("/alloc_ports", {"count": 1, "role": "worker"}),
+        ("/release_ports", {"role": "worker"}),
+        ("/fork", {"role": "worker", "raw_cmd": ["python"]}),
+        ("/kill_forked_worker", {"role": "worker"}),
+    ],
+)
+def test_lifecycle_routes_invalid_worker_index_returns_bad_request(
+    client, state: GuardState, endpoint: str, payload: dict, bad_index
+):
+    """Invalid owner indices are client errors and never mutate Guard state."""
+    response = client.post(endpoint, json={**payload, "worker_index": bad_index})
+
+    assert response.status_code == 400
+    assert state.allocated_ports == set()
+    assert state.owned_ports == {}
+    assert state.forked_children_map == {}
+
+
+@patch("areal.infra.rpc.guard.app.kill_process_tree")
+@patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
+@patch("areal.infra.rpc.guard.app.find_free_ports")
+def test_lifecycle_routes_normalize_numeric_string_worker_index(
+    mock_find, mock_run, mock_kill, client, state: GuardState
+):
+    """All lifecycle routes map a numeric string to the same integer owner key."""
+    mock_find.side_effect = [[9015], [9016]]
+    mock_run.return_value = _make_mock_process(pid=43)
+
+    alloc = client.post(
+        "/alloc_ports",
+        json={"count": 1, "role": "worker", "worker_index": "7"},
+    )
+    forked = client.post(
+        "/fork",
+        json={"role": "worker", "worker_index": "7", "raw_cmd": ["python"]},
+    )
+    killed = client.post(
+        "/kill_forked_worker", json={"role": "worker", "worker_index": "7"}
+    )
+    second_alloc = client.post(
+        "/alloc_ports",
+        json={"count": 1, "role": "worker", "worker_index": "8"},
+    )
+    released = client.post(
+        "/release_ports", json={"role": "worker", "worker_index": "8"}
+    )
+
+    assert [response.status_code for response in (alloc, forked, killed)] == [
+        200,
+        200,
+        200,
+    ]
+    assert [second_alloc.status_code, released.status_code] == [200, 200]
+    assert state.allocated_ports == set()
+    assert state.owned_ports == {}
+    assert state.forked_children_map == {}
+    mock_kill.assert_called_once_with(43, timeout=3, graceful=True)
+
+
+@patch("areal.infra.rpc.guard.app.fcntl.flock")
+@patch("areal.infra.rpc.guard.app.Path.open")
+@patch("areal.infra.rpc.guard.app.find_free_ports")
+def test_alloc_ports_partial_lock_failure_rolls_back(
+    mock_find, mock_open, mock_flock, client, state: GuardState
+):
+    """A failed multi-port reservation closes every lock opened by that call."""
+    first_lock = MagicMock()
+    second_lock = MagicMock()
+    first_lock.fileno.return_value = 10
+    second_lock.fileno.return_value = 11
+    mock_find.return_value = [9017, 9018]
+    mock_open.side_effect = [first_lock, second_lock]
+    mock_flock.side_effect = [None, OSError("lock failed")]
+
+    response = client.post(
+        "/alloc_ports",
+        json={"count": 2, "role": "worker", "worker_index": 9},
+    )
+
+    assert response.status_code == 500
+    assert state.port_lock_files == {}
+    assert state.allocated_ports == set()
+    assert state.owned_ports == {}
+    first_lock.close.assert_called_once()
+    second_lock.close.assert_called_once()
 
 
 def test_release_ports_running_child_returns_conflict(client, state: GuardState):
@@ -144,6 +252,168 @@ def test_fork_spawn_failure_releases_owned_ports(mock_run, client, state: GuardS
 
 
 @patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
+def test_concurrent_forks_start_only_one_process(mock_run, state: GuardState):
+    """Two requests for one owner cannot both spawn a child process."""
+    app = create_app(state)
+    app.config["TESTING"] = True
+    state.owned_ports[("worker", 10)] = {9019}
+    state.allocated_ports.add(9019)
+    spawn_entered = threading.Event()
+    allow_spawn = threading.Event()
+    second_lock_attempted = threading.Event()
+    statuses: list[int] = []
+    state.forked_children_lock = _ObservableLock(
+        state.forked_children_lock, "second-fork", second_lock_attempted
+    )
+
+    def _spawn(*args, **kwargs):
+        spawn_entered.set()
+        assert allow_spawn.wait(timeout=5)
+        return _make_mock_process(pid=44)
+
+    def _fork_request():
+        with app.test_client() as thread_client:
+            response = thread_client.post(
+                "/fork",
+                json={
+                    "role": "worker",
+                    "worker_index": 10,
+                    "raw_cmd": ["python"],
+                },
+            )
+            statuses.append(response.status_code)
+
+    mock_run.side_effect = _spawn
+    first = threading.Thread(target=_fork_request)
+    second = threading.Thread(target=_fork_request, name="second-fork")
+
+    first.start()
+    assert spawn_entered.wait(timeout=5)
+    second.start()
+    assert second_lock_attempted.wait(timeout=5)
+    allow_spawn.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert sorted(statuses) == [200, 409]
+    assert mock_run.call_count == 1
+    assert state.forked_children_map[("worker", 10)].pid == 44
+
+
+@patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
+def test_failed_fork_releases_before_waiting_fork_proceeds(mock_run, state: GuardState):
+    """A failed fork drops its reservation before a waiting fork validates."""
+    app = create_app(state)
+    app.config["TESTING"] = True
+    state.owned_ports[("worker", 12)] = {9024}
+    state.allocated_ports.add(9024)
+    spawn_entered = threading.Event()
+    allow_failure = threading.Event()
+    second_lock_attempted = threading.Event()
+    statuses: list[int] = []
+    state.forked_children_lock = _ObservableLock(
+        state.forked_children_lock, "second-fork", second_lock_attempted
+    )
+
+    def _fail_spawn(*args, **kwargs):
+        spawn_entered.set()
+        assert allow_failure.wait(timeout=5)
+        raise RuntimeError("spawn failed")
+
+    def _fork_request():
+        with app.test_client() as thread_client:
+            response = thread_client.post(
+                "/fork",
+                json={
+                    "role": "worker",
+                    "worker_index": 12,
+                    "raw_cmd": ["python"],
+                },
+            )
+            statuses.append(response.status_code)
+
+    mock_run.side_effect = _fail_spawn
+    first = threading.Thread(target=_fork_request)
+    second = threading.Thread(target=_fork_request, name="second-fork")
+
+    first.start()
+    assert spawn_entered.wait(timeout=5)
+    second.start()
+    assert second_lock_attempted.wait(timeout=5)
+    allow_failure.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert sorted(statuses) == [409, 500]
+    assert mock_run.call_count == 1
+    assert state.allocated_ports == set()
+    assert state.owned_ports == {}
+    assert state.forked_children_map == {}
+
+
+@patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
+def test_release_waits_for_inflight_fork(mock_run, state: GuardState):
+    """A release racing with Popen observes the registered child and conflicts."""
+    app = create_app(state)
+    app.config["TESTING"] = True
+    state.owned_ports[("worker", 11)] = {9021}
+    state.allocated_ports.add(9021)
+    spawn_entered = threading.Event()
+    allow_spawn = threading.Event()
+    release_lock_attempted = threading.Event()
+    statuses: dict[str, int] = {}
+    state.forked_children_lock = _ObservableLock(
+        state.forked_children_lock, "release-request", release_lock_attempted
+    )
+
+    def _spawn(*args, **kwargs):
+        spawn_entered.set()
+        assert allow_spawn.wait(timeout=5)
+        return _make_mock_process(pid=45)
+
+    def _fork_request():
+        with app.test_client() as thread_client:
+            response = thread_client.post(
+                "/fork",
+                json={
+                    "role": "worker",
+                    "worker_index": 11,
+                    "raw_cmd": ["python"],
+                },
+            )
+            statuses["fork"] = response.status_code
+
+    def _release_request():
+        with app.test_client() as thread_client:
+            response = thread_client.post(
+                "/release_ports", json={"role": "worker", "worker_index": 11}
+            )
+            statuses["release"] = response.status_code
+
+    mock_run.side_effect = _spawn
+    fork_thread = threading.Thread(target=_fork_request)
+    release_thread = threading.Thread(target=_release_request, name="release-request")
+
+    fork_thread.start()
+    assert spawn_entered.wait(timeout=5)
+    release_thread.start()
+    assert release_lock_attempted.wait(timeout=5)
+    allow_spawn.set()
+    fork_thread.join(timeout=5)
+    release_thread.join(timeout=5)
+
+    assert not fork_thread.is_alive()
+    assert not release_thread.is_alive()
+    assert statuses == {"fork": 200, "release": 409}
+    assert state.owned_ports[("worker", 11)] == {9021}
+    assert state.allocated_ports == {9021}
+
+
+@patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
 def test_fork_raw_command_success(mock_run, client, state: GuardState):
     mock_proc = _make_mock_process(pid=42)
     mock_run.return_value = mock_proc
@@ -181,6 +451,39 @@ def test_kill_known_worker(mock_kill, client, state: GuardState):
     assert ("test", 0) not in state.owned_ports
     assert 9014 not in state.allocated_ports
     mock_kill.assert_called_once_with(123, timeout=3, graceful=True)
+
+
+@patch("areal.infra.rpc.guard.app.kill_process_tree")
+def test_kill_does_not_remove_replacement_owner(mock_kill, client, state: GuardState):
+    """A stale concurrent kill cannot clean up a newer child generation."""
+    key = ("test", 2)
+    old_process = _make_mock_process(pid=125)
+    replacement_process = _make_mock_process(pid=126)
+    state.forked_children.append(old_process)
+    state.forked_children_map[key] = old_process
+    state.owned_ports[key] = {9022}
+    state.allocated_ports.add(9022)
+
+    def _replace_owner(*args, **kwargs):
+        with state.forked_children_lock, state.allocated_ports_lock:
+            state.forked_children.remove(old_process)
+            state.forked_children.append(replacement_process)
+            state.forked_children_map[key] = replacement_process
+            state.allocated_ports.remove(9022)
+            state.allocated_ports.add(9023)
+            state.owned_ports[key] = {9023}
+
+    mock_kill.side_effect = _replace_owner
+
+    response = client.post(
+        "/kill_forked_worker", json={"role": "test", "worker_index": 2}
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["released_ports"] == []
+    assert state.forked_children_map[key] is replacement_process
+    assert state.owned_ports[key] == {9023}
+    assert state.allocated_ports == {9023}
 
 
 @patch("areal.infra.rpc.guard.app.kill_process_tree", side_effect=RuntimeError("busy"))

--- a/tests/infra/data_service/test_guard.py
+++ b/tests/infra/data_service/test_guard.py
@@ -20,7 +20,9 @@ def state() -> GuardState:
     s.trial_name = "test-trial"
     s.role = "test-role"
     s.worker_index = 0
-    return s
+    yield s
+    for lock_file in s.port_lock_files.values():
+        lock_file.close()
 
 
 @pytest.fixture()
@@ -57,10 +59,96 @@ def test_alloc_ports_success(mock_find, client, state: GuardState):
     assert state.allocated_ports == {9001, 9002}
 
 
+@patch("areal.infra.rpc.guard.app.find_free_ports")
+def test_owned_ports_release_after_failed_fork(mock_find, client, state: GuardState):
+    mock_find.return_value = [9010]
+    alloc = client.post(
+        "/alloc_ports",
+        json={"count": 1, "role": "worker", "worker_index": 2},
+    )
+    assert alloc.status_code == 200
+
+    released = client.post("/release_ports", json={"role": "worker", "worker_index": 2})
+
+    assert released.status_code == 200
+    assert released.get_json()["ports"] == [9010]
+    assert 9010 not in state.allocated_ports
+    assert ("worker", 2) not in state.owned_ports
+
+
+@patch("areal.infra.rpc.guard.app.find_free_ports")
+def test_alloc_ports_duplicate_owner_returns_conflict(
+    mock_find, client, state: GuardState
+):
+    mock_find.return_value = [9011]
+    payload = {"count": 1, "role": "worker", "worker_index": 3}
+
+    first = client.post("/alloc_ports", json=payload)
+    second = client.post("/alloc_ports", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+    assert state.owned_ports[("worker", 3)] == {9011}
+
+
+def test_release_ports_running_child_returns_conflict(client, state: GuardState):
+    mock_proc = _make_mock_process(pid=41)
+    state.forked_children_map[("worker", 4)] = mock_proc
+    state.owned_ports[("worker", 4)] = {9012}
+    state.allocated_ports.add(9012)
+
+    response = client.post("/release_ports", json={"role": "worker", "worker_index": 4})
+
+    assert response.status_code == 409
+    assert state.owned_ports[("worker", 4)] == {9012}
+    assert state.allocated_ports == {9012}
+
+
+@patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
+def test_fork_without_port_reservation_returns_conflict(
+    mock_run, client, state: GuardState
+):
+    response = client.post(
+        "/fork",
+        json={
+            "role": "worker",
+            "worker_index": 5,
+            "raw_cmd": ["python", "-m", "module"],
+        },
+    )
+
+    assert response.status_code == 409
+    mock_run.assert_not_called()
+
+
+@patch(
+    "areal.infra.rpc.guard.app.run_with_streaming_logs",
+    side_effect=RuntimeError("spawn failed"),
+)
+def test_fork_spawn_failure_releases_owned_ports(mock_run, client, state: GuardState):
+    state.owned_ports[("worker", 6)] = {9013}
+    state.allocated_ports.add(9013)
+
+    response = client.post(
+        "/fork",
+        json={
+            "role": "worker",
+            "worker_index": 6,
+            "raw_cmd": ["python", "-m", "module", "--port", "9013"],
+        },
+    )
+
+    assert response.status_code == 500
+    assert ("worker", 6) not in state.owned_ports
+    assert 9013 not in state.allocated_ports
+
+
 @patch("areal.infra.rpc.guard.app.run_with_streaming_logs")
 def test_fork_raw_command_success(mock_run, client, state: GuardState):
     mock_proc = _make_mock_process(pid=42)
     mock_run.return_value = mock_proc
+    state.owned_ports[("worker", 1)] = {8001}
+    state.allocated_ports.add(8001)
 
     resp = client.post(
         "/fork",
@@ -83,11 +171,31 @@ def test_kill_known_worker(mock_kill, client, state: GuardState):
     mock_proc = _make_mock_process(pid=123)
     state.forked_children.append(mock_proc)
     state.forked_children_map[("test", 0)] = mock_proc
+    state.owned_ports[("test", 0)] = {9014}
+    state.allocated_ports.add(9014)
 
     resp = client.post("/kill_forked_worker", json={"role": "test", "worker_index": 0})
     assert resp.status_code == 200
+    assert resp.get_json()["released_ports"] == [9014]
     assert ("test", 0) not in state.forked_children_map
+    assert ("test", 0) not in state.owned_ports
+    assert 9014 not in state.allocated_ports
     mock_kill.assert_called_once_with(123, timeout=3, graceful=True)
+
+
+@patch("areal.infra.rpc.guard.app.kill_process_tree", side_effect=RuntimeError("busy"))
+def test_failed_kill_keeps_child_and_ports_for_retry(mock_kill, client, state):
+    mock_proc = _make_mock_process(pid=124)
+    state.forked_children.append(mock_proc)
+    state.forked_children_map[("test", 1)] = mock_proc
+    state.owned_ports[("test", 1)] = {9020}
+    state.allocated_ports.add(9020)
+
+    resp = client.post("/kill_forked_worker", json={"role": "test", "worker_index": 1})
+
+    assert resp.status_code == 500
+    assert state.forked_children_map[("test", 1)] is mock_proc
+    assert state.owned_ports[("test", 1)] == {9020}
 
 
 @patch("areal.infra.rpc.guard.app.kill_process_tree")

--- a/tests/test_local_scheduler.py
+++ b/tests/test_local_scheduler.py
@@ -2126,7 +2126,7 @@ class TestForkColocationBehavior:
 
         alloc_resp = requests.post(
             f"http://{host}:{port}/alloc_ports",
-            json={"count": 1},
+            json={"count": 1, "role": "ref", "worker_index": 0},
             timeout=10,
         )
         assert alloc_resp.status_code == 200
@@ -2190,7 +2190,7 @@ class TestForkColocationBehavior:
 
         alloc_resp = requests.post(
             f"http://{host}:{port}/alloc_ports",
-            json={"count": 1},
+            json={"count": 1, "role": "ref", "worker_index": 0},
             timeout=10,
         )
         assert alloc_resp.status_code == 200

--- a/tests/v2/agent_service/test_guard.py
+++ b/tests/v2/agent_service/test_guard.py
@@ -22,7 +22,11 @@ GUARD_APP = "areal.infra.rpc.guard.app"
 @pytest.fixture(autouse=True)
 def _reset_guard_globals():
     """Reset all guard state between tests."""
+    for lock_file in guard_module._state.port_lock_files.values():
+        lock_file.close()
     guard_module._state.allocated_ports = set()
+    guard_module._state.owned_ports = {}
+    guard_module._state.port_lock_files = {}
     guard_module._state.forked_children = []
     guard_module._state.forked_children_map = {}
     guard_module._state.server_host = "10.0.0.1"
@@ -30,7 +34,11 @@ def _reset_guard_globals():
     guard_module._state.trial_name = "test-trial"
     guard_module._state.fileroot = None
     yield
+    for lock_file in guard_module._state.port_lock_files.values():
+        lock_file.close()
     guard_module._state.allocated_ports = set()
+    guard_module._state.owned_ports = {}
+    guard_module._state.port_lock_files = {}
     guard_module._state.forked_children = []
     guard_module._state.forked_children_map = {}
 

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -1065,6 +1065,7 @@ class TestMultiNodeConfig:
 
         # Track async client .post calls to /alloc_ports and /fork
         alloc_port_counter = 0
+        alloc_calls = []
         fork_calls = []
 
         async def mock_async_post(url, json=None, timeout=None):
@@ -1074,10 +1075,13 @@ class TestMultiNodeConfig:
             resp.raise_for_status = MagicMock()
             if "/alloc_ports" in url:
                 alloc_port_counter += 1
+                alloc_calls.append(json)
+                port_count = json["count"]
+                first_port = 30000 + 2 * alloc_port_counter
                 resp.json.return_value = {
                     "status": "success",
                     "host": url.split("//")[1].split(":")[0],
-                    "ports": [30000 + alloc_port_counter],
+                    "ports": list(range(first_port, first_port + port_count)),
                 }
             elif "/fork" in url:
                 fork_calls.append(json)
@@ -1115,9 +1119,13 @@ class TestMultiNodeConfig:
         job = create_call.kwargs.get("job") or create_call.args[0]
         assert job.replicas == 2
 
-        # Async client .post calls for inf server fork:
-        # 1 rendezvous alloc (nnodes_per_instance > 1) + 2 node allocs + 2 forks = 5
-        assert alloc_port_counter == 3  # 1 rendezvous + 2 per-node
+        # One owner-bound reservation per inference worker. The head reserves
+        # both its HTTP port and the distributed rendezvous port.
+        assert alloc_port_counter == 2
+        assert alloc_calls == [
+            {"count": 2, "role": "inf-server", "worker_index": 0},
+            {"count": 1, "role": "inf-server", "worker_index": 1},
+        ]
         assert len(fork_calls) == 2  # 1 per node in the group
 
         # Verify fork payloads have correct worker_index and role
@@ -1149,3 +1157,67 @@ class TestMultiNodeConfig:
             c for c in mock_fork.call_args_list if c.kwargs.get("role") == "data-proxy"
         ]
         assert len(data_proxy_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_fork_inf_servers_failure_releases_owned_ports(self):
+        worker = MagicMock()
+        worker.ip = "10.0.0.1"
+        worker.worker_ports = [18000]
+
+        cfg = InferenceEngineConfig(
+            tokenizer_path="mock-tokenizer",
+            backend="sglang:d1",
+        )
+        controller = RolloutControllerV2(
+            config=cfg, scheduler=MagicMock(n_gpus_per_node=8)
+        )
+        requests = []
+
+        async def mock_async_post(url, json=None, timeout=None):
+            requests.append((url, json))
+            resp = MagicMock()
+            if url.endswith("/alloc_ports"):
+                resp.json.return_value = {
+                    "status": "success",
+                    "host": "10.0.0.1",
+                    "ports": [30000],
+                }
+            elif url.endswith("/fork"):
+                resp.raise_for_status.side_effect = RuntimeError("fork failed")
+            return resp
+
+        mock_async_client = AsyncMock()
+        mock_async_client.post = mock_async_post
+
+        with (
+            patch.object(
+                controller, "_get_async_client", return_value=mock_async_client
+            ),
+            patch(
+                "areal.api.cli_args.SGLangConfig.build_cmd_from_args",
+                return_value=["python", "-m", "sglang.launch_server"],
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="fork failed"):
+                await controller._async_fork_inf_servers(
+                    cfg=cfg,
+                    alloc=None,
+                    inf_backend="sglang",
+                    inf_workers=[worker],
+                    dp_size=1,
+                    nnodes_per_instance=1,
+                    worker_env={},
+                    server_args=None,
+                )
+
+        assert requests[0] == (
+            "http://10.0.0.1:18000/alloc_ports",
+            {"count": 1, "role": "inf-server", "worker_index": 0},
+        )
+        assert [url.rsplit("/", 1)[-1] for url, _ in requests[-2:]] == [
+            "kill_forked_worker",
+            "release_ports",
+        ]
+        assert controller._inf_addrs == []
+        assert controller._server_infos == []
+        assert controller._forked_services == []

--- a/tests/v2/inference_service/test_guard.py
+++ b/tests/v2/inference_service/test_guard.py
@@ -20,7 +20,11 @@ GUARD_APP = "areal.infra.rpc.guard.app"
 
 @pytest.fixture(autouse=True)
 def _reset_guard_globals():
+    for lock_file in guard_module._state.port_lock_files.values():
+        lock_file.close()
     guard_module._state.allocated_ports = set()
+    guard_module._state.owned_ports = {}
+    guard_module._state.port_lock_files = {}
     guard_module._state.forked_children = []
     guard_module._state.forked_children_map = {}
     guard_module._state.server_host = "10.0.0.1"
@@ -28,7 +32,11 @@ def _reset_guard_globals():
     guard_module._state.trial_name = "test-trial"
     guard_module._state.fileroot = None
     yield
+    for lock_file in guard_module._state.port_lock_files.values():
+        lock_file.close()
     guard_module._state.allocated_ports = set()
+    guard_module._state.owned_ports = {}
+    guard_module._state.port_lock_files = {}
     guard_module._state.forked_children = []
     guard_module._state.forked_children_map = {}
 
@@ -129,6 +137,7 @@ class TestFork:
     def test_fork_raw_cmd_passes_command_as_is(self, mock_run, client):
         mock_proc = _make_mock_process(pid=55)
         mock_run.return_value = mock_proc
+        guard_module._state.owned_ports[("sglang", 0)] = {8001}
 
         raw = [
             "python",
@@ -156,6 +165,7 @@ class TestFork:
     def test_fork_tracks_child(self, mock_run, client):
         mock_proc = _make_mock_process(pid=42)
         mock_run.return_value = mock_proc
+        guard_module._state.owned_ports[("test", 0)] = {8001}
 
         client.post(
             "/fork",
@@ -173,6 +183,7 @@ class TestFork:
     @patch(f"{GUARD_APP}.run_with_streaming_logs")
     def test_fork_with_env_overrides(self, mock_run, client):
         mock_run.return_value = _make_mock_process()
+        guard_module._state.owned_ports[("test", 0)] = {8001}
 
         resp = client.post(
             "/fork",


### PR DESCRIPTION
## Summary

- bind Guard port reservations to `(role, worker_index)` and coordinate same-user Guards with node-local file locks
- keep child and port ownership retryable when process termination fails
- roll back partial fork, readiness, and configuration failures across schedulers and service controllers
- migrate Guard fork callers to the owner-bound allocation protocol

## Related issue

Related to #1592. This PR isolates the Guard process/port lifecycle change for independent review.

## Risk analysis

- `POST /fork` now requires a matching owner-bound `/alloc_ports` reservation; all in-tree callers are migrated here.
- startup rollback is best-effort and retains Guard ownership when termination fails, allowing a later retry instead of losing the child record and reserved ports.
- node-local file locks prevent two same-user Guard processes from reserving the same port.

## Validation

- Slurm job `957054`: 151 passed, 93 skipped
- Slurm job `957057`: `pre-commit run --all-files` passed

## Checklist

- [x] based on the latest `main`
- [x] targeted scheduler and controller tests passed
- [x] full pre-commit stack passed
- [x] self-reviewed for unrelated MOPD/AWEX changes