### PR TITLE
fix(engine): preserve signals across MindSpeed import

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -20,14 +20,14 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import areal.engine.megatron_utils.ascend_log_patches  # noqa: F401 isort: skip  # before MindSpeed
-import areal.utils.torch_npu_compat  # noqa: F401 isort: skip  # before MindSpeed
+from areal.utils.torch_npu_compat import import_mindspeed_adaptor  # isort: skip
 import areal.engine.megatron_utils.triton_l2norm_patch  # noqa: F401 isort: skip  # before MindSpeed: fast GDN l2norm
 from areal.engine.megatron_utils.mindspeed_args_patch import (
     ensure_mindspeed_args_sanitized,
 )  # isort: skip
 
 ensure_mindspeed_args_sanitized()
-import mindspeed.megatron_adaptor  # noqa: F401 isort: skip
+import_mindspeed_adaptor()
 
 # Install the Transformer Engine import shim before the first ``import mbridge``.
 import areal.utils.mbridge_compat  # noqa: F401, I001  # isort: skip

--- a/areal/utils/torch_npu_compat.py
+++ b/areal/utils/torch_npu_compat.py
@@ -7,7 +7,11 @@ this BEFORE ``mindspeed.megatron_adaptor`` so the shims are in place before
 MindSpeed re-binds the affected symbols.
 """
 
+import importlib
 import os
+import signal
+import threading
+from types import ModuleType
 
 GROUPED_P2P_ENV = "AREAL_NPU_GROUPED_P2P"
 
@@ -28,6 +32,27 @@ GROUPED_P2P_ENV = "AREAL_NPU_GROUPED_P2P"
 # The pinned 2.10.0.post4 wheel (git 5dd8ef3f) still contains this code.
 GROUPED_P2P_BROKEN_SINCE = "2.10.0.post2"
 GROUPED_P2P_FIXED_IN = None  # set once a wheel carrying the fix is validated
+
+
+def import_mindspeed_adaptor() -> ModuleType:
+    """Import MindSpeed without retaining TorchAir's process signal handlers.
+
+    MindSpeed 0.18 eagerly imports TorchAir, whose import-time handlers consume
+    SIGINT and SIGTERM instead of terminating the process. Preserve whatever
+    handlers the application installed before the adaptor import so Ctrl-C and
+    scheduler termination retain their original semantics.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        return importlib.import_module("mindspeed.megatron_adaptor")
+
+    original_handlers = {
+        signum: signal.getsignal(signum) for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    try:
+        return importlib.import_module("mindspeed.megatron_adaptor")
+    finally:
+        for signum, handler in original_handlers.items():
+            signal.signal(signum, handler)
 
 
 def grouped_p2p_broken(torch_npu_version: str) -> bool:

--- a/tests/test_megatron_engine_vlm_distributed.py
+++ b/tests/test_megatron_engine_vlm_distributed.py
@@ -19,7 +19,9 @@ import sys
 import pytest
 
 try:
-    import mindspeed.megatron_adaptor  # noqa: F401 isort: skip  # must precede mbridge on NPU
+    from areal.utils.torch_npu_compat import import_mindspeed_adaptor
+
+    import_mindspeed_adaptor()
 except ImportError:
     pass
 

--- a/tests/test_mixed_multimodal_batch_megatron.py
+++ b/tests/test_mixed_multimodal_batch_megatron.py
@@ -12,7 +12,9 @@ in. Run this file in its own pytest process::
 
 try:
     # Must precede every areal.engine import; absent on non-NPU platforms.
-    import mindspeed.megatron_adaptor  # noqa: F401  # isort: skip
+    from areal.utils.torch_npu_compat import import_mindspeed_adaptor
+
+    import_mindspeed_adaptor()
 except ImportError:
     pass
 

--- a/tests/test_torch_npu_compat.py
+++ b/tests/test_torch_npu_compat.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import signal
+from types import ModuleType
+
+import pytest
+
+from areal.utils import torch_npu_compat
+
+
+def _mock_signal_state(monkeypatch):
+    original_sigint = object()
+    original_sigterm = object()
+    handlers = {
+        signal.SIGINT: original_sigint,
+        signal.SIGTERM: original_sigterm,
+    }
+
+    monkeypatch.setattr(signal, "getsignal", handlers.__getitem__)
+
+    def set_handler(signum, handler):
+        previous = handlers[signum]
+        handlers[signum] = handler
+        return previous
+
+    monkeypatch.setattr(signal, "signal", set_handler)
+    return handlers, original_sigint, original_sigterm
+
+
+def test_import_mindspeed_adaptor_restores_signal_handlers(monkeypatch):
+    handlers, original_sigint, original_sigterm = _mock_signal_state(monkeypatch)
+    torchair_handler = object()
+    adaptor = ModuleType("mindspeed.megatron_adaptor")
+
+    def import_module(name):
+        assert name == "mindspeed.megatron_adaptor"
+        handlers[signal.SIGINT] = torchair_handler
+        handlers[signal.SIGTERM] = torchair_handler
+        return adaptor
+
+    monkeypatch.setattr(torch_npu_compat.importlib, "import_module", import_module)
+
+    assert torch_npu_compat.import_mindspeed_adaptor() is adaptor
+    assert handlers == {
+        signal.SIGINT: original_sigint,
+        signal.SIGTERM: original_sigterm,
+    }
+
+
+def test_import_mindspeed_adaptor_restores_handlers_after_error(monkeypatch):
+    handlers, original_sigint, original_sigterm = _mock_signal_state(monkeypatch)
+    torchair_handler = object()
+
+    def import_module(name):
+        assert name == "mindspeed.megatron_adaptor"
+        handlers[signal.SIGINT] = torchair_handler
+        handlers[signal.SIGTERM] = torchair_handler
+        raise RuntimeError("adaptor import failed")
+
+    monkeypatch.setattr(torch_npu_compat.importlib, "import_module", import_module)
+
+    with pytest.raises(RuntimeError, match="adaptor import failed"):
+        torch_npu_compat.import_mindspeed_adaptor()
+
+    assert handlers == {
+        signal.SIGINT: original_sigint,
+        signal.SIGTERM: original_sigterm,
+    }
+
+
+def test_import_mindspeed_adaptor_skips_signal_calls_off_main_thread(monkeypatch):
+    adaptor = ModuleType("mindspeed.megatron_adaptor")
+    monkeypatch.setattr(torch_npu_compat.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(
+        torch_npu_compat.importlib, "import_module", lambda name: adaptor
+    )
+    monkeypatch.setattr(
+        torch_npu_compat.signal,
+        "getsignal",
+        lambda signum: pytest.fail("getsignal should not be called"),
+    )
+    monkeypatch.setattr(
+        torch_npu_compat.signal,
+        "signal",
+        lambda signum, handler: pytest.fail("signal should not be called"),
+    )
+
+    assert torch_npu_compat.import_mindspeed_adaptor() is adaptor

--- a/tests/torchrun/run_megatron_engine_distributed.py
+++ b/tests/torchrun/run_megatron_engine_distributed.py
@@ -6,8 +6,9 @@ from functools import cache
 from typing import Any
 
 try:
-    import areal.utils.torch_npu_compat  # noqa: F401  isort: skip  # before MindSpeed
-    import mindspeed.megatron_adaptor  # noqa: F401  isort: skip  # before megatron.core
+    from areal.utils.torch_npu_compat import import_mindspeed_adaptor
+
+    import_mindspeed_adaptor()
 except ImportError:
     pass
 

--- a/tests/torchrun/run_megatron_engine_vlm_distributed.py
+++ b/tests/torchrun/run_megatron_engine_vlm_distributed.py
@@ -20,7 +20,9 @@ from pathlib import Path
 from typing import Any
 
 try:
-    import mindspeed.megatron_adaptor  # noqa: F401  # must precede mbridge on NPU
+    from areal.utils.torch_npu_compat import import_mindspeed_adaptor
+
+    import_mindspeed_adaptor()
 except ImportError:
     pass
 


### PR DESCRIPTION
## Description

Preserve the application's SIGINT and SIGTERM handlers while importing the MindSpeed adaptor.

MindSpeed 0.18 eagerly imports TorchAir, whose import-time handler replaces both process signals. On the first Ctrl-C, TorchAir finalizes its graph engine, switches SIGINT to `SIG_IGN`, and re-sends the now-ignored signal. A foreground trainer therefore continues running, and later Ctrl-C attempts have no effect. This is especially visible with Ray because actor workers run outside the terminal foreground process group.

Key changes:

- Add a shared MindSpeed-adaptor import helper that saves and restores existing SIGINT/SIGTERM handlers, including when import fails.
- Route the production Megatron engine and direct distributed-test adaptor imports through the helper.
- Preserve non-main-thread behavior, where Python cannot install process signal handlers.
- Add focused tests for normal restoration, exception restoration, and non-main-thread imports.

## Related Issue

Follow-up to #1660.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

The issue was reproduced in a two-node Ray training run on node12. The trainer was the terminal foreground process but remained inside `ppo_update`; `/proc/<pid>/status` showed SIGINT ignored after Ctrl-C, while Ray actors in a separate process group continued running. Comparing containers showed MindSpeed 0.16 with torch-npu 2.10.0.post2 left signal handlers unchanged, while MindSpeed 0.18 with torch-npu 2.10.0.post4 replaced both handlers during adaptor import.

Validation:

- `pytest -q tests/test_torch_npu_compat.py` (`3 passed`) locally and in `areal-node-rongzhi-m18` on node12.
- Full `pre-commit run --all-files` passed in a clean checkout.
- Fresh-process node12 validation confirmed SIGINT and SIGTERM remained unchanged after importing `areal.engine.megatron_engine`.
- A self-sent SIGINT raised `KeyboardInterrupt` after the import instead of being swallowed.

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
