### PR TITLE
fix(awex): fix and refactor awex gate attn converter for qwen3.6

### DIFF
--- a/areal/engine/models/qwen3_vl.py
+++ b/areal/engine/models/qwen3_vl.py
@@ -220,22 +220,50 @@ def _split_mcore_gated_attn_qkv(
     train_tp_rank: int,
     train_tp_size: int,
 ) -> list[tuple[str, torch.Tensor]]:
-    """Convert Qwen3.5 full-attention QKV weight: transform + infer TP sharding.
+    """Convert Qwen3.5 full-attention QKV: mcore GQA-interleaved -> infer layout.
 
-    Ported from awex Qwen3_5McoreConverterMixin._transform_qwen3_5_qkv +
-    _shard_qkv_for_infer + _convert_qwen3_5_qkv_param
-    (awex/converter/mcore_converter.py:1379, 1484, 1559).
+    u->q_heads=24,using 8 as example.
+    g->gate_heads=24,using 8 as example just like q.
+    k,v->kv_heads=4
 
-    Per-rank train layout: [Q0..Q_{n-1}(sequential), K, V]
-      Q sequential = [u0..u_{h-1}, c0..c_{h-1}] (unique first, copies second)
-    HF order: Q interleaved [u0,c0,u1,c1,...] + K/V concatenated across ranks.
-    K/V are sharded (not replicated): each rank holds 1 unique KV head
-    (when train_tp >= num_kv_heads). Confirmed via verify_against_hf.py:
-    infer pkl has 3584 rows/rank = 12Q+1K+1V for TP4.
+    mcore 4 group,q_heads // kv_heads
 
-    Note: num_attention_heads reports UNIQUE q heads (24), but the actual
-    QKV tensor has duplicated q heads (48 = 24*2) for Qwen3.5 gating. We
-    detect the duplication factor by matching the local tensor size.
+    g0:[u0 u1 g0 g1 k0 v0]
+    g1:[u2 u3 g2 g3 k1 v1]
+    g2:[u4 u5 g4 g5 k2 v2]
+    g3:[u6 u7 g6 g7 k3 v3]
+    when tp=2, rank_0 has g0、g1 and rank_1 has g2、g3。every rank has full group
+    when tp=4, rank_x has gx,x in [0,1,2,3]。every rank has full group
+    when tp=8，rank_0 has [u0 u1 g0] and rank_1 has [g1 k0 v0].they split up g0 in half.
+
+    vllm
+
+    [u0 g0 u1 g1 u2 g2 u3 g3 u4 g4 u5 g5 u6 g6 u7 g7]
+    [k0 k1 k2 k3]
+    [v0 v1 v2 v3]
+    when tp=2,rank_0 has [u0 g0 u1 g1 u2 g2 u3 g3 k0 k1 v0 v1]
+    when tp=4,rank_0 has [u0 g0 u1 g1 k0 v0]
+    when tp=8,repeat kv:
+    [u0 g0 u1 g1 u2 g2 u3 g3 u4 g4 u5 g5 u6 g6 u7 g7]
+    [k0 k0 k1 k1 k2 k2 k3 k3]
+    [v0 v0 v1 v1 v2 v2 v3 v3]
+    rank_0 has [u0 g0 k0 v0]
+    rank_1 has [u1 g1 k0 v0]
+
+    No mater what the train tp is,just allgather to get all groups.
+    then traverse each group to get all q,z,k,v.like:
+    g0 [u0 u1 g0 g1 k0 v0] → q_u=[u0,u1], z=[g0,g1], k=[k0], v=[v0]
+    g1 [u2 u3 g2 g3 k1 v1] → q_u=[u2,u3], z=[g2,g3], k=[k1], v=[v1]
+    g2 [u4 u5 g4 g5 k2 v2] → q_u=[u4,u5], z=[g4,g5], k=[k2], v=[v2]
+    g3 [u6 u7 g6 g7 k3 v3] → q_u=[u6,u7], z=[g6,g7], k=[k3], v=[v3]
+    q_unique = [u0 u1 u2 u3 u4 u5 u6 u7]
+    z_full   = [g0 g1 g2 g3 g4 g5 g6 g7]
+    key      = [k0 k1 k2 k3]
+    value    = [v0 v1 v2 v3]
+    interleave_idx = _q_interleave_index(16)--> [0,8,1,9,2,10,3,11,4,12,5,13,6,14,7,15]
+    query = [u0 g0 u1 g1 u2 g2 u3 g3 u4 g4 u5 g5 u6 g6 u7 g7]
+    key   =  [k0 k1 k2 k3]
+    value =  [v0 v1 v2 v3]
     """
     from awex.converter.mcore_converter import get_full_tensor
 
@@ -245,119 +273,114 @@ def _split_mcore_gated_attn_qkv(
     head_size = int(getattr(text_config, "head_dim", 0))
     if not head_size:
         head_size = int(getattr(text_config, "hidden_size", 0)) // total_num_heads
+    if not (total_num_heads and total_num_kv_heads and head_size):
+        raise ValueError(
+            f"num_attention_heads/num_key_value_heads/head_dim are required in "
+            f"hf_config.text_config to convert the gated-attn QKV, but some "
+            f"were missing: heads={total_num_heads}, kv={total_num_kv_heads}, "
+            f"head_size={head_size}"
+        )
+    heads_per_group = total_num_heads // total_num_kv_heads
 
-    if train_tp_size <= 1:
-        # No TP: weight is already full. Do Q interleave directly.
-        weight = linear_qkv
-        matched = None
-        for q_dup in (2, 1):
-            effective_q = total_num_heads * q_dup
-            q_per_rank = effective_q
-            kv_per_rank = total_num_kv_heads
-            q_rows = q_per_rank * head_size
-            kv_rows = kv_per_rank * head_size
-            per_rank_total = q_rows + 2 * kv_rows
-            if weight.shape[0] == per_rank_total:
-                matched = (q_dup, effective_q, q_per_rank, kv_per_rank)
-                break
-        if matched is None:
+    per_group_slots = 2 * heads_per_group + 2
+    full_rows = per_group_slots * total_num_kv_heads * head_size
+    # Row sizes of each component within one kv-group.
+    q_u_rows = heads_per_group * head_size
+    z_rows = heads_per_group * head_size
+    kv_rows = head_size
+
+    train_tp_size_eff = train_tp_size if (train_tp_size and train_tp_size > 0) else 1
+    local_size = linear_qkv.shape[0]
+
+    if train_tp_size_eff > 1:
+        if local_size == full_rows:
+            need_gather = False
+        elif local_size * train_tp_size_eff == full_rows:
+            need_gather = True
+        else:
             raise ValueError(
-                f"QKV weight size mismatch (train_tp_size=1): "
-                f"actual={weight.shape[0]}, no q_dup match. "
-                f"num_heads={total_num_heads}, "
-                f"num_kv_heads={total_num_kv_heads}, "
+                f"QKV weight size mismatch: local_size={local_size}, "
+                f"train_tp_size={train_tp_size_eff}. Expected a per-rank shard "
+                f"({full_rows // train_tp_size_eff}) or full ({full_rows}) for "
+                f"the gated GQA layout. num_heads={total_num_heads}, "
+                f"num_kv_heads={total_num_kv_heads}, head_size={head_size}"
+            )
+    else:
+        need_gather = False
+        if local_size != full_rows:
+            raise ValueError(
+                f"QKV weight size mismatch: local_size={local_size}, expected "
+                f"full={full_rows} for the gated GQA layout. num_heads="
+                f"{total_num_heads}, num_kv_heads={total_num_kv_heads}, "
                 f"head_size={head_size}"
             )
-        q_dup, effective_q, q_per_rank, kv_per_rank = matched
-        q_rows = q_per_rank * head_size
-        kv_rows = kv_per_rank * head_size
-        interleave_idx = _q_interleave_index(q_per_rank)
-        q, k, v = weight.split([q_rows, kv_rows, kv_rows], dim=0)
-        orig_shape = q.shape
-        q_heads = q.reshape(q_per_rank, head_size, -1)
-        q = q_heads[interleave_idx].reshape(orig_shape)
-        query, key, value = q, k, v
-    else:
-        # Detect Q head duplication factor (Qwen3.5: 24 unique -> 48 duplicated).
-        local_size = linear_qkv.shape[0]
-        matched = None  # (q_dup, effective_q, q_per_rank, kv_per_rank, need_gather)
-        for q_dup in (2, 1):
-            effective_q = total_num_heads * q_dup
-            if effective_q % train_tp_size != 0:
-                continue
-            q_per_rank = effective_q // train_tp_size
-            kv_per_rank = max(1, total_num_kv_heads // train_tp_size)
-            q_rows = q_per_rank * head_size
-            kv_rows = kv_per_rank * head_size
-            per_rank_total = q_rows + 2 * kv_rows
-            full_total = per_rank_total * train_tp_size
-            if local_size == per_rank_total:
-                matched = (q_dup, effective_q, q_per_rank, kv_per_rank, True)
-                break
-            elif local_size == full_total:
-                matched = (q_dup, effective_q, q_per_rank, kv_per_rank, False)
-                break
-        if matched is None:
-            raise ValueError(
-                f"QKV weight size mismatch: actual local_size={local_size}, "
-                f"no q_dup match. num_heads={total_num_heads}, "
-                f"num_kv_heads={total_num_kv_heads}, head_size={head_size}, "
-                f"train_tp_size={train_tp_size}"
-            )
-        q_dup, effective_q, q_per_rank, kv_per_rank, need_gather = matched
-        q_rows_per_rank = q_per_rank * head_size
-        kv_rows_per_rank = kv_per_rank * head_size
-        weight = get_full_tensor(linear_qkv, dim=0) if need_gather else linear_qkv
-        interleave_idx = _q_interleave_index(q_per_rank)
-        q_parts = []
-        k_parts = []
-        v_parts = []
-        for rank_chunk in torch.chunk(weight, train_tp_size, dim=0):
-            q, k, v = rank_chunk.split(
-                [q_rows_per_rank, kv_rows_per_rank, kv_rows_per_rank], dim=0
-            )
-            orig_shape = q.shape
-            q_heads = q.reshape(q_per_rank, head_size, -1)
-            q = q_heads[interleave_idx].reshape(orig_shape)
-            q_parts.append(q)
-            k_parts.append(k)
-            v_parts.append(v)
-        query = torch.cat(q_parts, dim=0)
-        key = torch.cat(k_parts, dim=0)
-        value = torch.cat(v_parts, dim=0)
 
-    # Shard (Q, K, V) for inference TP: [Q0,K0,V0,Q1,K1,V1,...] + train_tp shard.
-    # Qwen3.5: K/V are SHARDED across infer ranks (1 KV head per rank when
-    # infer_tp == total_num_kv_heads), NOT replicated. The NPU replication
-    # branch was removed for Qwen3.5 (was giving 5120 instead of 3584 rows/rank).
+    weight = get_full_tensor(linear_qkv, dim=0) if need_gather else linear_qkv
+    if weight.shape[0] != full_rows or weight.ndim != 2:
+        raise ValueError(
+            f"QKV full weight mismatch after gather: shape="
+            f"{tuple(weight.shape)}, ndim={weight.ndim}, expected "
+            f"[{full_rows}, *]. Qwen3.5 uses attention_bias=false so a 2D "
+            f"weight is expected on this path."
+        )
+    feature_dim = weight.shape[-1]
+    q_u_parts, z_parts, key_parts, value_parts = [], [], [], []
+    for group in torch.chunk(weight, total_num_kv_heads, dim=0):
+        q_u, z, k, v = group.split([q_u_rows, z_rows, kv_rows, kv_rows], dim=0)
+        q_u_parts.append(q_u)
+        z_parts.append(z)
+        key_parts.append(k)
+        value_parts.append(v)
+    q_unique = torch.cat(q_u_parts, dim=0)  # [num_heads * head_size, feature]
+    z_full = torch.cat(z_parts, dim=0)  # [num_heads * head_size, feature]
+    key = torch.cat(key_parts, dim=0)  # [num_kv * head_size, feature]
+    value = torch.cat(value_parts, dim=0)  # [num_kv * head_size, feature]
+
+    # Q is duplicated (unique + gate). mcore stores them per group as
+    # [Q_u, Z]; HF wants them interleaved per head [u0, c0, u1, c1, ...].
+    # Gather into [all-unique, all-gate] then interleave per head to HF order.
+    effective_q = 2 * total_num_heads
+    combined = torch.cat([q_unique, z_full], dim=0)
+    interleave_idx = _q_interleave_index(effective_q)
+    query = combined.view(effective_q, head_size, feature_dim)[interleave_idx].reshape(
+        -1, feature_dim
+    )
+    # Free the gate intermediates (only `query` is needed downstream).
+    del q_unique, z_full, combined
     if infer_atten_tp_size >= total_num_kv_heads:
         num_kv_head_replicas = infer_atten_tp_size // total_num_kv_heads
-    else:
-        num_kv_head_replicas = 1
-    query_shards = query.chunk(infer_atten_tp_size, dim=0)
-    if infer_atten_tp_size >= total_num_kv_heads:
-        key_chunks = key.chunk(total_num_kv_heads, dim=0)
-        key_shards = [k for k in key_chunks for _ in range(num_kv_head_replicas)]
-        value_chunks = value.chunk(total_num_kv_heads, dim=0)
-        value_shards = [v for v in value_chunks for _ in range(num_kv_head_replicas)]
+        key_shards = [
+            k
+            for k in key.chunk(total_num_kv_heads, dim=0)
+            for _ in range(num_kv_head_replicas)
+        ]
+        value_shards = [
+            v
+            for v in value.chunk(total_num_kv_heads, dim=0)
+            for _ in range(num_kv_head_replicas)
+        ]
     else:
         key_shards = key.chunk(infer_atten_tp_size, dim=0)
         value_shards = value.chunk(infer_atten_tp_size, dim=0)
+    query_shards = query.chunk(infer_atten_tp_size, dim=0)
+
     qkv_tp_groups = []
-    for q_s, k_s, v_s in zip(query_shards, key_shards, value_shards):
-        qkv_tp_groups.append(q_s)
-        qkv_tp_groups.append(k_s)
-        qkv_tp_groups.append(v_s)
+    for query_shard, key_shard, value_shard in zip(
+        query_shards, key_shards, value_shards
+    ):
+        qkv_tp_groups.append(query_shard)
+        qkv_tp_groups.append(key_shard)
+        qkv_tp_groups.append(value_shard)
     merged = torch.cat(qkv_tp_groups, dim=0)
 
-    if train_tp_size and train_tp_size > 1:
+    if train_tp_size_eff > 1:
         if train_tp_rank is None:
             raise ValueError("train_tp_rank is required when train_tp_size > 1")
-        shards = torch.chunk(merged, train_tp_size, dim=0)
+        shards = torch.chunk(merged, train_tp_size_eff, dim=0)
         if train_tp_rank >= len(shards):
             raise ValueError(
                 f"train_tp_rank {train_tp_rank} out of range for "
-                f"tp_size {train_tp_size}"
+                f"tp_size {train_tp_size_eff}"
             )
         merged = shards[train_tp_rank]
     return [("self_attn.qkv_proj.weight", merged)]

--- a/tests/test_qwen3_5_gate_attn_converter.py
+++ b/tests/test_qwen3_5_gate_attn_converter.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import importlib.util as il
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(_HERE)
+
+
+def _ensure_awex_importable():
+    try:
+        import awex  # noqa: F401
+
+        return
+    except Exception:
+        pass
+    awex = types.ModuleType("awex")
+    awex.__path__ = []
+    ac = types.ModuleType("awex.converter")
+    ac.__path__ = []
+    awex.converter = ac
+    am = types.ModuleType("awex.converter.mcore_converter")
+    ac.mcore_converter = am
+    am.get_full_tensor = lambda w, dim=0: w
+    am.McoreToHFWeightConverter = type("X", (), {})
+    am._process_mcore_pp_name = lambda n, *a, **k: n
+    sg = types.ModuleType("awex.converter.sglang_converter")
+    ac.sglang_converter = sg
+    sg.SGlangToHFWeightConverter = type("X", (), {})
+    wc = types.ModuleType("awex.converter.weights_converter")
+    ac.weights_converter = wc
+    wc.append_scale_inv = lambda n, b: n
+    wc.normalize_scale_inv_name = lambda n: (n, False)
+    ashp = types.ModuleType("awex.sharding")
+    ashp.__path__ = []
+    awex.sharding = ashp
+    shp = types.ModuleType("awex.sharding.param_sharding")
+    ashp.param_sharding = shp
+    shp.ShardingStrategy = type("X", (), {})
+    shp.ShardingType = type("X", (), {})
+    shp.get_default_sharding_dim = lambda n: 0
+    sys.modules.update(
+        {
+            "awex": awex,
+            "awex.converter": ac,
+            "awex.converter.mcore_converter": am,
+            "awex.converter.sglang_converter": sg,
+            "awex.converter.weights_converter": wc,
+            "awex.sharding": ashp,
+            "awex.sharding.param_sharding": shp,
+        }
+    )
+
+
+def _load_converter():
+    try:
+        from areal.engine.models.qwen3_vl import _split_mcore_gated_attn_qkv as _fn
+
+        return _fn
+    except Exception:
+        for _pkg in ("areal", "areal.engine", "areal.engine.models"):
+            if _pkg not in sys.modules:
+                _m = types.ModuleType(_pkg)
+                _m.__path__ = []
+                sys.modules[_pkg] = _m
+        _path = os.path.join(REPO, "areal", "engine", "models", "qwen3_vl.py")
+        _spec = il.spec_from_file_location("areal.engine.models.qwen3_vl", _path)
+        _mod = il.module_from_spec(_spec)
+        sys.modules["areal.engine.models.qwen3_vl"] = _mod
+        _spec.loader.exec_module(_mod)
+        return _mod._split_mcore_gated_attn_qkv
+
+
+_ensure_awex_importable()
+_split_mcore_gated_attn_qkv = _load_converter()
+
+
+def _make_hf_qkv(num_heads: int, num_kv: int, head_dim: int, hidden: int):
+    """HF q_proj (per-head [query, gate] -> HF order [u0, c0, u1, c1, ...]),
+    plus k_proj / v_proj (one head per kv group)."""
+    q_proj = torch.zeros(num_heads * head_dim * 2, hidden)
+    for h in range(num_heads):
+        q_proj[h * 2 * head_dim : h * 2 * head_dim + head_dim] = 1000 + h
+        q_proj[h * 2 * head_dim + head_dim : h * 2 * head_dim + 2 * head_dim] = 2000 + h
+    k_proj = torch.zeros(num_kv * head_dim, hidden)
+    v_proj = torch.zeros(num_kv * head_dim, hidden)
+    for g in range(num_kv):
+        k_proj[g * head_dim : (g + 1) * head_dim] = 3000 + g
+        v_proj[g * head_dim : (g + 1) * head_dim] = 4000 + g
+    return q_proj, k_proj, v_proj
+
+
+def _make_mcore_weight(q_proj, k_proj, v_proj, num_heads, num_kv, head_dim):
+    """Build the mcore GQA-interleaved `linear_qkv` (mirrors Megatron-Bridge
+    `merge_qkv_weights` with `attention_output_gate=True`):
+    per kv-group = `[Q_unique(hpg), Z/gate(hpg), K(1), V(1)]`."""
+    hpg = num_heads // num_kv
+    q_r = q_proj.view(num_heads, head_dim * 2, -1)
+    q_r, z_r = torch.chunk(q_r, 2, dim=1)  # [num_heads, head_dim, hidden] each
+    k_r = k_proj.view(num_kv, head_dim, -1)
+    v_r = v_proj.view(num_kv, head_dim, -1)
+    parts = []
+    for g in range(num_kv):
+        parts.extend(
+            [
+                q_r[g * hpg : (g + 1) * hpg],
+                z_r[g * hpg : (g + 1) * hpg],
+                k_r[g : g + 1],
+                v_r[g : g + 1],
+            ]
+        )
+    return torch.cat(parts, dim=0).reshape(-1, q_proj.shape[-1])
+
+
+def _kv_heads_for_infer_rank(i: int, infer_tp: int, num_kv: int) -> list[int]:
+    """kv-head indices vLLM assigns to infer rank i (replicated when
+    infer_tp > num_kv, chunked when infer_tp < num_kv)."""
+    if infer_tp >= num_kv:
+        replicas = infer_tp // num_kv
+        return [i // replicas]
+    per = num_kv // infer_tp
+    return list(range(i * per, (i + 1) * per))
+
+
+def _vllm_expected(q_proj, k_proj, v_proj, num_heads, num_kv, head_dim, infer_tp):
+    """Fused qkv_proj layout vLLM loads: per rank `[Q_shard, K*, V*]` (all K
+    heads then all V heads), Q in HF order. Derived from vLLM semantics only."""
+    q_total = 2 * num_heads  # query + gate
+    q_per = q_total // infer_tp
+    parts = []
+    for i in range(infer_tp):
+        parts.append(q_proj[i * q_per * head_dim : (i + 1) * q_per * head_dim])
+        heads = _kv_heads_for_infer_rank(i, infer_tp, num_kv)
+        for h in heads:  # all K heads for this rank
+            parts.append(k_proj[h * head_dim : (h + 1) * head_dim])
+        for h in heads:  # all V heads for this rank
+            parts.append(v_proj[h * head_dim : (h + 1) * head_dim])
+    return torch.cat(parts, dim=0)
+
+
+def _cfg(num_heads, num_kv, head_dim, hidden):
+    return SimpleNamespace(
+        num_attention_heads=num_heads,
+        num_key_value_heads=num_kv,
+        head_dim=head_dim,
+        hidden_size=hidden,
+        attn_output_gate=True,
+    )
+
+
+def _run_converter(mcore_w, cfg, train_tp, infer_tp, monkeypatch):
+    """Run the converter for every train rank (mocking the TP all-gather) and
+    concatenate per-rank outputs into the full infer-layout."""
+
+    def _fake_get_full_tensor(weight, dim=0):  # noqa: ARG001
+        return mcore_w
+
+    monkeypatch.setattr(
+        "awex.converter.mcore_converter.get_full_tensor", _fake_get_full_tensor
+    )
+    per = mcore_w.shape[0] // train_tp if train_tp > 1 else mcore_w.shape[0]
+    outs = []
+    for r in range(train_tp):
+        shard = mcore_w[r * per : (r + 1) * per] if train_tp > 1 else mcore_w
+        outs.append(
+            _split_mcore_gated_attn_qkv(
+                shard,
+                cfg,
+                infer_tp,
+                train_tp_rank=(r if train_tp > 1 else None),
+                train_tp_size=train_tp,
+            )[0][1]
+        )
+    return torch.cat(outs, dim=0)
+
+
+# Two head structures: hpg=2 (small) and hpg=6 (real Qwen3.5: 24 q / 4 kv).
+
+CONFIGS = [
+    pytest.param(8, 4, 4, 4, id="hpg2"),
+    pytest.param(24, 4, 4, 4, id="hpg6"),
+]
+
+CASES = [
+    pytest.param(2, 2, id="train2_infer2_bug"),
+    pytest.param(2, 4, id="train2_infer4_prod"),
+    pytest.param(4, 4, id="train4_infer4_nocp"),
+    pytest.param(1, 4, id="train1_infer4"),
+    pytest.param(2, 8, id="train2_infer8_repl"),
+    pytest.param(4, 2, id="train4_infer2"),
+    pytest.param(1, 2, id="train1_infer2"),
+    pytest.param(1, 1, id="train1_infer1"),
+    pytest.param(8, 4, id="train8_infer4_tp_gt_kv"),  # train_tp>num_kv (contiguous)
+    pytest.param(8, 8, id="train8_infer8_tp_gt_kv"),
+    pytest.param(8, 2, id="train8_infer2_tp_gt_kv"),
+]
+
+
+@pytest.mark.parametrize("train_tp,infer_tp", CASES)
+@pytest.mark.parametrize("num_heads,num_kv,head_dim,hidden", CONFIGS)
+def test_split_qkv_matches_vllm_layout_for_tp_combo(
+    num_heads, num_kv, head_dim, hidden, train_tp, infer_tp, monkeypatch
+):
+    """Converter output equals vLLM's fused qkv_proj layout for any TP combo."""
+    # Arrange
+    qp, kp, vp = _make_hf_qkv(num_heads, num_kv, head_dim, hidden)
+    mcore_w = _make_mcore_weight(qp, kp, vp, num_heads, num_kv, head_dim)
+    expected = _vllm_expected(qp, kp, vp, num_heads, num_kv, head_dim, infer_tp)
+    cfg = _cfg(num_heads, num_kv, head_dim, hidden)
+
+    got = _run_converter(mcore_w, cfg, train_tp, infer_tp, monkeypatch)
+
+    # Assert
+    assert got.shape == expected.shape, f"{got.shape} != {expected.shape}"
+    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("num_heads,num_kv,head_dim,hidden", CONFIGS)
+def test_split_qkv_all_k_then_all_v_when_infer_tp_below_num_kv(
+    num_heads, num_kv, head_dim, hidden, monkeypatch
+):
+    """Regression: with infer_tp=2 < num_kv=4, each rank's qkv_proj is
+    `[Q, K*, V*]` -- the K block holds only k-head rows (3xxx) and the V
+    block only v-head rows (4xxx), NOT interleaved per kv-head."""
+    # Arrange
+    train_tp, infer_tp = 2, 2
+    qp, kp, vp = _make_hf_qkv(num_heads, num_kv, head_dim, hidden)
+    mcore_w = _make_mcore_weight(qp, kp, vp, num_heads, num_kv, head_dim)
+    cfg = _cfg(num_heads, num_kv, head_dim, hidden)
+
+    # Act
+    got = _run_converter(mcore_w, cfg, train_tp, infer_tp, monkeypatch)
+
+    # Assert: split each rank's qkv into [Q, K*, V*] and check id ranges.
+    q_per = (2 * num_heads) // infer_tp
+    kv_per = num_kv // infer_tp  # >1 here (infer_tp < num_kv)
+    per_rank = (q_per + 2 * kv_per) * head_dim
+    for r in range(train_tp):
+        block = got[r * per_rank : (r + 1) * per_rank]
+        q_ids = {int(x) for x in block[: q_per * head_dim][:, 0].tolist()}
+        k_ids = {
+            int(x)
+            for x in block[q_per * head_dim : (q_per + kv_per) * head_dim][
+                :, 0
+            ].tolist()
+        }
+        v_ids = {int(x) for x in block[(q_per + kv_per) * head_dim :][:, 0].tolist()}
+        assert all(1000 <= i < 3000 for i in q_ids), f"rank {r} Q block leaked: {q_ids}"
+        assert all(3000 <= i < 4000 for i in k_ids), f"rank {r} K block leaked: {k_ids}"
+        assert all(4000 <= i < 5000 for i in v_ids), f"rank {r} V block leaked: {v_ids}"
+
+
+def test_split_qkv_raises_on_unexpected_weight_size(monkeypatch):
+    """A local shard whose size matches neither the per-rank shard nor the full
+    weight is rejected with a clear error (guards against silent corruption)."""
+    # Arrange
+    num_heads, num_kv, head_dim, hidden = 8, 4, 4, 4
+    qp, kp, vp = _make_hf_qkv(num_heads, num_kv, head_dim, hidden)
+    mcore_w = _make_mcore_weight(qp, kp, vp, num_heads, num_kv, head_dim)
+    cfg = _cfg(num_heads, num_kv, head_dim, hidden)
+    wrong = mcore_w[:3]
+    with pytest.raises(ValueError, match="QKV weight size mismatch"):
+        _split_mcore_gated_attn_qkv(
+            wrong, cfg, infer_atten_tp_size=4, train_tp_rank=0, train_tp_size=2
+        )


### PR DESCRIPTION
## Description

awex mcore converter for gate attn now is only avaliable for tp == kv_heads.the situatiion that meets expectations is q_heads % tp == 0.refactor for readability.

u->q_heads=24,using 8 as example.
g->gate_heads=24,using 8 as example just like q.
k,v->kv_heads=4

mcore 
4 group == kv_heads

g0:[u0 u1 g0 g1 k0 v0]
g1:[u2 u3 g2 g3 k1 v1]
g2:[u4 u5 g4 g5 k2 v2]
g3:[u6 u7 g6 g7 k3 v3]
when tp=2, rank_0 has g0、g1 and rank_1 has g2、g3。every rank has full group
when tp=4, rank_x has gx,x in [0,1,2,3]。every rank has full group
when tp=8，rank_0 has [u0 u1 g0] and rank_1 has [g1 k0 v0].they split up g0 in half.

vllm

[u0 g0 u1 g1 u2 g2 u3 g3 u4 g4 u5 g5 u6 g6 u7 g7]
[k0 k1 k2 k3]
[v0 v1 v2 v3]
when tp=2,rank_0 has [u0 g0 u1 g1 u2 g2 u3 g3 k0 k1 v0 v1]
when tp=4,rank_0 has [u0 g0 u1 g1 k0 v0]
when tp=8,repeat kv:
[u0 g0 u1 g1 u2 g2 u3 g3 u4 g4 u5 g5 u6 g6 u7 g7]
[k0 k0 k1 k1 k2 k2 k3 k3]
[v0 v0 v1 v1 v2 v2 v3 v3]
rank_0 has [u0 g0 k0 v0]
rank_1 has [u1 g1 k0 v0]

No mater what the train tp is,just allgather to get all groups.
then traverse each group to get all q,z,k,v.like:
g0 [u0 u1 g0 g1 k0 v0] → q_u=[u0,u1], z=[g0,g1], k=[k0], v=[v0]
g1 [u2 u3 g2 g3 k1 v1] → q_u=[u2,u3], z=[g2,g3], k=[k1], v=[v1]
g2 [u4 u5 g4 g5 k2 v2] → q_u=[u4,u5], z=[g4,g5], k=[k2], v=[v2]
g3 [u6 u7 g6 g7 k3 v3] → q_u=[u6,u7], z=[g6,g7], k=[k3], v=[v3]
q_unique = [u0 u1 u2 u3 u4 u5 u6 u7]
z_full   = [g0 g1 g2 g3 g4 g5 g6 g7]
key      = [k0 k1 k2 k3]
value    = [v0 v1 v2 v3]
interleave_idx = _q_interleave_index(16)--> [0,8,1,9,2,10,3,11,4,12,5,13,6,14,7,15]
query = [u0 g0 u1 g1 u2 g2 u3 g3 u4 g4 u5 g5 u6 g6 u7 g7]
key   =  [k0 k1 k2 k3]
value =  [v0 v1 v2 v3]
## Related Issue

no

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context
no