### PR TITLE
fix(megatron): preserve gradients across MTP depths

### DIFF
--- a/areal/engine/megatron_utils/megatron_bridge_patches.py
+++ b/areal/engine/megatron_utils/megatron_bridge_patches.py
@@ -12,6 +12,7 @@ sentinel prevents double-application. Apply patches at import time via
 from __future__ import annotations
 
 import contextvars
+import functools
 
 import areal.utils.logging as logging
 
@@ -27,6 +28,9 @@ _MTP_TRAIN_LABELS: contextvars.ContextVar = contextvars.ContextVar(
 )
 _MTP_TRAIN_LOSS_MASK: contextvars.ContextVar = contextvars.ContextVar(
     "areal_mtp_train_loss_mask", default=None
+)
+_MTP_TRAIN_DEPTH: contextvars.ContextVar = contextvars.ContextVar(
+    "areal_mtp_train_depth", default=None
 )
 
 
@@ -160,6 +164,51 @@ def _detach_mtp_output_weight(output_layer, output_weight):
     return output_weight.detach()
 
 
+def _wrap_mtp_block_forward_for_gradient_isolation(forward):
+    """Track prediction depth for one MTP block invocation."""
+
+    @functools.wraps(forward)
+    def _patched_forward(self, *args, **kwargs):
+        if _MTP_TRAIN_LABELS.get() is None:
+            return forward(self, *args, **kwargs)
+        depth_token = _MTP_TRAIN_DEPTH.set(0)
+        try:
+            return forward(self, *args, **kwargs)
+        finally:
+            _MTP_TRAIN_DEPTH.reset(depth_token)
+
+    return _patched_forward
+
+
+def _wrap_mtp_get_embeddings_for_gradient_isolation(get_embeddings):
+    """Cut only backbone/shared-embedding edges from the auxiliary graph."""
+
+    @functools.wraps(get_embeddings)
+    def _patched_get_embeddings(self, *args, **kwargs):
+        out = get_embeddings(self, *args, **kwargs)
+        if _MTP_TRAIN_LABELS.get() is None:
+            return out
+        input_ids, position_ids, decoder_input, hidden_states = out
+        depth = _MTP_TRAIN_DEPTH.get()
+        if depth is None:
+            raise RuntimeError(
+                "MTP depth tracking is inactive while isolating training gradients."
+            )
+        _MTP_TRAIN_DEPTH.set(depth + 1)
+
+        # Every prediction depth reuses the backbone embedding. Detach each
+        # embedding output, but detach hidden states only where the backbone
+        # enters the first MTP layer. Later depths must retain their graph so
+        # deeper losses can update preceding MTP layers, including when one
+        # physical layer is applied repeatedly.
+        decoder_input = decoder_input.detach()
+        if depth == 0:
+            hidden_states = hidden_states.detach().requires_grad_(True)
+        return input_ids, position_ids, decoder_input, hidden_states
+
+    return _patched_get_embeddings
+
+
 def _patch_gpt_model_mtp_training() -> None:
     """Enable training the Multi-Token-Prediction (MTP) head as an auxiliary loss.
 
@@ -186,9 +235,11 @@ def _patch_gpt_model_mtp_training() -> None:
            0 predicts t+2); and
          - detaches the effective output weight (shared or untied LM head) to
            isolate backbone gradients.
-    3. ``MultiTokenPredictionLayer._get_embeddings`` is wrapped to detach the
-       backbone hidden states and the MTP embedding input, so the MTP loss only
-       updates MTP parameters.
+    3. ``MultiTokenPredictionBlock.forward`` tracks prediction depth, while
+       ``MultiTokenPredictionLayer._get_embeddings`` detaches the backbone
+       hidden states only at depth zero and detaches the shared embedding input
+       at every depth. This isolates backbone parameters without breaking the
+       gradient chain between distinct or repeated MTP layers.
     """
     try:
         from megatron.core.models.gpt import gpt_model
@@ -201,6 +252,7 @@ def _patch_gpt_model_mtp_training() -> None:
 
     roll_tensor = mtp_mod.roll_tensor
     GPTModel = gpt_model.GPTModel
+    MultiTokenPredictionBlock = mtp_mod.MultiTokenPredictionBlock
     MultiTokenPredictionLayer = mtp_mod.MultiTokenPredictionLayer
 
     # --- 1. GPTModel.forward: capture mtp_kwargs into the ContextVar ---
@@ -236,27 +288,22 @@ def _patch_gpt_model_mtp_training() -> None:
 
     gpt_model.process_mtp_loss = _patched_process_mtp_loss
 
-    # --- 3. MTP layer embeddings: cut backbone from the MTP graph ---
-    _orig_get_embeddings = MultiTokenPredictionLayer._get_embeddings
-
-    def _patched_get_embeddings(self, *args, **kwargs):
-        out = _orig_get_embeddings(self, *args, **kwargs)
-        if _MTP_TRAIN_LABELS.get() is None:
-            return out
-        input_ids, position_ids, decoder_input, hidden_states = out
-        # detach the shared embedding output and the backbone hidden states so
-        # only MTP-internal parameters receive gradients.
-        decoder_input = decoder_input.detach()
-        hidden_states = hidden_states.detach().requires_grad_(True)
-        return input_ids, position_ids, decoder_input, hidden_states
-
-    MultiTokenPredictionLayer._get_embeddings = _patched_get_embeddings
+    # --- 3. MTP layer embeddings: isolate the backbone without severing MTP depth ---
+    MultiTokenPredictionBlock.forward = _wrap_mtp_block_forward_for_gradient_isolation(
+        MultiTokenPredictionBlock.forward
+    )
+    MultiTokenPredictionLayer._get_embeddings = (
+        _wrap_mtp_get_embeddings_for_gradient_isolation(
+            MultiTokenPredictionLayer._get_embeddings
+        )
+    )
 
     gpt_model._areal_mtp_training_applied = True
     logger.info(
         "Applied MTP training patch: GPTModel.forward accepts mtp_kwargs, "
         "process_mtp_loss uses independent label/mask channels with detached "
-        "output weight, and MTP gradients are isolated from the backbone."
+        "output weight, and MTP gradients are isolated from the backbone while "
+        "remaining connected across prediction depths."
     )
 
 

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -5,6 +5,7 @@ Distributed integration tests live in
 subprocesses and require GPUs.
 """
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -598,6 +599,239 @@ class TestPackedContextParallelForward:
         assert seen_mask is loss_mask
         assert _MTP_TRAIN_LABELS.get() is None
         assert _MTP_TRAIN_LOSS_MASK.get() is None
+
+    @pytest.mark.parametrize("repeated_layer", [False, True])
+    def test_mtp_multidepth_gradient_isolation_and_unclipped_sgd_updates(
+        self,
+        monkeypatch,
+        repeated_layer,
+    ):
+        """Auxiliary gradients stay inside all MTP depths, including reuse."""
+        from megatron.core import transformer as transformer_package
+        from megatron.core.models import gpt as gpt_package
+
+        from areal.engine.megatron_utils.megatron_bridge_patches import (
+            _MTP_TRAIN_DEPTH,
+            _MTP_TRAIN_LABELS,
+            _MTP_TRAIN_LOSS_MASK,
+            _patch_gpt_model_mtp_training,
+        )
+
+        class FakeMTPLayer(torch.nn.Module):
+            def __init__(self, weight):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.tensor([weight]))
+
+            def _get_embeddings(
+                self,
+                input_ids,
+                position_ids,
+                embedding,
+                hidden_states,
+            ):
+                return (
+                    input_ids,
+                    position_ids,
+                    embedding(input_ids=input_ids, position_ids=position_ids),
+                    hidden_states,
+                )
+
+            def forward(
+                self,
+                input_ids,
+                position_ids,
+                embedding,
+                hidden_states,
+            ):
+                input_ids, position_ids, decoder_input, hidden_states = (
+                    self._get_embeddings(
+                        input_ids=input_ids,
+                        position_ids=position_ids,
+                        embedding=embedding,
+                        hidden_states=hidden_states,
+                    )
+                )
+                return (
+                    self.weight * (decoder_input + hidden_states),
+                    input_ids,
+                    position_ids,
+                )
+
+        class FakeMTPBlock(torch.nn.Module):
+            def __init__(self, use_repeated_layer):
+                super().__init__()
+                self.use_repeated_layer = use_repeated_layer
+                weights = [7.0] if use_repeated_layer else [7.0, 11.0]
+                self.layers = torch.nn.ModuleList(
+                    [FakeMTPLayer(weight) for weight in weights]
+                )
+
+            def forward(
+                self,
+                input_ids,
+                position_ids,
+                embedding,
+                hidden_states,
+            ):
+                depth_outputs = []
+                for depth in range(2):
+                    layer = (
+                        self.layers[0]
+                        if self.use_repeated_layer
+                        else self.layers[depth]
+                    )
+                    hidden_states, input_ids, position_ids = layer(
+                        input_ids=input_ids,
+                        position_ids=position_ids,
+                        embedding=embedding,
+                        hidden_states=hidden_states,
+                    )
+                    depth_outputs.append(hidden_states)
+                return depth_outputs
+
+        fake_gpt_model = None
+
+        class FakeGPTModel(torch.nn.Module):
+            def __init__(self, use_repeated_layer):
+                super().__init__()
+                self.backbone_weight = torch.nn.Parameter(torch.tensor([5.0]))
+                self.embedding_weight = torch.nn.Parameter(torch.tensor([3.0]))
+                self.output_weight = torch.nn.Parameter(torch.tensor([2.0]))
+                self.mtp = FakeMTPBlock(use_repeated_layer)
+
+            def embedding(self, *, input_ids, position_ids):
+                del input_ids, position_ids
+                return self.embedding_weight
+
+            def forward(self, input_ids, position_ids):
+                backbone_hidden = self.backbone_weight
+                depth_outputs = self.mtp(
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    embedding=self.embedding,
+                    hidden_states=backbone_hidden,
+                )
+                mtp_loss = fake_gpt_model.process_mtp_loss(
+                    hidden_states=depth_outputs,
+                    labels=None,
+                    loss_mask=None,
+                    output_weight=self.output_weight,
+                )
+                main_loss = (
+                    13.0
+                    * self.output_weight
+                    * (backbone_hidden + self.embedding_weight)
+                )
+                return main_loss, mtp_loss
+
+        def fake_roll_tensor(tensor, **_kwargs):
+            return tensor.clone(), tensor.sum()
+
+        def fake_process_mtp_loss(
+            *,
+            hidden_states,
+            labels,
+            loss_mask,
+            output_weight,
+        ):
+            assert labels is not None
+            assert loss_mask is not None
+            return output_weight * (2.0 * hidden_states[0] + 3.0 * hidden_states[1])
+
+        fake_gpt_model = SimpleNamespace(
+            GPTModel=FakeGPTModel,
+            process_mtp_loss=fake_process_mtp_loss,
+        )
+        fake_mtp_module = SimpleNamespace(
+            roll_tensor=fake_roll_tensor,
+            MultiTokenPredictionBlock=FakeMTPBlock,
+            MultiTokenPredictionLayer=FakeMTPLayer,
+        )
+        monkeypatch.setattr(gpt_package, "gpt_model", fake_gpt_model)
+        monkeypatch.setattr(
+            transformer_package,
+            "multi_token_prediction",
+            fake_mtp_module,
+        )
+        _patch_gpt_model_mtp_training()
+
+        mtp_kwargs = {
+            "mtp_labels": torch.ones(1, dtype=torch.long),
+            "mtp_loss_mask": torch.ones(1),
+        }
+        model = FakeGPTModel(repeated_layer)
+        main_loss, mtp_loss = model(
+            input_ids=torch.ones(1, dtype=torch.long),
+            position_ids=torch.zeros(1, dtype=torch.long),
+            mtp_kwargs=mtp_kwargs,
+        )
+        (main_loss + mtp_loss).backward()
+
+        torch.testing.assert_close(model.backbone_weight.grad, torch.tensor([26.0]))
+        torch.testing.assert_close(model.embedding_weight.grad, torch.tensor([26.0]))
+        torch.testing.assert_close(model.output_weight.grad, torch.tensor([104.0]))
+        if repeated_layer:
+            torch.testing.assert_close(
+                model.mtp.layers[0].weight.grad,
+                torch.tensor([722.0]),
+            )
+        else:
+            torch.testing.assert_close(
+                model.mtp.layers[0].weight.grad,
+                torch.tensor([560.0]),
+            )
+            torch.testing.assert_close(
+                model.mtp.layers[1].weight.grad,
+                torch.tensor([354.0]),
+            )
+        assert _MTP_TRAIN_LABELS.get() is None
+        assert _MTP_TRAIN_LOSS_MASK.get() is None
+        assert _MTP_TRAIN_DEPTH.get() is None
+
+        # This update check intentionally uses uncoupled, unclipped SGD. It
+        # verifies the direct gradient boundary above; production-wide gradient
+        # clipping may still couple parameter updates through the global norm.
+        baseline = FakeGPTModel(repeated_layer)
+        combined = FakeGPTModel(repeated_layer)
+        baseline_optimizer = torch.optim.SGD(baseline.parameters(), lr=0.01)
+        combined_optimizer = torch.optim.SGD(combined.parameters(), lr=0.01)
+
+        baseline_main_loss, _ = baseline(
+            input_ids=torch.ones(1, dtype=torch.long),
+            position_ids=torch.zeros(1, dtype=torch.long),
+            mtp_kwargs=mtp_kwargs,
+        )
+        baseline_main_loss.backward()
+        baseline_optimizer.step()
+
+        combined_main_loss, combined_mtp_loss = combined(
+            input_ids=torch.ones(1, dtype=torch.long),
+            position_ids=torch.zeros(1, dtype=torch.long),
+            mtp_kwargs=mtp_kwargs,
+        )
+        (combined_main_loss + combined_mtp_loss).backward()
+        combined_optimizer.step()
+
+        for parameter_name in (
+            "backbone_weight",
+            "embedding_weight",
+            "output_weight",
+        ):
+            torch.testing.assert_close(
+                getattr(combined, parameter_name),
+                getattr(baseline, parameter_name),
+                rtol=0,
+                atol=0,
+            )
+        assert not torch.equal(
+            combined.mtp.layers[0].weight,
+            baseline.mtp.layers[0].weight,
+        )
+        if not repeated_layer:
+            assert not torch.equal(
+                combined.mtp.layers[1].weight,
+                baseline.mtp.layers[1].weight,
+            )
 
     def test_model_thd_passes_padded_inputs_and_packed_metadata(self, monkeypatch):
         from areal.engine.megatron_utils import packed_context_parallel


### PR DESCRIPTION
## Description

Stacked follow-up to #1659.

For multi-depth MTP, detaching `hidden_states` at every prediction depth prevents deeper auxiliary losses from updating earlier MTP blocks. This change:

- detaches backbone hidden states only where they enter depth 0;
- keeps later MTP depths connected, including repeated-layer mode;
- continues detaching the shared embedding input at every depth;
- preserves #1659's label/mask and tied/untied output-weight isolation;
- adds exact-gradient tests for distinct and repeated MTP depths.

## Related Issue

Related PR: #1659

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable; no user-facing API change)
- [ ] Branch is up to date with `main` (this PR intentionally targets #1659's feature branch)
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

## Validation

- 7 focused MTP CPU test cases passed with Megatron-Core 0.17.0 and Megatron-Bridge 0.4.0.
- Exact gradients verified for distinct and repeated MTP depths.
- An unclipped-SGD sanity check verifies that shared parameters receive no direct MTP gradient contribution while MTP parameters update.
- Ruff format/check, Python compilation, and `git diff --check` passed.

The SGD check intentionally does not claim production optimizer-step equivalence: global gradient clipping can couple updates through the overall gradient norm. CUDA/Transformer Engine, PP/VPP, and distributed-optimizer execution remain for CI/GPU validation.