### PR TITLE
perf: reduce duplicated VLM rollout processing and transfers

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -59,6 +59,7 @@ from areal.api.cli_args import GenerationHyperparameters
 from areal.experimental.openai.cache import InteractionCache
 from areal.experimental.openai.tool_call_parser import process_tool_calls
 from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.infra.processor_cache import ProcessorCallCache
 from areal.utils import logging
 from areal.utils.hf_utils import apply_chat_template
 
@@ -86,6 +87,22 @@ class _PreparedPrompt:
     input_ids: list[int]
     mm_token_type_ids: list[int] | None = None
     multi_modal_input: dict[str, torch.Tensor] | None = None
+
+    def copy_for_consumer(self) -> "_PreparedPrompt":
+        """Copy mutable containers while sharing immutable processor tensors."""
+        return _PreparedPrompt(
+            input_ids=list(self.input_ids),
+            mm_token_type_ids=(
+                list(self.mm_token_type_ids)
+                if self.mm_token_type_ids is not None
+                else None
+            ),
+            multi_modal_input=(
+                dict(self.multi_modal_input)
+                if self.multi_modal_input is not None
+                else None
+            ),
+        )
 
 
 def _process_multimodal_prompt(
@@ -713,6 +730,7 @@ async def _prepare_prompt(
     tools: Iterable[ChatCompletionToolParam] | None,
     extra_body: Body,
     require_multimodal_processor: bool = False,
+    processor_cache: ProcessorCallCache | None = None,
 ) -> _PreparedPrompt:
     """Prepare text or multimodal prompt data for one agent interaction."""
     chat_template_kwargs = extra_body.get("chat_template_kwargs", {})
@@ -723,15 +741,34 @@ async def _prepare_prompt(
             "available for this rollout model."
         )
     if image_data and processor is not None:
-        processed_prompt = await asyncio.to_thread(
-            _process_multimodal_prompt,
-            processor,
-            tokenizer,
-            tokenizer_messages,
-            image_data,
-            tools,
-            chat_template_kwargs,
-        )
+
+        def process_prompt() -> _PreparedPrompt:
+            return _process_multimodal_prompt(
+                processor,
+                tokenizer,
+                tokenizer_messages,
+                image_data,
+                tools,
+                chat_template_kwargs,
+            )
+
+        if processor_cache is None:
+            processed_prompt = await asyncio.to_thread(process_prompt)
+        else:
+            cache_key = processor_cache.make_key(
+                "openai_multimodal",
+                id(processor),
+                id(tokenizer),
+                tokenizer_messages,
+                image_data,
+                tools,
+                chat_template_kwargs,
+            )
+            cached_prompt = await processor_cache.aget_or_compute(
+                cache_key,
+                process_prompt,
+            )
+            processed_prompt = cached_prompt.copy_for_consumer()
 
     if chat_template_type == "hf":
         input_ids = (
@@ -918,6 +955,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         top_p: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: InteractionCache | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[ChatCompletionChunk, None]: ...
 
@@ -942,6 +980,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         top_p: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: InteractionCache | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> ChatCompletion: ...
 
@@ -965,6 +1004,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         top_p: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: InteractionCache | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> ChatCompletion | AsyncGenerator[ChatCompletionChunk, None]:
         """Override create method to use AReaL engine and cache responses."""
@@ -1051,6 +1091,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             tools=tools_list,
             extra_body=extra_body,
             require_multimodal_processor=self.require_multimodal_processor,
+            processor_cache=processor_cache,
         )
         prompt_token_ids = prepared_prompt.input_ids
         if interaction is not None and self.processor is not None:
@@ -1412,6 +1453,7 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
         frequency_penalty: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: dict[str, InteractionWithTokenLogpReward] | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> Response:
         """Override create method to use AReaL engine"""
@@ -1508,6 +1550,7 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
             tools=tools_list,
             extra_body=extra_body,
             require_multimodal_processor=self.require_multimodal_processor,
+            processor_cache=processor_cache,
         )
         prompt_token_ids = prepared_prompt.input_ids
         if self.processor is not None:

--- a/areal/experimental/openai/proxy/client_session.py
+++ b/areal/experimental/openai/proxy/client_session.py
@@ -17,18 +17,22 @@ from tenacity import (
     wait_exponential,
 )
 
+from areal.infra.rpc.serialization import deserialize_value
 from areal.infra.utils.http import ensure_end_with_slash
 from areal.utils.logging import getLogger
 
 from .server import (
     EXPORT_TRAJECTORIES_PATHNAME,
     RL_END_SESSION_PATHNAME,
+    RL_FETCH_SHARED_TENSORS_PATHNAME,
     RL_SET_REWARD_PATHNAME,
     RL_START_SESSION_PATHNAME,
+    FetchSharedTensorsRequest,
     SetRewardRequest,
     StartSessionRequest,
     deserialize_interactions,
 )
+from .tensor_reference import SharedTensorResolver
 
 if TYPE_CHECKING:
     from ..types import InteractionWithTokenLogpReward
@@ -62,6 +66,8 @@ class OpenAIProxyClient:
         Shared processor-cache identity for grouped rollout sessions.
     processor_cache_group_size : int
         Expected number of sessions sharing the processor cache.
+    shared_tensor_resolver : SharedTensorResolver | None
+        Group-local resolver used to fetch each referenced image tensor once.
 
     Example
     -------
@@ -91,6 +97,7 @@ class OpenAIProxyClient:
         admin_api_key: str,
         processor_cache_group_id: str | None = None,
         processor_cache_group_size: int = 1,
+        shared_tensor_resolver: SharedTensorResolver | None = None,
     ):
         self._session = session
         self.base_url = ensure_end_with_slash(base_url)
@@ -98,6 +105,9 @@ class OpenAIProxyClient:
         self._admin_api_key = admin_api_key
         self._processor_cache_group_id = processor_cache_group_id
         self._processor_cache_group_size = processor_cache_group_size
+        self._shared_tensor_resolver = shared_tensor_resolver
+        if processor_cache_group_id is not None and shared_tensor_resolver is None:
+            self._shared_tensor_resolver = SharedTensorResolver()
         self.session_id: str | None = None
         self._session_api_key: str | None = None
 
@@ -191,12 +201,44 @@ class OpenAIProxyClient:
             "discount": discount,
             "style": style,
             "drop_retry_orphans": drop_retry_orphans,
+            "supports_shared_tensor_references": (
+                self._processor_cache_group_id is not None
+            ),
         }
         headers = self._admin_auth_headers()
         async with self._session.post(url, json=payload, headers=headers) as resp:
             resp.raise_for_status()
             data = await resp.json()
-            return deserialize_interactions(data["interactions"])
+
+        serialized_interactions = data["interactions"]
+        tensor_group_id = data.get("tensor_reference_group_id")
+        if tensor_group_id is not None:
+            if self._shared_tensor_resolver is None:
+                raise RuntimeError(
+                    "Proxy returned shared tensor references without a resolver"
+                )
+
+            async def fetch_shared_tensors(ref_ids: list[str]):
+                fetch_payload = FetchSharedTensorsRequest(
+                    group_id=tensor_group_id,
+                    ref_ids=ref_ids,
+                )
+                async with self._session.post(
+                    f"{self.base_url}{RL_FETCH_SHARED_TENSORS_PATHNAME}",
+                    json=fetch_payload.model_dump(),
+                    headers=headers,
+                ) as response:
+                    response.raise_for_status()
+                    response_data = await response.json()
+                return deserialize_value(response_data["tensors"])
+
+            serialized_interactions = await self._shared_tensor_resolver.resolve(
+                serialized_interactions,
+                group_id=tensor_group_id,
+                fetch=fetch_shared_tensors,
+            )
+
+        return deserialize_interactions(serialized_interactions)
 
     async def __aenter__(self) -> OpenAIProxyClient:
         """Start the RL session via HTTP request."""

--- a/areal/experimental/openai/proxy/client_session.py
+++ b/areal/experimental/openai/proxy/client_session.py
@@ -58,6 +58,10 @@ class OpenAIProxyClient:
         Unique identifier for this task
     admin_api_key : str
         Admin API key for management operations
+    processor_cache_group_id : str | None
+        Shared processor-cache identity for grouped rollout sessions.
+    processor_cache_group_size : int
+        Expected number of sessions sharing the processor cache.
 
     Example
     -------
@@ -85,11 +89,15 @@ class OpenAIProxyClient:
         base_url: str,
         task_id: str,
         admin_api_key: str,
+        processor_cache_group_id: str | None = None,
+        processor_cache_group_size: int = 1,
     ):
         self._session = session
         self.base_url = ensure_end_with_slash(base_url)
         self.task_id = task_id
         self._admin_api_key = admin_api_key
+        self._processor_cache_group_id = processor_cache_group_id
+        self._processor_cache_group_size = processor_cache_group_size
         self.session_id: str | None = None
         self._session_api_key: str | None = None
 
@@ -195,7 +203,11 @@ class OpenAIProxyClient:
         data = await _start_session(
             self._session,
             url=f"{self.base_url}{RL_START_SESSION_PATHNAME}",
-            payload=StartSessionRequest(task_id=self.task_id),
+            payload=StartSessionRequest(
+                task_id=self.task_id,
+                processor_cache_group_id=self._processor_cache_group_id,
+                processor_cache_group_size=self._processor_cache_group_size,
+            ),
             headers=self._admin_auth_headers(),
         )
         self.session_id = data["session_id"]

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -31,6 +31,7 @@ from areal.experimental.openai.anthropic import (
     translate_anthropic_stream,
 )
 from areal.experimental.openai.client import ArealOpenAI
+from areal.infra.processor_cache import ProcessorCacheRegistry
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.utils.http import validate_admin_api_key
 from areal.utils import name_resolve, names, seeding
@@ -46,11 +47,13 @@ from .server import (
     EXPORT_TRAJECTORIES_PATHNAME,
     GRANT_CAPACITY_PATHNAME,
     RESPONSES_PATHNAME,
+    RL_END_PROCESSOR_CACHE_GROUP_PATHNAME,
     RL_END_SESSION_PATHNAME,
     RL_SET_REWARD_PATHNAME,
     RL_START_SESSION_PATHNAME,
     ExportTrajectoriesRequest,
     ExportTrajectoriesResponse,
+    ProcessorCacheGroupRequest,
     SessionData,
     SetRewardRequest,
     StartSessionRequest,
@@ -107,6 +110,7 @@ _lock = threading.Lock()
 _capacity = 0
 _last_cleanup_time: float = 0
 _session_timeout_seconds: int = 3600  # Default timeout (overridden by config)
+_processor_cache_registry = ProcessorCacheRegistry()
 
 # API key authentication
 # Initialized to a random value so pre-configuration requests cannot bypass auth.
@@ -421,7 +425,13 @@ def _cleanup_stale_sessions():
 
     for session_id in stale_sessions:
         logger.warning(f"Removing stale session: {session_id}")
-        _session_cache.pop(session_id, None)
+        session_data = _session_cache.pop(session_id, None)
+        if session_data is not None:
+            cache_group_id = session_data.take_processor_cache_group_id()
+            if cache_group_id is not None:
+                _processor_cache_registry.release(cache_group_id)
+
+    _processor_cache_registry.discard_stale(_session_timeout_seconds)
 
     # Clean up API key mappings for stale sessions
     if stale_sessions:
@@ -450,6 +460,15 @@ def start_session(request: StartSessionRequest) -> StartSessionResponse:
     """
     global _capacity
     task_id = request.task_id
+
+    if (
+        request.processor_cache_group_id is not None
+        and request.processor_cache_group_size < 2
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="processor_cache_group_size must be at least 2 for grouped caching",
+        )
 
     with _lock:
         # Periodically cleanup stale sessions
@@ -494,11 +513,20 @@ def start_session(request: StartSessionRequest) -> StartSessionResponse:
             ):
                 session_api_key = secrets.token_urlsafe(32)
 
+        processor_cache = None
+        if request.processor_cache_group_id is not None:
+            processor_cache = _processor_cache_registry.acquire(
+                request.processor_cache_group_id,
+                request.processor_cache_group_size,
+            )
+
         _capacity -= 1
         _session_cache[session_id] = SessionData(
             session_id=session_id,
             prefix_matcher=_prefix_matcher,
             sampling_seed_identity=task_id,
+            processor_cache=processor_cache,
+            processor_cache_group_id=request.processor_cache_group_id,
         )
         _api_key_to_session[session_api_key] = session_id
         _session_to_api_key[session_id] = session_api_key
@@ -524,7 +552,20 @@ def end_session(session_id: str = Depends(_require_session_key)):
 
     # finish() outside lock to avoid holding lock during potential I/O
     session.finish()
+    cache_group_id = session.take_processor_cache_group_id()
+    if cache_group_id is not None:
+        _processor_cache_registry.release(cache_group_id)
     return {"message": "success", "interaction_count": interaction_count}
+
+
+@app.post(
+    f"/{RL_END_PROCESSOR_CACHE_GROUP_PATHNAME}",
+    dependencies=[Depends(_require_admin_key)],
+)
+def end_processor_cache_group(request: ProcessorCacheGroupRequest):
+    """Discard cached processor results after a rollout group finishes."""
+    _processor_cache_registry.discard(request.group_id)
+    return {"message": "success"}
 
 
 @app.post(f"/{RL_SET_REWARD_PATHNAME}")
@@ -592,8 +633,12 @@ async def _call_client_create(
     )
 
     sig = inspect.signature(create_fn)
+    supports_processor_cache = "processor_cache" in sig.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in sig.parameters.values()
+    )
     areal_client_ignored_args = ["model"] + (extra_ignored_args or [])
-    areal_client_disallowed_args = ["areal_cache"]
+    areal_client_disallowed_args = ["areal_cache", "processor_cache"]
     areal_client_allowed_args = list(
         k
         for k in sig.parameters.keys()
@@ -660,7 +705,13 @@ async def _call_client_create(
         kwargs["stream"] = True
 
     try:
-        return await create_fn(areal_cache=session_data.completions, **kwargs)
+        client_kwargs: dict[str, Any] = {
+            "areal_cache": session_data.completions,
+            **kwargs,
+        }
+        if supports_processor_cache:
+            client_kwargs["processor_cache"] = session_data.processor_cache
+        return await create_fn(**client_kwargs)
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -49,10 +49,13 @@ from .server import (
     RESPONSES_PATHNAME,
     RL_END_PROCESSOR_CACHE_GROUP_PATHNAME,
     RL_END_SESSION_PATHNAME,
+    RL_FETCH_SHARED_TENSORS_PATHNAME,
     RL_SET_REWARD_PATHNAME,
     RL_START_SESSION_PATHNAME,
     ExportTrajectoriesRequest,
     ExportTrajectoriesResponse,
+    FetchSharedTensorsRequest,
+    FetchSharedTensorsResponse,
     ProcessorCacheGroupRequest,
     SessionData,
     SetRewardRequest,
@@ -60,6 +63,7 @@ from .server import (
     StartSessionResponse,
     serialize_interactions,
 )
+from .tensor_reference import GroupTensorStoreRegistry
 
 if TYPE_CHECKING:
     from areal.api import InferenceEngine
@@ -111,6 +115,7 @@ _capacity = 0
 _last_cleanup_time: float = 0
 _session_timeout_seconds: int = 3600  # Default timeout (overridden by config)
 _processor_cache_registry = ProcessorCacheRegistry()
+_group_tensor_store_registry = GroupTensorStoreRegistry()
 
 # API key authentication
 # Initialized to a random value so pre-configuration requests cannot bypass auth.
@@ -432,6 +437,7 @@ def _cleanup_stale_sessions():
                 _processor_cache_registry.release(cache_group_id)
 
     _processor_cache_registry.discard_stale(_session_timeout_seconds)
+    _group_tensor_store_registry.discard_stale(_session_timeout_seconds)
 
     # Clean up API key mappings for stale sessions
     if stale_sessions:
@@ -563,9 +569,25 @@ def end_session(session_id: str = Depends(_require_session_key)):
     dependencies=[Depends(_require_admin_key)],
 )
 def end_processor_cache_group(request: ProcessorCacheGroupRequest):
-    """Discard cached processor results after a rollout group finishes."""
+    """Discard processor and shared-tensor state after a rollout group finishes."""
     _processor_cache_registry.discard(request.group_id)
+    _group_tensor_store_registry.discard(request.group_id)
     return {"message": "success"}
+
+
+@app.post(
+    f"/{RL_FETCH_SHARED_TENSORS_PATHNAME}",
+    dependencies=[Depends(_require_admin_key)],
+)
+def fetch_shared_tensors(
+    request: FetchSharedTensorsRequest,
+) -> FetchSharedTensorsResponse:
+    """Fetch each unique multimodal tensor once for a grouped rollout."""
+    try:
+        tensors = _group_tensor_store_registry.fetch(request.group_id, request.ref_ids)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FetchSharedTensorsResponse(tensors=serialize_value(tensors))
 
 
 @app.post(f"/{RL_SET_REWARD_PATHNAME}")
@@ -983,9 +1005,23 @@ async def export_trajectories(
         _session_cache.pop(session_id, None)
         _remove_api_keys_for_session(session_id)
 
-    # Serialize for HTTP transport
-    serialized = serialize_interactions(interactions)
-    return ExportTrajectoriesResponse(interactions=serialized)
+    # Grouped inline/subproc sessions export only multimodal tensor references.
+    # The workflow fetches each unique tensor once through the group endpoint.
+    tensor_reference_group_id = (
+        session_data.processor_cache_group_id
+        if request.supports_shared_tensor_references
+        else None
+    )
+    tensor_store = (
+        _group_tensor_store_registry.get_or_create(tensor_reference_group_id)
+        if tensor_reference_group_id is not None
+        else None
+    )
+    serialized = serialize_interactions(interactions, tensor_store=tensor_store)
+    return ExportTrajectoriesResponse(
+        interactions=serialized,
+        tensor_reference_group_id=tensor_reference_group_id,
+    )
 
 
 # =============================================================================

--- a/areal/experimental/openai/proxy/server.py
+++ b/areal/experimental/openai/proxy/server.py
@@ -13,6 +13,7 @@ from areal.experimental.openai.cache import InteractionCache
 
 if TYPE_CHECKING:
     from areal.experimental.openai.types import InteractionWithTokenLogpReward
+    from areal.infra.processor_cache import ProcessorCallCache
 
 # Session timeout for cleanup (1 hour)
 SESSION_TIMEOUT_SECONDS = 3600
@@ -28,6 +29,8 @@ class StartSessionRequest(BaseModel):
 
     task_id: str
     api_key: str | None = None  # Reuse a previously-issued key (refresh)
+    processor_cache_group_id: str | None = None
+    processor_cache_group_size: int = 1
 
 
 class StartSessionResponse(BaseModel):
@@ -35,6 +38,12 @@ class StartSessionResponse(BaseModel):
 
     session_id: str
     api_key: str
+
+
+class ProcessorCacheGroupRequest(BaseModel):
+    """Request to discard one completed or aborted processor-cache group."""
+
+    group_id: str
 
 
 class SetRewardRequest(BaseModel):
@@ -72,9 +81,13 @@ class SessionData:
         session_id: str,
         prefix_matcher=None,
         sampling_seed_identity: str | None = None,
+        processor_cache: ProcessorCallCache | None = None,
+        processor_cache_group_id: str | None = None,
     ):
         self.session_id = session_id
         self.sampling_seed_identity = sampling_seed_identity or session_id
+        self.processor_cache = processor_cache
+        self.processor_cache_group_id = processor_cache_group_id
 
         self._completed = False
         self._completions = InteractionCache(
@@ -87,6 +100,7 @@ class SessionData:
         self._end_time = None
         self._lock = threading.Lock()
         self._next_sampling_request_index = 0
+        self._processor_cache_released = False
 
     def next_sampling_request_index(self) -> int:
         """Reserve a unique request index without serializing request execution."""
@@ -99,6 +113,15 @@ class SessionData:
         """Update the last access time for this session."""
         with self._lock:
             self._last_access_time = time.time()
+
+    def take_processor_cache_group_id(self) -> str | None:
+        """Detach the cache and return its group ID once for idempotent release."""
+        with self._lock:
+            if self._processor_cache_released:
+                return None
+            self._processor_cache_released = True
+            self.processor_cache = None
+            return self.processor_cache_group_id
 
     def is_stale(self, timeout_seconds: float = SESSION_TIMEOUT_SECONDS) -> bool:
         """Check if this session has been inactive for too long."""
@@ -198,6 +221,7 @@ def deserialize_interactions(
 
 RL_START_SESSION_PATHNAME = "rl/start_session"
 RL_END_SESSION_PATHNAME = "rl/end_session"
+RL_END_PROCESSOR_CACHE_GROUP_PATHNAME = "rl/end_processor_cache_group"
 RL_SET_REWARD_PATHNAME = "rl/set_reward"
 CHAT_COMPLETIONS_PATHNAME = "chat/completions"
 RESPONSES_PATHNAME = "responses"

--- a/areal/experimental/openai/proxy/server.py
+++ b/areal/experimental/openai/proxy/server.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from areal.experimental.openai.types import InteractionWithTokenLogpReward
     from areal.infra.processor_cache import ProcessorCallCache
 
+    from .tensor_reference import GroupTensorStore
+
 # Session timeout for cleanup (1 hour)
 SESSION_TIMEOUT_SECONDS = 3600
 
@@ -46,6 +48,19 @@ class ProcessorCacheGroupRequest(BaseModel):
     group_id: str
 
 
+class FetchSharedTensorsRequest(BaseModel):
+    """Request unique multimodal tensors referenced by grouped trajectories."""
+
+    group_id: str
+    ref_ids: list[str]
+
+
+class FetchSharedTensorsResponse(BaseModel):
+    """Response containing tensors keyed by their group-scoped references."""
+
+    tensors: dict[str, Any]
+
+
 class SetRewardRequest(BaseModel):
     """Request to set reward for an interaction."""
 
@@ -60,12 +75,14 @@ class ExportTrajectoriesRequest(BaseModel):
     discount: float = 1.0
     style: str = "individual"
     drop_retry_orphans: bool = False
+    supports_shared_tensor_references: bool = False
 
 
 class ExportTrajectoriesResponse(BaseModel):
     """Response containing serialized interactions."""
 
     interactions: dict[str, Any]
+    tensor_reference_group_id: str | None = None
 
 
 # =============================================================================
@@ -171,6 +188,7 @@ class SessionData:
 
 def serialize_interactions(
     interactions: dict[str, InteractionWithTokenLogpReward],
+    tensor_store: GroupTensorStore | None = None,
 ) -> dict[str, Any]:
     """Serialize interactions into a json-compatible format for HTTP transport."""
     from areal.infra.rpc.serialization import serialize_value
@@ -190,6 +208,8 @@ def serialize_interactions(
                 "reward": interaction.reward,
                 "interaction_id": interaction.interaction_id,
             }
+    if tensor_store is not None:
+        result = tensor_store.encode_multimodal_tensors(result)
     return serialize_value(result)
 
 
@@ -222,6 +242,7 @@ def deserialize_interactions(
 RL_START_SESSION_PATHNAME = "rl/start_session"
 RL_END_SESSION_PATHNAME = "rl/end_session"
 RL_END_PROCESSOR_CACHE_GROUP_PATHNAME = "rl/end_processor_cache_group"
+RL_FETCH_SHARED_TENSORS_PATHNAME = "rl/fetch_shared_tensors"
 RL_SET_REWARD_PATHNAME = "rl/set_reward"
 CHAT_COMPLETIONS_PATHNAME = "chat/completions"
 RESPONSES_PATHNAME = "responses"

--- a/areal/experimental/openai/proxy/tensor_reference.py
+++ b/areal/experimental/openai/proxy/tensor_reference.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import uuid
 from collections.abc import Awaitable, Callable
 from threading import Lock
 from typing import Any, Literal
@@ -26,6 +27,8 @@ class GroupTensorStore:
 
     def __init__(self) -> None:
         self._lock = Lock()
+        # A recreated store must not reuse references cached by group resolvers.
+        self._generation = uuid.uuid4().hex
         self._ref_by_tensor_id: dict[int, str] = {}
         self._tensor_by_ref: dict[str, torch.Tensor] = {}
 
@@ -79,7 +82,7 @@ class GroupTensorStore:
         with self._lock:
             ref_id = self._ref_by_tensor_id.get(tensor_id)
             if ref_id is None:
-                ref_id = f"tensor-{len(self._tensor_by_ref)}"
+                ref_id = f"{self._generation}:tensor-{len(self._tensor_by_ref)}"
                 self._ref_by_tensor_id[tensor_id] = ref_id
                 # Keep a strong reference so Python cannot reuse ``tensor_id``
                 # during the lifetime of this rollout group.

--- a/areal/experimental/openai/proxy/tensor_reference.py
+++ b/areal/experimental/openai/proxy/tensor_reference.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from threading import Lock
+from typing import Any, Literal
+
+import torch
+from pydantic import BaseModel
+
+from areal.utils.data import is_multi_modal_key
+
+
+class SharedTensorReference(BaseModel):
+    """JSON marker for one tensor stored in a proxy-side rollout group."""
+
+    type: Literal["areal_shared_tensor"] = "areal_shared_tensor"
+    ref_id: str
+
+
+class GroupTensorStore:
+    """Store unique multimodal tensors and replace them with lightweight refs."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._ref_by_tensor_id: dict[int, str] = {}
+        self._tensor_by_ref: dict[str, torch.Tensor] = {}
+
+    def encode_multimodal_tensors(self, value: Any) -> Any:
+        """Replace tensors below ``multi_modal_input*`` keys with references."""
+        return self._encode(value, in_multimodal_value=False)
+
+    def fetch(self, ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        """Return requested tensors, rejecting unknown group-scoped refs."""
+        with self._lock:
+            missing = [
+                ref_id for ref_id in ref_ids if ref_id not in self._tensor_by_ref
+            ]
+            if missing:
+                raise KeyError(f"Unknown shared tensor references: {missing}")
+            return {ref_id: self._tensor_by_ref[ref_id] for ref_id in ref_ids}
+
+    def _encode(self, value: Any, *, in_multimodal_value: bool) -> Any:
+        if isinstance(value, torch.Tensor):
+            if not in_multimodal_value:
+                return value
+            return self._reference(value).model_dump()
+
+        if isinstance(value, dict):
+            return {
+                key: self._encode(
+                    item,
+                    in_multimodal_value=(
+                        in_multimodal_value or is_multi_modal_key(str(key))
+                    ),
+                )
+                for key, item in value.items()
+            }
+
+        if isinstance(value, list):
+            return [
+                self._encode(item, in_multimodal_value=in_multimodal_value)
+                for item in value
+            ]
+
+        if isinstance(value, tuple):
+            return [
+                self._encode(item, in_multimodal_value=in_multimodal_value)
+                for item in value
+            ]
+
+        return value
+
+    def _reference(self, tensor: torch.Tensor) -> SharedTensorReference:
+        tensor_id = id(tensor)
+        with self._lock:
+            ref_id = self._ref_by_tensor_id.get(tensor_id)
+            if ref_id is None:
+                ref_id = f"tensor-{len(self._tensor_by_ref)}"
+                self._ref_by_tensor_id[tensor_id] = ref_id
+                # Keep a strong reference so Python cannot reuse ``tensor_id``
+                # during the lifetime of this rollout group.
+                self._tensor_by_ref[ref_id] = tensor
+        return SharedTensorReference(ref_id=ref_id)
+
+
+class GroupTensorStoreRegistry:
+    """Own proxy-side tensor stores until their rollout groups are finalized."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._stores: dict[str, GroupTensorStore] = {}
+        self._last_access: dict[str, float] = {}
+
+    def get_or_create(self, group_id: str) -> GroupTensorStore:
+        with self._lock:
+            store = self._stores.get(group_id)
+            if store is None:
+                store = GroupTensorStore()
+                self._stores[group_id] = store
+            self._last_access[group_id] = time.monotonic()
+            return store
+
+    def fetch(self, group_id: str, ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        with self._lock:
+            store = self._stores.get(group_id)
+            if store is None:
+                raise KeyError(f"Unknown shared tensor group: {group_id}")
+            self._last_access[group_id] = time.monotonic()
+        return store.fetch(ref_ids)
+
+    def discard(self, group_id: str) -> None:
+        with self._lock:
+            self._stores.pop(group_id, None)
+            self._last_access.pop(group_id, None)
+
+    def discard_stale(self, timeout_seconds: float) -> None:
+        cutoff = time.monotonic() - timeout_seconds
+        with self._lock:
+            stale_ids = [
+                group_id
+                for group_id, last_access in self._last_access.items()
+                if last_access < cutoff
+            ]
+            for group_id in stale_ids:
+                self._stores.pop(group_id, None)
+                self._last_access.pop(group_id, None)
+
+
+FetchSharedTensors = Callable[[list[str]], Awaitable[dict[str, torch.Tensor]]]
+
+
+class SharedTensorResolver:
+    """Resolve each group-scoped tensor ref once across concurrent sessions."""
+
+    def __init__(self) -> None:
+        self._values: dict[tuple[str, str], torch.Tensor] = {}
+        self._inflight: dict[tuple[str, str], asyncio.Future[torch.Tensor]] = {}
+
+    async def resolve(
+        self,
+        value: Any,
+        *,
+        group_id: str,
+        fetch: FetchSharedTensors,
+    ) -> Any:
+        """Fetch missing references once, then restore aliases in ``value``."""
+        ref_ids: list[str] = []
+        self._collect_ref_ids(value, ref_ids, in_multimodal_value=False)
+        if not ref_ids:
+            return value
+
+        owned: list[str] = []
+        futures: dict[str, asyncio.Future[torch.Tensor]] = {}
+        loop = asyncio.get_running_loop()
+        for ref_id in dict.fromkeys(ref_ids):
+            key = (group_id, ref_id)
+            cached = self._values.get(key)
+            if cached is not None:
+                future = loop.create_future()
+                future.set_result(cached)
+            else:
+                future = self._inflight.get(key)
+                if future is None:
+                    future = loop.create_future()
+                    self._inflight[key] = future
+                    owned.append(ref_id)
+            futures[ref_id] = future
+
+        if owned:
+            try:
+                fetched = await fetch(owned)
+                missing = [ref_id for ref_id in owned if ref_id not in fetched]
+                if missing:
+                    raise RuntimeError(
+                        f"Proxy omitted shared tensor references: {missing}"
+                    )
+                invalid = [
+                    ref_id
+                    for ref_id in owned
+                    if not isinstance(fetched[ref_id], torch.Tensor)
+                ]
+                if invalid:
+                    raise TypeError(
+                        f"Proxy returned non-tensor shared references: {invalid}"
+                    )
+            except BaseException as exc:
+                for ref_id in owned:
+                    key = (group_id, ref_id)
+                    future = self._inflight.pop(key)
+                    if not future.done():
+                        future.set_exception(exc)
+                        # The owner raises directly; retrieving the exception
+                        # prevents an unobserved-future warning without hiding it
+                        # from concurrent waiters.
+                        future.exception()
+                raise
+
+            for ref_id in owned:
+                key = (group_id, ref_id)
+                tensor = fetched[ref_id]
+                self._values[key] = tensor
+                future = self._inflight.pop(key)
+                future.set_result(tensor)
+
+        resolved = {
+            ref_id: await asyncio.shield(future) for ref_id, future in futures.items()
+        }
+        return self._replace_refs(value, resolved, in_multimodal_value=False)
+
+    def discard(self, group_id: str) -> None:
+        keys = [key for key in self._values if key[0] == group_id]
+        for key in keys:
+            self._values.pop(key, None)
+
+        inflight_keys = [key for key in self._inflight if key[0] == group_id]
+        if inflight_keys:
+            raise RuntimeError(
+                f"Cannot discard shared tensor group {group_id} while fetches are active"
+            )
+
+    @classmethod
+    def _collect_ref_ids(
+        cls,
+        value: Any,
+        result: list[str],
+        *,
+        in_multimodal_value: bool,
+    ) -> None:
+        if in_multimodal_value and cls._is_reference(value):
+            result.append(value["ref_id"])
+            return
+        if isinstance(value, dict):
+            for key, item in value.items():
+                cls._collect_ref_ids(
+                    item,
+                    result,
+                    in_multimodal_value=(
+                        in_multimodal_value or is_multi_modal_key(str(key))
+                    ),
+                )
+        elif isinstance(value, list):
+            for item in value:
+                cls._collect_ref_ids(
+                    item,
+                    result,
+                    in_multimodal_value=in_multimodal_value,
+                )
+
+    @classmethod
+    def _replace_refs(
+        cls,
+        value: Any,
+        resolved: dict[str, torch.Tensor],
+        *,
+        in_multimodal_value: bool,
+    ) -> Any:
+        if in_multimodal_value and cls._is_reference(value):
+            return resolved[value["ref_id"]]
+        if isinstance(value, dict):
+            return {
+                key: cls._replace_refs(
+                    item,
+                    resolved,
+                    in_multimodal_value=(
+                        in_multimodal_value or is_multi_modal_key(str(key))
+                    ),
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                cls._replace_refs(
+                    item,
+                    resolved,
+                    in_multimodal_value=in_multimodal_value,
+                )
+                for item in value
+            ]
+        return value
+
+    @staticmethod
+    def _is_reference(value: Any) -> bool:
+        return (
+            isinstance(value, dict)
+            and value.get("type") == "areal_shared_tensor"
+            and isinstance(value.get("ref_id"), str)
+        )

--- a/areal/experimental/openai/proxy/workflow.py
+++ b/areal/experimental/openai/proxy/workflow.py
@@ -16,8 +16,13 @@ from areal.infra import workflow_context
 from areal.utils import logging, stats_tracker
 from areal.utils.perf_tracer import session_context, trace_session
 
-from .client_session import OpenAIProxyClient
-from .server import DEFAULT_ADMIN_API_KEY, GRANT_CAPACITY_PATHNAME
+from .client_session import OpenAIProxyClient, post_json
+from .server import (
+    DEFAULT_ADMIN_API_KEY,
+    GRANT_CAPACITY_PATHNAME,
+    RL_END_PROCESSOR_CACHE_GROUP_PATHNAME,
+    ProcessorCacheGroupRequest,
+)
 
 if TYPE_CHECKING:
     from ..client import TRolloutEngine
@@ -70,6 +75,13 @@ def _wrap_run(agent: Any, data: dict[str, Any], extra_envs: dict[str, str]):
 
 
 class OpenAIProxyWorkflow(RolloutWorkflow):
+    """Run an agent through the v1 proxy.
+
+    Group-scoped processor caching is supported in ``inline`` and ``subproc``
+    modes. Online mode owns its sessions externally and does not receive the
+    rollout group's cache identity.
+    """
+
     def __init__(
         self,
         mode: str,
@@ -162,6 +174,30 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
         async with session.post(url, headers=headers) as resp:
             resp.raise_for_status()
 
+    def _processor_cache_group_id(
+        self, context: workflow_context.WorkflowContext
+    ) -> str | None:
+        if self.mode == "online" or context.group_size <= 1 or context.task_id is None:
+            return None
+        scope = "eval" if context.is_eval else "train"
+        return f"{scope}:{context.task_id}"
+
+    async def _afinalize_processor_cache_group(
+        self, context: workflow_context.WorkflowContext
+    ) -> None:
+        """Release proxy-side cache state after an inline/subproc group ends."""
+        group_id = self._processor_cache_group_id(context)
+        if group_id is None:
+            return
+
+        http_session = await workflow_context.get_aiohttp_session()
+        await post_json(
+            http_session,
+            url=(f"{self.proxy_addr}/{RL_END_PROCESSOR_CACHE_GROUP_PATHNAME}"),
+            payload=ProcessorCacheGroupRequest(group_id=group_id),
+            headers={"Authorization": f"Bearer {self._admin_api_key}"},
+        )
+
     @session_context()
     async def arun_episode(
         self, engine: TRolloutEngine, data: dict[str, Any]
@@ -175,6 +211,7 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
             if context.sample_idx is not None
             else str(task_id)
         )
+        processor_cache_group_id = self._processor_cache_group_id(context)
 
         http_session = await workflow_context.get_aiohttp_session()
 
@@ -230,6 +267,8 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
             base_url=self.proxy_addr,
             task_id=proxy_task_id,
             admin_api_key=self._admin_api_key,
+            processor_cache_group_id=processor_cache_group_id,
+            processor_cache_group_size=context.group_size,
         )
         async with proxy_client:
             # Run the user code.

--- a/areal/experimental/openai/proxy/workflow.py
+++ b/areal/experimental/openai/proxy/workflow.py
@@ -23,6 +23,7 @@ from .server import (
     RL_END_PROCESSOR_CACHE_GROUP_PATHNAME,
     ProcessorCacheGroupRequest,
 )
+from .tensor_reference import SharedTensorResolver
 
 if TYPE_CHECKING:
     from ..client import TRolloutEngine
@@ -131,6 +132,7 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
         self.export_style = export_style
         self.subproc_max_workers = subproc_max_workers
         self.drop_retry_orphans = drop_retry_orphans
+        self._shared_tensor_resolver = SharedTensorResolver()
 
     @trace_session("run_agent")
     async def _run_agent(self, session_api_key: str, data: dict):
@@ -185,18 +187,21 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
     async def _afinalize_processor_cache_group(
         self, context: workflow_context.WorkflowContext
     ) -> None:
-        """Release proxy-side cache state after an inline/subproc group ends."""
+        """Release processor and tensor-ref state after an inline/subproc group."""
         group_id = self._processor_cache_group_id(context)
         if group_id is None:
             return
 
         http_session = await workflow_context.get_aiohttp_session()
-        await post_json(
-            http_session,
-            url=(f"{self.proxy_addr}/{RL_END_PROCESSOR_CACHE_GROUP_PATHNAME}"),
-            payload=ProcessorCacheGroupRequest(group_id=group_id),
-            headers={"Authorization": f"Bearer {self._admin_api_key}"},
-        )
+        try:
+            await post_json(
+                http_session,
+                url=(f"{self.proxy_addr}/{RL_END_PROCESSOR_CACHE_GROUP_PATHNAME}"),
+                payload=ProcessorCacheGroupRequest(group_id=group_id),
+                headers={"Authorization": f"Bearer {self._admin_api_key}"},
+            )
+        finally:
+            self._shared_tensor_resolver.discard(group_id)
 
     @session_context()
     async def arun_episode(
@@ -269,6 +274,7 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
             admin_api_key=self._admin_api_key,
             processor_cache_group_id=processor_cache_group_id,
             processor_cache_group_size=context.group_size,
+            shared_tensor_resolver=self._shared_tensor_resolver,
         )
         async with proxy_client:
             # Run the user code.

--- a/areal/infra/processor_cache.py
+++ b/areal/infra/processor_cache.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable, Hashable
+from concurrent.futures import Future
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, TypeVar, cast
+
+T = TypeVar("T")
+
+
+class ProcessorCallCache:
+    """Thread-safe single-flight cache for identical calls within one group."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._results: dict[Hashable, Any] = {}
+        self._inflight: dict[Hashable, Future[Any]] = {}
+        self._generation = 0
+        self._closed = False
+
+    def _claim(self, key: Hashable) -> tuple[Future[Any] | None, bool, int]:
+        with self._lock:
+            if self._closed:
+                return None, False, self._generation
+            if key in self._results:
+                future: Future[Any] = Future()
+                future.set_result(self._results[key])
+                return future, False, self._generation
+
+            future = self._inflight.get(key)
+            is_owner = future is None
+            if future is None:
+                future = Future()
+                self._inflight[key] = future
+            return future, is_owner, self._generation
+
+    def _publish_result(
+        self,
+        key: Hashable,
+        future: Future[Any],
+        generation: int,
+        result: Any,
+    ) -> None:
+        with self._lock:
+            if generation == self._generation:
+                self._results[key] = result
+            self._inflight.pop(key, None)
+            future.set_result(result)
+
+    def _publish_exception(
+        self, key: Hashable, future: Future[Any], exc: BaseException
+    ) -> None:
+        with self._lock:
+            self._inflight.pop(key, None)
+            future.set_exception(exc)
+
+    def get_or_compute(self, key: Hashable, factory: Callable[[], T]) -> T:
+        """Return a cached value, computing it once across concurrent callers."""
+        future, is_owner, generation = self._claim(key)
+        if future is None:
+            return factory()
+
+        if not is_owner:
+            return cast(T, future.result())
+
+        try:
+            result = factory()
+        except BaseException as exc:
+            self._publish_exception(key, future, exc)
+            raise
+
+        self._publish_result(key, future, generation, result)
+        return result
+
+    async def aget_or_compute(self, key: Hashable, factory: Callable[[], T]) -> T:
+        """Asynchronously compute once without occupying threads for waiters."""
+        future, is_owner, generation = self._claim(key)
+        if future is None:
+            return await asyncio.to_thread(factory)
+        if not is_owner:
+            return cast(T, await asyncio.shield(asyncio.wrap_future(future)))
+
+        try:
+            result = await asyncio.to_thread(factory)
+        except BaseException as exc:
+            self._publish_exception(key, future, exc)
+            raise
+
+        self._publish_result(key, future, generation, result)
+        return result
+
+    def close(self) -> None:
+        """Disable caching and drop results owned by a completed group."""
+        with self._lock:
+            self._closed = True
+            self._generation += 1
+            self._results.clear()
+
+    @classmethod
+    def make_key(cls, *values: Any) -> Hashable:
+        """Convert processor inputs into a stable, hashable cache key."""
+        return tuple(cls._freeze(value) for value in values)
+
+    @classmethod
+    def _freeze(cls, value: Any) -> Hashable:
+        if isinstance(value, dict):
+            return tuple(
+                sorted((str(key), cls._freeze(item)) for key, item in value.items())
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(cls._freeze(item) for item in value)
+        if isinstance(value, (set, frozenset)):
+            return tuple(sorted(repr(cls._freeze(item)) for item in value))
+        try:
+            hash(value)
+        except TypeError:
+            return repr(value)
+        return cast(Hashable, value)
+
+
+@dataclass
+class _RegistryEntry:
+    cache: ProcessorCallCache
+    expected_users: int
+    acquired_users: int = 0
+    active_users: int = 0
+    last_access_time: float = 0.0
+
+
+class ProcessorCacheRegistry:
+    """Own group caches that must be shared across proxy sessions."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._entries: dict[str, _RegistryEntry] = {}
+
+    def acquire(self, group_id: str, expected_users: int) -> ProcessorCallCache:
+        if expected_users < 2:
+            raise ValueError("A shared processor cache requires at least two users.")
+
+        with self._lock:
+            entry = self._entries.get(group_id)
+            if entry is None:
+                entry = _RegistryEntry(
+                    cache=ProcessorCallCache(),
+                    expected_users=expected_users,
+                )
+                self._entries[group_id] = entry
+            else:
+                entry.expected_users = max(entry.expected_users, expected_users)
+            entry.acquired_users += 1
+            entry.active_users += 1
+            entry.last_access_time = time.monotonic()
+            return entry.cache
+
+    def release(self, group_id: str) -> None:
+        with self._lock:
+            entry = self._entries.get(group_id)
+            if entry is None:
+                return
+            entry.active_users = max(0, entry.active_users - 1)
+            entry.last_access_time = time.monotonic()
+            if entry.acquired_users >= entry.expected_users and entry.active_users == 0:
+                self._entries.pop(group_id).cache.close()
+
+    def discard(self, group_id: str) -> None:
+        """Explicitly clear a completed or aborted group's cached results."""
+        with self._lock:
+            entry = self._entries.pop(group_id, None)
+            if entry is not None:
+                entry.cache.close()
+
+    def discard_stale(self, timeout_seconds: float) -> None:
+        cutoff = time.monotonic() - timeout_seconds
+        with self._lock:
+            stale_ids = [
+                group_id
+                for group_id, entry in self._entries.items()
+                if entry.last_access_time < cutoff
+            ]
+            for group_id in stale_ids:
+                self._entries.pop(group_id).cache.close()

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -120,20 +120,29 @@ class GroupedRolloutWorkflow(RolloutWorkflow):
         ]
         try:
             indexed_results = await asyncio.gather(*group_tasks)
+        except BaseException:
+            # gather does not cancel siblings when a child fails or is cancelled.
+            for task in group_tasks:
+                if not task.done():
+                    task.cancel()
+            raise
         finally:
-            # gather propagates the first child error without waiting for the
-            # remaining children. Drain them before releasing group resources.
-            await asyncio.gather(*group_tasks, return_exceptions=True)
-            finalizer = getattr(self.workflow, "_afinalize_processor_cache_group", None)
-            if finalizer is not None:
-                try:
-                    await finalizer(group_context)
-                except Exception as exc:
-                    self.logger.warning(
-                        "Failed to finalize rollout group resources (%s: %s).",
-                        type(exc).__name__,
-                        exc,
-                    )
+            try:
+                # Drain cancellation handlers before releasing shared resources.
+                await asyncio.gather(*group_tasks, return_exceptions=True)
+            finally:
+                finalizer = getattr(
+                    self.workflow, "_afinalize_processor_cache_group", None
+                )
+                if finalizer is not None:
+                    try:
+                        await finalizer(group_context)
+                    except Exception as exc:
+                        self.logger.warning(
+                            "Failed to finalize rollout group resources (%s: %s).",
+                            type(exc).__name__,
+                            exc,
+                        )
         indexed_results.sort(key=lambda item: item[0])
         sample_indices = [sample_idx for sample_idx, _ in indexed_results]
         if sample_indices != list(range(self.group_size)):

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -88,25 +88,52 @@ class GroupedRolloutWorkflow(RolloutWorkflow):
         self, engine: InferenceEngine, data: dict[str, Any]
     ) -> dict[str, Any] | None:
         from areal.experimental.openai import InteractionWithTokenLogpReward
+        from areal.infra import workflow_context
+        from areal.infra.processor_cache import ProcessorCallCache
+        from areal.infra.workflow_context import WorkflowContext
+
+        parent = workflow_context.get()
+        shared_processor_cache = ProcessorCallCache()
+        group_context = WorkflowContext(
+            is_eval=parent.is_eval,
+            task_id=parent.task_id,
+            group_size=self.group_size,
+            processor_cache=shared_processor_cache,
+        )
 
         async def run_sample(sample_idx: int) -> tuple[int, Any]:
-            from areal.infra import workflow_context
-            from areal.infra.workflow_context import WorkflowContext
-
-            parent = workflow_context.get()
             workflow_context.set(
                 WorkflowContext(
-                    is_eval=parent.is_eval,
-                    task_id=parent.task_id,
+                    is_eval=group_context.is_eval,
+                    task_id=group_context.task_id,
                     sample_idx=sample_idx,
+                    group_size=group_context.group_size,
+                    processor_cache=shared_processor_cache,
                 )
             )
             result = await self.workflow.arun_episode(engine, data)
             return sample_idx, result
 
-        indexed_results = await asyncio.gather(
-            *[run_sample(sample_idx) for sample_idx in range(self.group_size)]
-        )
+        group_tasks = [
+            asyncio.create_task(run_sample(sample_idx))
+            for sample_idx in range(self.group_size)
+        ]
+        try:
+            indexed_results = await asyncio.gather(*group_tasks)
+        finally:
+            # gather propagates the first child error without waiting for the
+            # remaining children. Drain them before releasing group resources.
+            await asyncio.gather(*group_tasks, return_exceptions=True)
+            finalizer = getattr(self.workflow, "_afinalize_processor_cache_group", None)
+            if finalizer is not None:
+                try:
+                    await finalizer(group_context)
+                except Exception as exc:
+                    self.logger.warning(
+                        "Failed to finalize rollout group resources (%s: %s).",
+                        type(exc).__name__,
+                        exc,
+                    )
         indexed_results.sort(key=lambda item: item[0])
         sample_indices = [sample_idx for sample_idx, _ in indexed_results]
         if sample_indices != list(range(self.group_size)):

--- a/areal/infra/rpc/guard/engine_blueprint.py
+++ b/areal/infra/rpc/guard/engine_blueprint.py
@@ -492,9 +492,16 @@ def call_engine_method():
         # Deserialize data
         raw_args = deserialize_value(raw_args)
         raw_kwargs = deserialize_value(raw_kwargs)
-        # Fetch remote tensors
-        args = RTensor.localize(raw_args)
-        kwargs = RTensor.localize(raw_kwargs)
+        # CPU-staged engines (currently Megatron) can preserve shared rollout
+        # tensors until microbatch construction. Other v1 engines retain the
+        # existing per-reference localization behavior.
+        preserve_input_tensor_aliases = _should_stage_rpc_payload_on_cpu(
+            engine, method_name
+        )
+        args, kwargs = RTensor.localize(
+            (raw_args, raw_kwargs),
+            preserve_tensor_aliases=preserve_input_tensor_aliases,
+        )
 
         def execute_in_engine_thread():
             try:
@@ -626,7 +633,15 @@ def call_engine_method():
         is_init = is_train and engine.initialized
         if not is_train or not is_init or engine.is_data_parallel_head():
             state = get_state()
-            result = RTensor.remotize(result, node_addr=state.node_addr)
+            # wait_for_task is the v1 rollout boundary that returns the grouped
+            # trajectory. Preserve its shared image tensors as RTensor shards;
+            # unrelated engine results keep the existing behavior.
+            preserve_output_tensor_aliases = method_name == "wait_for_task"
+            result = RTensor.remotize(
+                result,
+                node_addr=state.node_addr,
+                preserve_tensor_aliases=preserve_output_tensor_aliases,
+            )
             serialized_result = serialize_value(result)
         else:
             # Non-DP-head: result is discarded by controller. Skip remotize

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -383,11 +383,15 @@ class RTensor:
         return self.data
 
     @staticmethod
-    def remotize(obj: Any, node_addr: str) -> Any:
+    def remotize(
+        obj: Any, node_addr: str, *, preserve_tensor_aliases: bool = False
+    ) -> Any:
         """Convert tensors to RTensors in nested structures.
 
         For dict objects that look like trajectory dicts (contain attention_mask),
         trailing padding is trimmed before storage to keep each RTensor compact.
+        When ``preserve_tensor_aliases`` is enabled, repeated references to the
+        same tensor object share one stored shard for this root call.
 
         Parameters
         ----------
@@ -395,23 +399,42 @@ class RTensor:
             Object potentially containing tensors
         node_addr : str
             Node address for shard storage
+        preserve_tensor_aliases : bool, default=False
+            Preserve tensor object aliases as shared RTensor shards. Distinct
+            tensor objects are never merged, even when their values match.
 
         Returns
         -------
         Any
             Object with tensors converted to RTensors
         """
+        tensor_memo = {} if preserve_tensor_aliases else None
+        return RTensor._remotize_recursive(obj, node_addr, tensor_memo)
+
+    @staticmethod
+    def _remotize_recursive(
+        obj: Any,
+        node_addr: str,
+        tensor_memo: dict[int, RTensor] | None,
+    ) -> Any:
         if obj is None:
             return None
 
         if isinstance(obj, torch.Tensor):
+            tensor_id = id(obj)
+            if tensor_memo is not None and tensor_id in tensor_memo:
+                return tensor_memo[tensor_id]
+
             tensor = obj.detach().cpu()
             shard_id = get_backend().store(tensor)
             shard = TensorShardInfo(
                 shard_id=shard_id,
                 node_addr=node_addr,
             )
-            return RTensor(shard=shard, data=tensor.to("meta"))
+            remote_tensor = RTensor(shard=shard, data=tensor.to("meta"))
+            if tensor_memo is not None:
+                tensor_memo[tensor_id] = remote_tensor
+            return remote_tensor
 
         if isinstance(obj, dict):
             # Compact trajectory dicts by trimming padding before storage.
@@ -427,27 +450,41 @@ class RTensor:
                 )
                 if compacted is not None:
                     obj = compacted[0]
-            return {k: RTensor.remotize(v, node_addr=node_addr) for k, v in obj.items()}
+            return {
+                k: RTensor._remotize_recursive(v, node_addr, tensor_memo)
+                for k, v in obj.items()
+            }
 
         if isinstance(obj, list):
-            return [RTensor.remotize(item, node_addr=node_addr) for item in obj]
+            return [
+                RTensor._remotize_recursive(item, node_addr, tensor_memo)
+                for item in obj
+            ]
 
         if isinstance(obj, tuple):
-            return tuple(RTensor.remotize(item, node_addr=node_addr) for item in obj)
+            return tuple(
+                RTensor._remotize_recursive(item, node_addr, tensor_memo)
+                for item in obj
+            )
 
         return obj
 
     @staticmethod
-    def localize(obj: Any) -> Any:
+    def localize(obj: Any, *, preserve_tensor_aliases: bool = False) -> Any:
         """Convert RTensors to local tensors in nested structures.
 
         Inverse of remotize() - fetches remote data and converts to local tensors.
         All remote fetches are batched concurrently for performance.
+        When ``preserve_tensor_aliases`` is enabled, RTensors that reference the
+        same shard are fetched once and resolve to the same local tensor object.
 
         Parameters
         ----------
         obj : Any
             Object potentially containing RTensors
+        preserve_tensor_aliases : bool, default=False
+            Preserve aliases represented by repeated shard IDs within this root
+            call. The default retains the existing localization behavior.
 
         Returns
         -------
@@ -457,6 +494,10 @@ class RTensor:
         # Pre-fetch all remote tensors concurrently
         rtensors: list[RTensor] = []
         RTensor._collect_all(obj, rtensors)
+        if preserve_tensor_aliases:
+            RTensor._localize_preserving_aliases(rtensors)
+            return RTensor._localize_recursive(obj)
+
         meta_rtensors = [rt for rt in rtensors if rt.data.is_meta]
         if meta_rtensors:
             # Resolve as many as possible from the client-side fetch buffer.
@@ -480,6 +521,46 @@ class RTensor:
 
         # Recursively replace RTensors with local tensors (all buffer hits now)
         return RTensor._localize_recursive(obj)
+
+    @staticmethod
+    def _localize_preserving_aliases(rtensors: list[RTensor]) -> None:
+        """Resolve each shard once and assign its tensor to every reference."""
+        references_by_shard: dict[Any, list[RTensor]] = {}
+        for rtensor in rtensors:
+            references_by_shard.setdefault(rtensor.shard.shard_id, []).append(rtensor)
+
+        misses: dict[Any, list[RTensor]] = {}
+
+        with _fetch_buffer_lock:
+            for shard_id, references in references_by_shard.items():
+                tensor = next(
+                    (
+                        rtensor.data
+                        for rtensor in references
+                        if not rtensor.data.is_meta
+                    ),
+                    None,
+                )
+                if tensor is None:
+                    tensor = _fetch_buffer.get(shard_id)
+
+                if tensor is not None:
+                    for rtensor in references:
+                        rtensor.data = tensor
+                else:
+                    misses[shard_id] = references
+
+        if not misses:
+            return
+
+        representatives = [references[0] for references in misses.values()]
+        results = get_backend().fetch([rtensor.shard for rtensor in representatives])
+        with _fetch_buffer_lock:
+            for references, tensor in zip(misses.values(), results, strict=True):
+                shard_id = references[0].shard.shard_id
+                _fetch_buffer[shard_id] = tensor
+                for rtensor in references:
+                    rtensor.data = tensor
 
     @staticmethod
     def _collect_all(obj: Any, result: list[RTensor]) -> None:

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -415,7 +415,7 @@ class RTensor:
     def _remotize_recursive(
         obj: Any,
         node_addr: str,
-        tensor_memo: dict[int, RTensor] | None,
+        tensor_memo: dict[int, tuple[torch.Tensor, RTensor]] | None,
     ) -> Any:
         if obj is None:
             return None
@@ -423,7 +423,7 @@ class RTensor:
         if isinstance(obj, torch.Tensor):
             tensor_id = id(obj)
             if tensor_memo is not None and tensor_id in tensor_memo:
-                return tensor_memo[tensor_id]
+                return tensor_memo[tensor_id][1]
 
             tensor = obj.detach().cpu()
             shard_id = get_backend().store(tensor)
@@ -433,7 +433,9 @@ class RTensor:
             )
             remote_tensor = RTensor(shard=shard, data=tensor.to("meta"))
             if tensor_memo is not None:
-                tensor_memo[tensor_id] = remote_tensor
+                # Compaction creates temporary tensor objects. Keep them alive
+                # until this root call ends so their Python IDs cannot be reused.
+                tensor_memo[tensor_id] = (obj, remote_tensor)
             return remote_tensor
 
         if isinstance(obj, dict):

--- a/areal/infra/workflow_context.py
+++ b/areal/infra/workflow_context.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import aiohttp
 import httpx
 
+from areal.infra.processor_cache import ProcessorCallCache
 from areal.infra.utils.concurrent import register_loop_cleanup
 from areal.infra.utils.http import (
     DEFAULT_REQUEST_TIMEOUT,
@@ -35,11 +36,17 @@ class WorkflowContext:
         Index of this sample within its rollout group, when the workflow runs
         under a grouped workflow. Gives group members a stable identity that
         does not depend on completion order.
+    group_size : int
+        Number of samples in the current rollout group.
+    processor_cache : ProcessorCallCache | None
+        Group-scoped cache shared by candidate workflows in the same process.
     """
 
     is_eval: bool = False
     task_id: int | None = None
     sample_idx: int | None = None
+    group_size: int = 1
+    processor_cache: ProcessorCallCache | None = None
 
 
 _current_context: ContextVar[WorkflowContext] = ContextVar(

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -34,6 +34,7 @@ from areal.utils.data import (
     Normalization,
     TrajBatchMeta,
     batched_call,
+    is_multi_modal_key,
     split_padded_tensor_dict_into_mb_list,
 )
 from areal.utils.functional import (
@@ -518,9 +519,55 @@ class PPOActorController(TrainController):
         )
 
     def compute_advantages(self, *args, **kwargs):
-        return self._custom_function_call(
-            "compute_advantages", *args, rpc_meta={"broadcast": True}, **kwargs
+        if (
+            self.train_alloc.backend != "megatron"
+            or not args
+            or not isinstance(args[0], list)
+            or not all(isinstance(item, dict) for item in args[0])
+        ):
+            return self._custom_function_call(
+                "compute_advantages", *args, rpc_meta={"broadcast": True}, **kwargs
+            )
+
+        data = args[0]
+        multi_modal_payloads = [
+            {key: value for key, value in item.items() if is_multi_modal_key(key)}
+            for item in data
+        ]
+        if not any(multi_modal_payloads):
+            return self._custom_function_call(
+                "compute_advantages", *args, rpc_meta={"broadcast": True}, **kwargs
+            )
+
+        # Advantage computation never consumes vision inputs. Keep the original
+        # RTensor references on the controller so the grouped image shards do
+        # not make an unnecessary worker round trip before ppo_update.
+        rpc_data = [
+            {key: value for key, value in item.items() if not is_multi_modal_key(key)}
+            for item in data
+        ]
+        results = self._custom_function_call(
+            "compute_advantages",
+            rpc_data,
+            *args[1:],
+            rpc_meta={"broadcast": True},
+            **kwargs,
         )
+        if not isinstance(results, list) or len(results) != len(multi_modal_payloads):
+            raise RuntimeError(
+                "Megatron compute_advantages returned an invalid trajectory batch: "
+                f"expected {len(multi_modal_payloads)} items, got "
+                f"{type(results).__name__} of length "
+                f"{len(results) if isinstance(results, list) else 'unknown'}"
+            )
+        for result, payload in zip(results, multi_modal_payloads, strict=True):
+            if not isinstance(result, dict):
+                raise RuntimeError(
+                    "Megatron compute_advantages returned a non-dict trajectory: "
+                    f"{type(result).__name__}"
+                )
+            result.update(payload)
+        return results
 
     def ppo_update(self, *args, **kwargs) -> None:
         self._custom_function_call(

--- a/areal/workflow/vision_rlvr.py
+++ b/areal/workflow/vision_rlvr.py
@@ -109,12 +109,30 @@ class VisionRLVRWorkflow(RLVRWorkflow):
             self.async_reward_fn = AsyncRewardWrapper(self.reward_fn)
 
         processor_callable = cast(Callable[..., dict[str, Any]], self.processor)
-        processed_input = processor_callable(
-            images=data["images"],
-            text=data["messages"],
-            padding=False,
-            return_tensors="pt",
-        )
+
+        def process_input() -> dict[str, Any]:
+            return processor_callable(
+                images=data["images"],
+                text=data["messages"],
+                padding=False,
+                return_tensors="pt",
+            )
+
+        processor_cache = workflow_context.get().processor_cache
+        if processor_cache is None:
+            processed_input = process_input()
+        else:
+            cache_key = processor_cache.make_key(
+                "vision_rlvr",
+                id(self.processor),
+                id(data),
+            )
+            cached_input = await processor_cache.aget_or_compute(
+                cache_key, process_input
+            )
+            # Containers remain private to each candidate. Tensor values are treated
+            # as immutable and intentionally shared within the rollout group.
+            processed_input = dict(cached_input)
 
         input_ids: list[int] = processed_input["input_ids"].tolist()[0]
         mm_token_type_ids: list[int] = processed_input["mm_token_type_ids"].tolist()[0]

--- a/tests/experimental/openai/test_proxy_rollout_server.py
+++ b/tests/experimental/openai/test_proxy_rollout_server.py
@@ -7,9 +7,14 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from areal.experimental.openai.proxy import proxy_rollout_server as srv
 from areal.experimental.openai.proxy.server import SessionData
+from areal.experimental.openai.proxy.tensor_reference import GroupTensorStoreRegistry
+from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.infra.processor_cache import ProcessorCacheRegistry
+from areal.infra.rpc.serialization import deserialize_value
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -30,6 +35,8 @@ def _reset_server_globals(monkeypatch):
     monkeypatch.setattr(srv, "_last_cleanup_time", 0.0)
     monkeypatch.setattr(srv, "_engine", None)
     monkeypatch.setattr(srv, "_openai_client", None)
+    monkeypatch.setattr(srv, "_processor_cache_registry", ProcessorCacheRegistry())
+    monkeypatch.setattr(srv, "_group_tensor_store_registry", GroupTensorStoreRegistry())
 
 
 httpx = pytest.importorskip("httpx")
@@ -244,6 +251,104 @@ class TestExportTrajectories:
             )
             assert resp_export.status_code == 200
             assert "interactions" in resp_export.json()
+
+    @pytest.mark.asyncio
+    async def test_group_exports_share_multimodal_tensor_reference(self):
+        """Two grouped sessions should export refs and fetch one tensor payload."""
+        group_id = "train:task-1"
+        pixel_values = torch.arange(12).reshape(1, 3, 2, 2)
+
+        for sample_idx in range(2):
+            session_id = f"task-1:{sample_idx}-0"
+            session = SessionData(
+                session_id=session_id,
+                processor_cache_group_id=group_id,
+            )
+            interaction = InteractionWithTokenLogpReward()
+            interaction.interaction_id = f"interaction-{sample_idx}"
+            interaction.messages = [{"role": "user", "content": "question"}]
+            interaction.reward = 1.0
+            interaction._cache = {
+                "input_ids": torch.tensor([[sample_idx, 2]]),
+                "multi_modal_input": [{"pixel_values": pixel_values}],
+            }
+            session.completions[interaction.interaction_id] = interaction
+            session.finish()
+            srv._session_cache[session_id] = session
+
+        async with _client() as client:
+            responses = []
+            for sample_idx in range(2):
+                response = await client.post(
+                    "/export_trajectories",
+                    headers=_admin_headers(),
+                    json={
+                        "session_id": f"task-1:{sample_idx}-0",
+                        "supports_shared_tensor_references": True,
+                    },
+                )
+                assert response.status_code == 200
+                responses.append(response.json())
+
+            first_item = next(iter(responses[0]["interactions"].values()))
+            second_item = next(iter(responses[1]["interactions"].values()))
+            first_ref = first_item["tensor_dict"]["multi_modal_input"][0][
+                "pixel_values"
+            ]
+            second_ref = second_item["tensor_dict"]["multi_modal_input"][0][
+                "pixel_values"
+            ]
+            assert first_ref == second_ref
+            assert responses[0]["tensor_reference_group_id"] == group_id
+            assert "data" not in first_ref
+
+            fetch_response = await client.post(
+                "/rl/fetch_shared_tensors",
+                headers=_admin_headers(),
+                json={"group_id": group_id, "ref_ids": [first_ref["ref_id"]]},
+            )
+
+        assert fetch_response.status_code == 200
+        fetched = deserialize_value(fetch_response.json()["tensors"])
+        assert list(fetched) == [first_ref["ref_id"]]
+        torch.testing.assert_close(
+            fetched[first_ref["ref_id"]], pixel_values, rtol=0, atol=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_group_export_without_reference_capability_keeps_inline_tensor(self):
+        """Legacy clients should continue receiving inline multimodal tensors."""
+        pixel_values = torch.arange(4)
+        session = SessionData(
+            session_id="legacy-session",
+            processor_cache_group_id="train:legacy-task",
+        )
+        interaction = InteractionWithTokenLogpReward()
+        interaction.interaction_id = "legacy-interaction"
+        interaction.messages = [{"role": "user", "content": "question"}]
+        interaction.reward = 1.0
+        interaction._cache = {
+            "input_ids": torch.tensor([[1, 2]]),
+            "multi_modal_input": [{"pixel_values": pixel_values}],
+        }
+        session.completions[interaction.interaction_id] = interaction
+        session.finish()
+        srv._session_cache[session.session_id] = session
+
+        async with _client() as client:
+            response = await client.post(
+                "/export_trajectories",
+                headers=_admin_headers(),
+                json={"session_id": session.session_id},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        item = next(iter(data["interactions"].values()))
+        serialized_image = item["tensor_dict"]["multi_modal_input"][0]["pixel_values"]
+        assert serialized_image["type"] == "tensor"
+        assert serialized_image["data"] is not None
+        assert data["tensor_reference_group_id"] is None
 
     @pytest.mark.asyncio
     async def test_export_rejects_non_admin_key(self, monkeypatch):

--- a/tests/experimental/openai/test_proxy_rollout_server.py
+++ b/tests/experimental/openai/test_proxy_rollout_server.py
@@ -267,6 +267,9 @@ class TestExportTrajectories:
             interaction = InteractionWithTokenLogpReward()
             interaction.interaction_id = f"interaction-{sample_idx}"
             interaction.messages = [{"role": "user", "content": "question"}]
+            interaction.output_message_list = [
+                {"role": "assistant", "content": "answer"}
+            ]
             interaction.reward = 1.0
             interaction._cache = {
                 "input_ids": torch.tensor([[sample_idx, 2]]),
@@ -326,6 +329,7 @@ class TestExportTrajectories:
         interaction = InteractionWithTokenLogpReward()
         interaction.interaction_id = "legacy-interaction"
         interaction.messages = [{"role": "user", "content": "question"}]
+        interaction.output_message_list = [{"role": "assistant", "content": "answer"}]
         interaction.reward = 1.0
         interaction._cache = {
             "input_ids": torch.tensor([[1, 2]]),

--- a/tests/experimental/openai/test_tensor_reference.py
+++ b/tests/experimental/openai/test_tensor_reference.py
@@ -179,3 +179,60 @@ def test_group_tensor_store_registry_discard_removes_references():
 
     with pytest.raises(KeyError, match="Unknown shared tensor group"):
         registry.fetch("train:task-1", [ref_id])
+
+
+@pytest.mark.asyncio
+async def test_staggered_exports_after_cleanup_resolve_new_store_tensors(monkeypatch):
+    """A recreated store must not collide with an earlier export's cached refs."""
+    now = 0.0
+    monkeypatch.setattr(
+        "areal.experimental.openai.proxy.tensor_reference.time.monotonic", lambda: now
+    )
+    registry = GroupTensorStoreRegistry()
+    resolver = SharedTensorResolver()
+    group_id = "train:staggered"
+    fetch_calls = []
+
+    async def fetch(ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        fetch_calls.append(ref_ids)
+        return registry.fetch(group_id, ref_ids)
+
+    first = registry.get_or_create(group_id).encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": torch.tensor([1])}]}
+    )
+    resolved_first = await resolver.resolve(first, group_id=group_id, fetch=fetch)
+
+    now = 61.0
+    registry.discard_stale(timeout_seconds=60)
+    with pytest.raises(KeyError, match="Unknown shared tensor group"):
+        registry.fetch(group_id, [])
+
+    later = registry.get_or_create(group_id).encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": torch.tensor([99])}]}
+    )
+    first_ref = first["multi_modal_input"][0]["pixel_values"]["ref_id"]
+    later_ref = later["multi_modal_input"][0]["pixel_values"]["ref_id"]
+    assert later_ref != first_ref
+    with pytest.raises(KeyError, match="Unknown shared tensor references"):
+        registry.fetch(group_id, [first_ref])
+
+    resolved_later = await resolver.resolve(later, group_id=group_id, fetch=fetch)
+    resolved_again = await resolver.resolve(later, group_id=group_id, fetch=fetch)
+
+    assert fetch_calls == [[first_ref], [later_ref]]
+    torch.testing.assert_close(
+        resolved_first["multi_modal_input"][0]["pixel_values"],
+        torch.tensor([1]),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        resolved_later["multi_modal_input"][0]["pixel_values"],
+        torch.tensor([99]),
+        rtol=0,
+        atol=0,
+    )
+    assert (
+        resolved_again["multi_modal_input"][0]["pixel_values"]
+        is resolved_later["multi_modal_input"][0]["pixel_values"]
+    )

--- a/tests/experimental/openai/test_tensor_reference.py
+++ b/tests/experimental/openai/test_tensor_reference.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import torch
+
+from areal.experimental.openai.proxy.server import deserialize_interactions
+from areal.experimental.openai.proxy.tensor_reference import (
+    GroupTensorStore,
+    GroupTensorStoreRegistry,
+    SharedTensorResolver,
+)
+from areal.utils.data import concat_padded_tensors
+
+
+def _trajectory(
+    *, input_ids: torch.Tensor, pixel_values: torch.Tensor
+) -> dict[str, Any]:
+    return {
+        "input_ids": input_ids,
+        "multi_modal_input": [
+            {
+                "pixel_values": pixel_values,
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            }
+        ],
+    }
+
+
+def test_group_tensor_store_shared_image_returns_same_reference():
+    """Shared image tensors should use one ref while text remains untouched."""
+    store = GroupTensorStore()
+    pixel_values = torch.arange(12).reshape(1, 3, 2, 2)
+    first_ids = torch.tensor([[1, 2]])
+    second_ids = torch.tensor([[1, 3]])
+
+    first = store.encode_multimodal_tensors(
+        _trajectory(input_ids=first_ids, pixel_values=pixel_values)
+    )
+    second = store.encode_multimodal_tensors(
+        _trajectory(input_ids=second_ids, pixel_values=pixel_values)
+    )
+
+    first_ref = first["multi_modal_input"][0]["pixel_values"]
+    second_ref = second["multi_modal_input"][0]["pixel_values"]
+    assert first_ref == second_ref
+    assert first["input_ids"] is first_ids
+    assert second["input_ids"] is second_ids
+    fetched = store.fetch([first_ref["ref_id"]])
+    assert fetched[first_ref["ref_id"]] is pixel_values
+
+
+def test_group_tensor_store_equal_distinct_images_return_distinct_references():
+    """Equal-valued image tensors must not be merged without shared identity."""
+    store = GroupTensorStore()
+    first_image = torch.arange(4)
+    second_image = first_image.clone()
+
+    first = store.encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": first_image}]}
+    )
+    second = store.encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": second_image}]}
+    )
+
+    assert (
+        first["multi_modal_input"][0]["pixel_values"]["ref_id"]
+        != second["multi_modal_input"][0]["pixel_values"]["ref_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_tensor_resolver_concurrent_sessions_fetches_reference_once():
+    """Concurrent session exports should share one fetch and one tensor object."""
+    resolver = SharedTensorResolver()
+    ref = {"type": "areal_shared_tensor", "ref_id": "tensor-0"}
+    tensor = torch.arange(8)
+    fetch_calls: list[list[str]] = []
+    allow_fetch = asyncio.Event()
+
+    async def fetch(ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        fetch_calls.append(ref_ids)
+        await allow_fetch.wait()
+        return {"tensor-0": tensor}
+
+    def serialized_interaction(interaction_id: str) -> dict[str, Any]:
+        return {
+            interaction_id: {
+                "tensor_dict": {
+                    "input_ids": torch.tensor([[1, 2]]),
+                    "multi_modal_input": [{"pixel_values": ref}],
+                },
+                "reward": 1.0,
+                "interaction_id": interaction_id,
+            }
+        }
+
+    first_task = asyncio.create_task(
+        resolver.resolve(
+            serialized_interaction("interaction-0"),
+            group_id="train:task-1",
+            fetch=fetch,
+        )
+    )
+    await asyncio.sleep(0)
+    second_task = asyncio.create_task(
+        resolver.resolve(
+            serialized_interaction("interaction-1"),
+            group_id="train:task-1",
+            fetch=fetch,
+        )
+    )
+    await asyncio.sleep(0)
+    allow_fetch.set()
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert fetch_calls == [["tensor-0"]]
+    first_interaction = deserialize_interactions(first)["interaction-0"]
+    second_interaction = deserialize_interactions(second)["interaction-1"]
+    first_image = first_interaction.to_tensor_dict()["multi_modal_input"][0][
+        "pixel_values"
+    ]
+    second_image = second_interaction.to_tensor_dict()["multi_modal_input"][0][
+        "pixel_values"
+    ]
+    assert first_image is tensor
+    assert second_image is tensor
+    assert first_image is second_image
+
+    grouped = concat_padded_tensors(
+        [first_interaction.to_tensor_dict(), second_interaction.to_tensor_dict()]
+    )
+    assert grouped["multi_modal_input"][0]["pixel_values"] is tensor
+    assert grouped["multi_modal_input"][1]["pixel_values"] is tensor
+
+
+@pytest.mark.asyncio
+async def test_shared_tensor_resolver_ignores_reference_marker_in_text_payload():
+    """Reference-like user text must not enter multimodal tensor resolution."""
+    resolver = SharedTensorResolver()
+    value = {
+        "messages": [
+            {
+                "role": "user",
+                "content": {
+                    "type": "areal_shared_tensor",
+                    "ref_id": "user-provided-value",
+                },
+            }
+        ]
+    }
+
+    async def unexpected_fetch(_ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        raise AssertionError("text payload must not fetch shared tensors")
+
+    resolved = await resolver.resolve(
+        value,
+        group_id="train:task-1",
+        fetch=unexpected_fetch,
+    )
+
+    assert resolved is value
+
+
+def test_group_tensor_store_registry_discard_removes_references():
+    """Finalizing a group should release all proxy-side tensor references."""
+    registry = GroupTensorStoreRegistry()
+    store = registry.get_or_create("train:task-1")
+    encoded = store.encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": torch.arange(4)}]}
+    )
+    ref_id = encoded["multi_modal_input"][0]["pixel_values"]["ref_id"]
+
+    registry.discard("train:task-1")
+
+    with pytest.raises(KeyError, match="Unknown shared tensor group"):
+        registry.fetch("train:task-1", [ref_id])

--- a/tests/infra/rpc/test_engine_validation.py
+++ b/tests/infra/rpc/test_engine_validation.py
@@ -1,6 +1,7 @@
 import pytest
 from flask import Flask
 
+from areal.infra.rpc.guard import engine_blueprint
 from areal.infra.rpc.guard.app import GuardState
 from areal.infra.rpc.guard.engine_blueprint import engine_bp
 
@@ -44,3 +45,73 @@ def test_set_env_invalid_json(client):
     # Sending a string where an object is expected for 'env'
     resp = client.post("/set_env", json={"env": "not-a-dict"})
     assert resp.status_code == 400
+
+
+@pytest.mark.parametrize(
+    (
+        "method",
+        "cpu_staged_rpc_methods",
+        "expected_localize",
+        "expected_remotize",
+    ),
+    [
+        ("echo", frozenset(), False, False),
+        ("echo", frozenset({"echo"}), True, False),
+        ("wait_for_task", frozenset(), False, True),
+    ],
+)
+def test_call_engine_scopes_alias_preservation_to_supported_v1_boundaries(
+    client,
+    monkeypatch,
+    method,
+    cpu_staged_rpc_methods,
+    expected_localize,
+    expected_remotize,
+):
+    """Only CPU-staged inputs and grouped rollout outputs preserve aliases."""
+
+    class FakeEngine:
+        def __init__(self):
+            self.cpu_staged_rpc_methods = cpu_staged_rpc_methods
+
+        def echo(self, value):
+            return value
+
+        def wait_for_task(self, value):
+            return value
+
+    localize_calls = []
+    remotize_calls = []
+
+    def fake_localize(obj, *, preserve_tensor_aliases=False):
+        localize_calls.append(preserve_tensor_aliases)
+        return obj
+
+    def fake_remotize(obj, node_addr, *, preserve_tensor_aliases=False):
+        remotize_calls.append(preserve_tensor_aliases)
+        return obj
+
+    monkeypatch.setitem(engine_blueprint._engines, "test", FakeEngine())
+    monkeypatch.setattr(
+        engine_blueprint, "_submit_to_engine_thread", lambda _name, func: func()
+    )
+    monkeypatch.setattr(
+        engine_blueprint.RTensor, "localize", staticmethod(fake_localize)
+    )
+    monkeypatch.setattr(
+        engine_blueprint.RTensor, "remotize", staticmethod(fake_remotize)
+    )
+
+    response = client.post(
+        "/call",
+        json={
+            "method": method,
+            "engine_name": "test",
+            "args": ["payload"],
+            "kwargs": {},
+        },
+    )
+
+    assert response.status_code == 200
+    assert localize_calls == [expected_localize]
+    assert remotize_calls == [expected_remotize]

--- a/tests/test_grouped_rollout_workflow.py
+++ b/tests/test_grouped_rollout_workflow.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 import torch
 
 from areal.api import RolloutWorkflow
 from areal.experimental.openai import InteractionWithTokenLogpReward
-from areal.infra import dist_rollout
+from areal.infra import dist_rollout, workflow_context
 from areal.infra.dist_rollout import DistRolloutCoordinator
 from areal.infra.remote_inf_engine import GroupedRolloutWorkflow
 
@@ -150,3 +152,55 @@ def test_dist_rollout_coordinator_forwards_reward_group_flags(monkeypatch):
     assert rollout_engine.prepare_kwargs["drop_incomplete_group"] is True
     assert rollout_engine.rollout_kwargs["reward_normalization"] is True
     assert rollout_engine.rollout_kwargs["drop_incomplete_group"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["child_error", "child_cancel", "parent_cancel"])
+async def test_group_failure_cancels_siblings_before_finalizing(failure):
+    """Failed or cancelled groups must not wait forever on unfinished siblings."""
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    never_set = asyncio.Event()
+    finalized = []
+    original_error = ValueError("candidate failed")
+
+    class FailingWorkflow(RolloutWorkflow):
+        async def arun_episode(self, engine, data):
+            if workflow_context.get().sample_idx == 0:
+                await sibling_started.wait()
+                if failure == "child_error":
+                    raise original_error
+                if failure == "child_cancel":
+                    raise asyncio.CancelledError()
+                await never_set.wait()
+            else:
+                sibling_started.set()
+                try:
+                    await never_set.wait()
+                except asyncio.CancelledError:
+                    # Include async teardown to verify it is drained as well.
+                    await asyncio.sleep(0)
+                    sibling_cancelled.set()
+                    raise
+
+        async def _afinalize_processor_cache_group(self, context):
+            finalized.append(sibling_cancelled.is_set())
+
+    workflow = GroupedRolloutWorkflow(FailingWorkflow(), group_size=2, logger=_Logger())
+    task = asyncio.create_task(workflow.arun_episode(engine=None, data={}))
+    try:
+        await asyncio.wait_for(sibling_started.wait(), timeout=1)
+        if failure == "parent_cancel":
+            task.cancel()
+        error_type = ValueError if failure == "child_error" else asyncio.CancelledError
+        with pytest.raises(error_type) as exc_info:
+            # Shield keeps the timeout from making the broken implementation
+            # pass by cancelling its otherwise indefinitely waiting siblings.
+            await asyncio.wait_for(asyncio.shield(task), timeout=1)
+        if failure == "child_error":
+            assert exc_info.value is original_error
+        assert sibling_cancelled.is_set()
+        assert finalized == [True]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)

--- a/tests/test_ppo_actor_controller.py
+++ b/tests/test_ppo_actor_controller.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import torch
+
+from areal.trainer.ppo.actor import PPOActorController
+
+
+def _make_controller(backend: str) -> PPOActorController:
+    controller = object.__new__(PPOActorController)
+    controller.train_alloc = SimpleNamespace(backend=backend)
+    return controller
+
+
+def test_megatron_compute_advantages_bypasses_multimodal_payload(monkeypatch):
+    """Megatron should keep vision RTensor references on the controller."""
+    controller = _make_controller("megatron")
+    pixel_values = torch.arange(4)
+    image_grid_thw = torch.tensor([[1, 2, 2]])
+    batch = [
+        {
+            "input_ids": torch.tensor([1, 2]),
+            "multi_modal_input": [
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                }
+            ],
+        },
+        {
+            "input_ids": torch.tensor([3, 4]),
+            "multi_modal_input": [
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                }
+            ],
+        },
+    ]
+    captured = {}
+
+    def fake_call(method, rpc_batch, *, rpc_meta):
+        captured["method"] = method
+        captured["batch"] = rpc_batch
+        captured["rpc_meta"] = rpc_meta
+        return [dict(item, advantages=torch.tensor([1.0])) for item in rpc_batch]
+
+    monkeypatch.setattr(controller, "_custom_function_call", fake_call)
+
+    result = controller.compute_advantages(batch)
+
+    assert captured["method"] == "compute_advantages"
+    assert captured["rpc_meta"] == {"broadcast": True}
+    assert all("multi_modal_input" not in item for item in captured["batch"])
+    assert result[0]["multi_modal_input"] is batch[0]["multi_modal_input"]
+    assert result[1]["multi_modal_input"] is batch[1]["multi_modal_input"]
+    assert "multi_modal_input" in batch[0]
+
+
+def test_non_megatron_compute_advantages_keeps_existing_payload(monkeypatch):
+    """Other v1 backends should retain their existing controller behavior."""
+    controller = _make_controller("fsdp")
+    batch = [{"multi_modal_input": [{"pixel_values": torch.arange(4)}]}]
+    expected = [{"status": "unchanged"}]
+    captured = {}
+
+    def fake_call(method, *args, rpc_meta, **kwargs):
+        captured["method"] = method
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        captured["rpc_meta"] = rpc_meta
+        return expected
+
+    monkeypatch.setattr(controller, "_custom_function_call", fake_call)
+
+    result = controller.compute_advantages(batch)
+
+    assert result is expected
+    assert captured["method"] == "compute_advantages"
+    assert captured["args"][0] is batch
+    assert captured["rpc_meta"] == {"broadcast": True}

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -60,6 +60,23 @@ class _FakeDeleteSession:
         return _FakeDeleteResponse(item)
 
 
+class _RecordingRTensorBackend:
+    def __init__(self):
+        self.tensors = {}
+        self.store_calls = []
+        self.fetch_calls = []
+
+    def store(self, tensor):
+        shard_id = f"shard-{len(self.store_calls)}"
+        self.store_calls.append(tensor)
+        self.tensors[shard_id] = tensor
+        return shard_id
+
+    def fetch(self, shards):
+        self.fetch_calls.append(shards)
+        return [self.tensors[shard.shard_id] for shard in shards]
+
+
 @pytest.fixture(scope="module")
 def rpc_server():
     """Start RPC server for integration tests."""
@@ -910,6 +927,104 @@ class TestRemotize:
         # attention_mask should be trimmed to [[1,1,1],[1,1,0]]
         expected_mask = torch.tensor([[1, 1, 1], [1, 1, 0]])
         assert torch.equal(localized["attention_mask"], expected_mask)
+
+
+class TestRTensorAliasPreservation:
+    def test_remotize_shared_tensor_default_uses_distinct_shards(self, monkeypatch):
+        """Alias preservation should remain opt-in for existing callers."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        tensor = torch.arange(6)
+
+        result = RTensor.remotize([tensor, tensor], node_addr="node-a")
+
+        assert result[0].shard.shard_id != result[1].shard.shard_id
+        assert len(backend.store_calls) == 2
+
+    def test_remotize_shared_multimodal_tensors_stores_each_object_once(
+        self, monkeypatch
+    ):
+        """Shared group image tensors should map to one shard per object."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+
+        pixel_values = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+        image_grid_thw = torch.tensor([[1, 2, 2]])
+        trajectory = {
+            "attention_mask": torch.tensor([[1, 1, 0], [1, 1, 0]]),
+            "multi_modal_input": [
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                },
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                },
+            ],
+        }
+
+        result = RTensor.remotize(
+            trajectory,
+            node_addr="node-a",
+            preserve_tensor_aliases=True,
+        )
+
+        first, second = result["multi_modal_input"]
+        assert first["pixel_values"] is second["pixel_values"]
+        assert first["image_grid_thw"] is second["image_grid_thw"]
+        assert len(backend.store_calls) == 3
+
+    def test_remotize_equal_distinct_tensors_uses_distinct_shards(self, monkeypatch):
+        """Equal values should not merge when tensor identities differ."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        first = torch.arange(6)
+        second = first.clone()
+
+        result = RTensor.remotize(
+            [first, second],
+            node_addr="node-a",
+            preserve_tensor_aliases=True,
+        )
+
+        assert result[0].shard.shard_id != result[1].shard.shard_id
+        assert len(backend.store_calls) == 2
+
+    def test_localize_repeated_shard_fetches_once_and_restores_aliases(
+        self, monkeypatch
+    ):
+        """Repeated shard references should share one fetch and local tensor."""
+        backend = _RecordingRTensorBackend()
+        backend.tensors["shared-image"] = torch.arange(12).reshape(3, 4)
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        monkeypatch.setattr("areal.infra.rpc.rtensor._fetch_buffer", {})
+
+        def make_remote_tensor():
+            return RTensor(
+                shard=TensorShardInfo(
+                    shard_id="shared-image",
+                    node_addr="node-a",
+                ),
+                data=torch.empty(3, 4, device="meta"),
+            )
+
+        serialized_payload = serialize_value(
+            {
+                "args": [make_remote_tensor()],
+                "kwargs": {"image": make_remote_tensor()},
+            }
+        )
+        payload = deserialize_value(serialized_payload)
+
+        result = RTensor.localize(
+            payload,
+            preserve_tensor_aliases=True,
+        )
+
+        assert len(backend.fetch_calls) == 1
+        assert len(backend.fetch_calls[0]) == 1
+        assert result["args"][0] is result["kwargs"]["image"]
 
 
 class TestFetchBuffer:

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 import uuid
+import weakref
 
 import aiohttp
 import orjson
@@ -738,7 +739,8 @@ class TestRTensorMemoryCleanup:
 class TestRemotize:
     """Test remotize method with various input types."""
 
-    def test_remotize_list_of_dicts(self, rpc_server):
+    @pytest.mark.parametrize("preserve_tensor_aliases", [False, True])
+    def test_remotize_list_of_dicts(self, rpc_server, preserve_tensor_aliases):
         """Test remotizing list of dicts with different attention masks."""
         # Create two trajectory dicts with different seqlens
         traj1 = {
@@ -754,7 +756,11 @@ class TestRemotize:
             "logits": torch.randn(3, 5).cpu(),
         }
 
-        result = RTensor.remotize([traj1, traj2], node_addr=rpc_server)
+        result = RTensor.remotize(
+            [traj1, traj2],
+            node_addr=rpc_server,
+            preserve_tensor_aliases=preserve_tensor_aliases,
+        )
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -767,6 +773,14 @@ class TestRemotize:
         # Verify size matches batch dimension
         assert result[0]["logits"].shape[0] == 2
         assert result[1]["logits"].shape[0] == 3
+
+        for original, remote, seqlen in zip(
+            [traj1, traj2], result, [3, 4], strict=True
+        ):
+            for key in original:
+                torch.testing.assert_close(
+                    remote[key].to_local(), original[key][:, :seqlen], rtol=0, atol=0
+                )
 
     def test_remotize_list_of_tensors(self, rpc_server):
         """Test remotizing list of standalone tensors."""
@@ -930,6 +944,60 @@ class TestRemotize:
 
 
 class TestRTensorAliasPreservation:
+    def test_remotize_nested_trajectories_retains_temporary_sources(self, monkeypatch):
+        """Compacted sources stay alive across siblings, only until remotize ends."""
+        from areal.utils import data as data_utils
+
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        split_and_unpad = data_utils.split_and_unpad_tensor
+        source_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+        compaction_calls = 0
+
+        def track_compacted_sources(*args, **kwargs):
+            nonlocal compaction_calls
+            # Check lifetime directly, without relying on allocator-dependent
+            # ID reuse to expose an unrelated shard being returned.
+            assert all(ref() is not None for ref in source_refs)
+            compacted = split_and_unpad(*args, **kwargs)
+            source_refs.extend(weakref.ref(value) for value in compacted[0].values())
+            compaction_calls += 1
+            return compacted
+
+        monkeypatch.setattr(
+            data_utils, "split_and_unpad_tensor", track_compacted_sources
+        )
+        first = {
+            "attention_mask": torch.tensor([[1, 1, 0]]),
+            "input_ids": torch.tensor([[1, 2, 0]]),
+        }
+        second = {
+            "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+            "input_ids": torch.tensor([[99, 98, 97, 0]]),
+        }
+
+        result = RTensor.remotize(
+            [first, {"nested": [second]}],
+            node_addr="node-a",
+            preserve_tensor_aliases=True,
+        )
+
+        assert compaction_calls == 2
+        assert len(source_refs) == 4
+        assert all(ref() is None for ref in source_refs)
+        assert len(backend.store_calls) == 4
+        for original, remote, seqlen in (
+            (first, result[0], 2),
+            (second, result[1]["nested"][0], 3),
+        ):
+            for key in original:
+                torch.testing.assert_close(
+                    backend.tensors[remote[key].shard.shard_id],
+                    original[key][:, :seqlen],
+                    rtol=0,
+                    atol=0,
+                )
+
     def test_remotize_shared_tensor_default_uses_distinct_shards(self, monkeypatch):
         """Alias preservation should remain opt-in for existing callers."""
         backend = _RecordingRTensorBackend()


### PR DESCRIPTION
## Description

VLM group sampling generates multiple trajectories from the same prompt and image. Before this change, each candidate independently ran the multimodal processor and carried its own copy of the resulting vision tensors through trajectory export, serialization, RTensor storage, RPC transport, and advantage computation.

This duplicated CPU processing and data movement even though the image and processor inputs were identical within the rollout group. The overhead becomes especially visible with larger images and larger GRPO group sizes.

This PR reduces that duplication across the v1 VLM rollout and Megatron training path.

### What changed

- Add a group-scoped, thread-safe single-flight processor cache.
      - Concurrent candidates wait asynchronously for the same in-flight processor call.
      - Cache state is released after the complete rollout group finishes or is aborted.
      - Mutable containers are copied for each consumer while processor-produced tensors are shared.
- Reuse processor outputs in grouped VLM workflows.
      - VisionRLVRWorkflow reuses identical processor calls within one rollout group.
      - OpenAI Chat Completions and Responses workflows reuse identical multimodal prompt processing.
      - OpenAI proxy sharing is limited to inline and subproc modes; online mode retains its existing behavior.
- Avoid repeatedly serializing identical multimodal tensors across proxy sessions.
      - Grouped trajectory exports replace repeated multimodal tensors with group-scoped references.
      - The rollout workflow asynchronously fetches each unique referenced tensor once and restores shared tensor identities.
      - Group resources have explicit completion cleanup and stale-session cleanup.
- Preserve shared tensor references through the transport primitives.
      - RTensor remotization and localization can preserve repeated tensor aliases.
      - Compatible CPU-staged engine RPC paths can retain shared tensor identities until microbatch preparation.
      - Existing behavior remains the default for unrelated engines and RPC methods.
- Avoid sending multimodal payloads through Megatron advantage computation.
      - Vision inputs are not consumed while computing advantages.
      - The controller keeps those payloads locally and attaches them to the returned trajectories before PPO update.

The optimization is enabled by rollout-group context and does not introduce a new user-facing configuration option. Text-only workloads and non-grouped rollouts retain their existing paths.

### Scope

This PR focuses on duplicate work among candidates in the same rollout group. It
does not implement:

- incremental processing of newly added images in multi-step workflows;
- SGLang request-side image_data reference transport;
- SGLang image-processor or vision-encoder caching;
- delayed or overlapped CPU-to-GPU image transfer.

Those optimizations have different lifecycle and serving contracts and can be
handled independently.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md) (https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (pre-commit run --all-files)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with ./docs/build_all.sh)
- [ ] Branch is up to date with main
- [ ] Self-reviewed via /review-pr command
- [ ] This PR was created by a coding agent via /create-pr
- [ ] This PR is a breaking change

Breaking Change Details (if applicable):

None.

## Additional Context

### Test coverage added

Unit tests cover:

- synchronous and asynchronous single-flight processor caching;
- grouped cache acquisition, release, cancellation, and stale cleanup;
- proxy tensor-reference encoding, fetching, and concurrent resolution;
- RTensor alias-preserving remotization and localization;
- engine RPC staging selection;
- Megatron PPO advantage computation without multimodal RPC payloads.

The unit-test suites were prepared but were not run locally as part of this development pass. The performance numbers above come from the end-to-end Geometry3K training experiment.
