### PR TITLE
perf(engine): encode each distinct image once per vision-tower forward

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -94,6 +94,7 @@ from areal.models.fsdp.ulysses import (
     ulysses_prepare_inputs,
 )
 from areal.models.transformers.ulyssess_patch import apply_monkey_patch
+from areal.models.transformers.vision_dedup import apply_vision_dedup
 from areal.models.tree_attn.functional import (
     _gather_packed_tree_logprobs,
     gather_packed_tree_logprobs_entropy,
@@ -395,6 +396,12 @@ class FSDPEngine(TrainEngine):
             ulysses_sp_size=self.parallel_helper.sp_size,
             shard_vision_across_sp=self.config.fsdp.shard_vision_across_sp,
         )
+        # Monkey patch: encode each distinct image once per vision-tower forward.
+        # Must follow apply_monkey_patch so this wrapper sits outside Vision SP
+        # Shard's: dedup then runs before images are distributed across SP ranks.
+        n_dedup = apply_vision_dedup()
+        if n_dedup:
+            self.logger.info(f"Vision-tower dedup applied to {n_dedup} class(es)")
         # Monkey patch: replace attention's forward() with tree attention.
         patch_fsdp_for_tree_training(enable=self.enable_tree_training)
 

--- a/areal/models/transformers/vision_dedup.py
+++ b/areal/models/transformers/vision_dedup.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deduplicate identical images inside a single vision-tower forward.
+
+A GRPO group of size G is G sequences that share one prompt and therefore one
+image. ``_prepare_multimodal_forward_inputs`` concatenates every sequence's
+``pixel_values`` into one microbatch, so the vision tower encodes that identical
+image once per group member. Measured on Qwen2.5-VL-3B / geometry3k at
+``n_samples=8``: 384 images encoded per 3 steps, 24 of them distinct.
+
+This wrapper encodes each distinct image once and expands the result back, so
+the tower sees only unique inputs while its caller sees exactly the same output.
+
+Scope is deliberately ONE forward. Caching across forwards is unsafe:
+  * the tower's weights change between optimizer steps, so a cached embedding
+    goes stale;
+  * within a step, ``recompute_logprob`` runs under ``no_grad`` while the update
+    forward needs grad, so reusing one in the other breaks the autograd graph.
+The microbatch packer (``allocate_balanced_mbs``) packs by sequence length and
+ignores group membership, so group members are only co-located by accident;
+measured, that caps this at ~32% of tower work rather than the ~94% a
+cross-forward cache would reach.
+
+PARAMETER gradients are unchanged in exact arithmetic: for identical inputs
+``sum_i(g_i^T x) == (sum_i g_i)^T x``, which is exactly what G separate forwards
+produce. Summation order differs, so results are NOT bit-identical -- expect
+ULP-level divergence; the tests assert a tolerance rather than equality.
+
+The gradient w.r.t. the INPUT tensor does change: dropped duplicates receive no
+gradient of their own. ``pixel_values`` is dataset-supplied and never requires
+grad here, and the wrapper falls back to the unmodified path if it ever does.
+
+Ordering against Vision SP Shard: this patch is applied *after*
+``apply_monkey_patch``, so it is the outer wrapper. Deduplication therefore
+happens before ``dp_vision_forward`` distributes images across SP ranks, which
+is the useful order -- every rank sees the same input and reaches the same
+unique set, so the assignment stays consistent, and the set that gets
+distributed is already the smaller one.
+"""
+
+import importlib
+import os
+from typing import Any
+
+import torch
+
+from areal.models.transformers.vision_sp_shard import _VISION_CLASSES
+from areal.utils import logging
+
+logger = logging.getLogger("VisionDedup")
+
+# ``_VISION_CLASSES`` is imported rather than restated: "which classes are the
+# vision tower" must have exactly one answer in this package, and a second list
+# would drift. An earlier version of this file duck-typed on the forward
+# signature instead -- and matched ``dp_vision_forward``, the Vision SP Shard
+# wrapper, which also takes ``(hidden_states, grid_thw)``. An explicit list
+# cannot make that mistake.
+
+
+def _fingerprint(flat: torch.Tensor, counts: list[int]) -> torch.Tensor:
+    """One cheap value per image, computed entirely on-device.
+
+    Deliberately NOT a content hash: hashing here would mean
+    ``.cpu().numpy().tobytes()`` per image -- a device-to-host copy inside the
+    forward this code exists to speed up.
+
+    Collisions are allowed: this only buckets candidates, and every candidate
+    pair is then confirmed with an exact ``torch.equal``.
+    """
+    segs = torch.split(flat, counts, dim=0)
+    # weight rows so that a permutation of rows does not collide with itself
+    return torch.stack(
+        [
+            (
+                s.float()
+                * torch.arange(1, s.shape[0] + 1, device=s.device, dtype=torch.float32)[
+                    :, None
+                ]
+            ).sum()
+            for s in segs
+        ]
+    )
+
+
+def _group_duplicates(
+    flat: torch.Tensor, dims: list[tuple[int, int, int]], counts: list[int]
+) -> tuple[list[int], list[int]]:
+    """Return (representative index per image, list of unique image indices).
+
+    Host syncs: one for the fingerprint vector, plus one per candidate pair that
+    reaches the exact ``torch.equal`` check. The grid geometry is *not* synced
+    here -- the caller reads it once with a single ``.tolist()`` and passes it
+    in, because ``int(v)`` over a device tensor costs one sync per element.
+    """
+    fp = _fingerprint(flat, counts).cpu().tolist()
+    segs = torch.split(flat, counts, dim=0)
+
+    reps: list[int] = []
+    uniques: list[int] = []
+    buckets: dict[tuple, list[int]] = {}
+    for i, (d, f) in enumerate(zip(dims, fp)):
+        key = (d, round(f, 6))
+        hit = -1
+        for j in buckets.get(key, ()):
+            # exact check; the fingerprint only narrowed the candidates
+            if torch.equal(segs[i], segs[j]):
+                hit = j
+                break
+        if hit >= 0:
+            reps.append(hit)
+        else:
+            buckets.setdefault(key, []).append(i)
+            uniques.append(i)
+            reps.append(i)
+    return reps, uniques
+
+
+def dedup_vision_forward(orig_forward):
+    """Wrap ``VisionTransformer.forward(hidden_states, grid_thw, ...)``."""
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: torch.Tensor | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        if grid_thw is None or grid_thw.shape[0] < 2:
+            return orig_forward(self, hidden_states, grid_thw, *args, **kwargs)
+
+        # Deduplication drops the duplicate input rows, so they receive no
+        # gradient of their own -- the representative receives the sum instead.
+        # Parameter gradients are unaffected (identical inputs, so
+        # sum_i(g_i^T x) == (sum_i g_i)^T x), but the gradient w.r.t. the INPUT
+        # tensor is not the same. In this framework pixel_values comes from the
+        # dataset and never requires grad, so this never triggers; the guard is
+        # here so correctness does not rest on that staying true.
+        if hidden_states.requires_grad:
+            return orig_forward(self, hidden_states, grid_thw, *args, **kwargs)
+
+        # Single host sync for the whole geometry. Reading it per element with
+        # int(v) costs 3N syncs, which is what this wrapper exists to avoid.
+        dims = [tuple(row) for row in grid_thw.tolist()]
+        counts = [t * h * w for t, h, w in dims]
+
+        reps, uniques = _group_duplicates(hidden_states, dims, counts)
+        if len(uniques) == len(dims):
+            return orig_forward(self, hidden_states, grid_thw, *args, **kwargs)
+
+        segs = torch.split(hidden_states, counts, dim=0)
+        out_u = orig_forward(
+            self,
+            torch.cat([segs[i] for i in uniques], dim=0),
+            grid_thw[uniques],
+            *args,
+            **kwargs,
+        )
+
+        unique_in = sum(counts[i] for i in uniques)
+
+        def expand(t):
+            """Map each original image back to its representative's slice of `t`.
+
+            Done per FIELD, because the tower returns tensors at two different
+            granularities: `last_hidden_state` is pre-merge (one row per input
+            patch) while `pooler_output` is post-merge (patches/merge^2). A single
+            shared divisor silently mis-slices one of them.
+            """
+            if not torch.is_tensor(t) or t.shape[0] == 0:
+                return t
+            if unique_in % t.shape[0]:
+                return None  # geometry we do not understand -> caller falls back
+            div = unique_in // t.shape[0]
+            if div < 1 or any(counts[i] % div for i in uniques):
+                return None
+            parts = dict(
+                zip(uniques, torch.split(t, [counts[i] // div for i in uniques], dim=0))
+            )
+            return torch.cat([parts[r] for r in reps], dim=0)
+
+        def expand_any(v):
+            """Expand a tensor, or a (possibly nested one level) sequence of them.
+
+            Qwen3-VL's tower returns ``(embeddings, deepstack_list)``, so a bare
+            tensor branch is not enough. ``None`` anywhere means we did not
+            understand the shape and the caller must redo the call unmodified.
+            """
+            if torch.is_tensor(v):
+                return expand(v)
+            if isinstance(v, (list, tuple)):
+                out = []
+                for item in v:
+                    g = expand_any(item)
+                    if g is None:
+                        return None
+                    out.append(g)
+                return type(v)(out) if isinstance(v, tuple) else out
+            return v
+
+        if torch.is_tensor(out_u) or isinstance(out_u, (list, tuple)):
+            grown = expand_any(out_u)
+            if grown is None:
+                return orig_forward(self, hidden_states, grid_thw, *args, **kwargs)
+            return grown
+
+        # transformers returns a ModelOutput dataclass here (Qwen2.5-VL gives
+        # BaseModelOutputWithPooling). Expand every tensor field; if any field has
+        # a shape we cannot account for, redo the call unmodified rather than
+        # hand back a half-correct object.
+        if hasattr(out_u, "keys") and hasattr(out_u, "__class__"):
+            grown = {}
+            for k in list(out_u.keys()):
+                g = expand_any(out_u[k])
+                if g is None:
+                    return orig_forward(self, hidden_states, grid_thw, *args, **kwargs)
+                grown[k] = g
+            return out_u.__class__(**grown)
+
+        # Unknown return type: never guess.
+        return orig_forward(self, hidden_states, grid_thw, *args, **kwargs)
+
+    return forward
+
+
+def _patch_vision_class(cls, class_name: str) -> bool:
+    """Patch one VisionTransformer class, with an idempotency guard."""
+    if getattr(cls, "_vision_dedup_patched", False):
+        return False
+    cls.forward = dedup_vision_forward(cls.forward)
+    cls._vision_dedup_patched = True
+    logger.info(f"[Vision Dedup] Patched {class_name}.forward")
+    return True
+
+
+def apply_vision_dedup() -> int:
+    """Patch the supported VisionTransformer classes. Returns how many were patched.
+
+    Shaped after ``apply_vision_sp_shard_patch``: class-level, no model argument,
+    safe to call more than once. Must run *after* ``apply_monkey_patch`` so that
+    this wrapper ends up outside Vision SP Shard's -- see the module docstring.
+
+    ``AREAL_VISION_DEDUP=0`` disables it. The switch exists so an A/B can run the
+    two legs from byte-identical code, and it doubles as an escape hatch if a
+    model's tower turns out to violate the assumptions above.
+    """
+    if os.environ.get("AREAL_VISION_DEDUP", "1") == "0":
+        return 0
+    patched = 0
+    for module_path, class_name in _VISION_CLASSES:
+        try:
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+        except (ImportError, AttributeError):
+            continue
+        if _patch_vision_class(cls, class_name):
+            patched += 1
+    return patched

--- a/areal/utils/logging.py
+++ b/areal/utils/logging.py
@@ -89,6 +89,8 @@ LOGGER_COLORS_EXACT = {
     "TreeAttentionCore": "light_cyan",
     "TreeAttentionConstants": "light_cyan",
     "TreeAttentionViz": "light_cyan",
+    # Vision model patches - cyan
+    "VisionDedup": "light_cyan",
     # Checkpoint - blue (infrastructure)
     "Saver": "blue",
     "AsyncCheckpoint": "blue",

--- a/tests/test_vision_dedup.py
+++ b/tests/test_vision_dedup.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for vision-tower deduplication (CPU-only, no distributed).
+
+Two questions every test here has to survive:
+  1. would this still pass if the wrapper were dropped?  -> TestLoadBearing
+  2. would this still pass if the wrapper returned garbage? -> the parity tests
+A test that only checks shape/dtype answers neither.
+
+Test naming convention: test_<what>_<condition>_<expected>()
+"""
+
+import importlib
+
+import pytest
+import torch
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+
+from areal.models.transformers.vision_dedup import (
+    _group_duplicates,
+    _patch_vision_class,
+    apply_vision_dedup,
+    dedup_vision_forward,
+)
+from areal.models.transformers.vision_sp_shard import create_dp_vision_forward
+
+
+class _VisionTower(torch.nn.Module):
+    """Stand-in with the real signature: forward(hidden_states, grid_thw).
+
+    Merges 2x2 patches like Qwen2.5-VL, so output rows = input rows / 4, which
+    is what makes the expand-back arithmetic non-trivial.
+    """
+
+    MERGE = 4
+
+    def __init__(self, dim=8, out=6):
+        super().__init__()
+        self.proj = torch.nn.Linear(dim * self.MERGE, out)
+        self.calls = 0
+        self.rows_seen = 0
+
+    def forward(self, hidden_states, grid_thw=None):
+        self.calls += 1
+        self.rows_seen += hidden_states.shape[0]
+        merged = hidden_states.reshape(hidden_states.shape[0] // self.MERGE, -1)
+        return self.proj(merged)
+
+
+class _RealShapeTower(torch.nn.Module):
+    """Returns the real dataclass with fields at two different granularities.
+
+    A test double that is more convenient than the real thing tests the double:
+    the first version of this suite returned a bare tensor, so nothing exercised
+    the per-field expansion and a wrong shared divisor stayed green.
+    """
+
+    MERGE = 4
+
+    def __init__(self, dim=8, out=6):
+        super().__init__()
+        self.proj = torch.nn.Linear(dim * self.MERGE, out)
+        self.rows_seen = 0
+
+    def forward(self, hidden_states, grid_thw=None):
+        self.rows_seen += hidden_states.shape[0]
+        merged = self.proj(
+            hidden_states.reshape(hidden_states.shape[0] // self.MERGE, -1)
+        )
+        return BaseModelOutputWithPooling(
+            last_hidden_state=hidden_states * 2.0,  # pre-merge granularity
+            pooler_output=merged,  # post-merge granularity
+        )
+
+
+class _DeepstackTower(torch.nn.Module):
+    """Returns ``(embeddings, [deepstack, ...])`` the way Qwen3-VL's tower does."""
+
+    MERGE = 4
+
+    def __init__(self, dim=8, out=6):
+        super().__init__()
+        self.proj = torch.nn.Linear(dim * self.MERGE, out)
+        self.rows_seen = 0
+
+    def forward(self, hidden_states, grid_thw=None):
+        self.rows_seen += hidden_states.shape[0]
+        merged = self.proj(
+            hidden_states.reshape(hidden_states.shape[0] // self.MERGE, -1)
+        )
+        return merged, [hidden_states * 3.0]
+
+
+_ORIGINALS = {
+    cls: cls.forward for cls in (_VisionTower, _RealShapeTower, _DeepstackTower)
+}
+
+
+@pytest.fixture(autouse=True)
+def _restore_forward():
+    """Undo class-level patching between tests, for real.
+
+    An earlier version restored with ``type(wrapped).forward = type(plain).forward``
+    -- but both are the SAME class, so that assigned the patched function back
+    onto itself and the patch leaked into every later test. Capture the original
+    function objects once, at import, and put those back.
+    """
+    yield
+    for cls, fn in _ORIGINALS.items():
+        cls.forward = fn
+        if hasattr(cls, "_vision_dedup_patched"):
+            del cls._vision_dedup_patched
+        if hasattr(cls, "_vision_sp_shard_patched"):
+            del cls._vision_sp_shard_patched
+
+
+def _make(mults, rows=8, dim=8, seed=0):
+    """Build (hidden_states, grid_thw) where each entry of ``mults`` is a
+    multiplicity: [4, 4] = two distinct images, each repeated four times."""
+    g = torch.Generator().manual_seed(seed)
+    imgs, order = [], []
+    for gi, mult in enumerate(mults):
+        imgs.append(torch.randn(rows, dim, generator=g))
+        order.extend([gi] * mult)
+    flat = torch.cat([imgs[i] for i in order], dim=0)
+    grid = torch.tensor([[rows // 4, 2, 2]] * len(order))
+    assert int(grid[0].prod()) == rows
+    return flat, grid, len(imgs), len(order)
+
+
+class TestGroupDuplicates:
+    def test_group_duplicates_repeated_images_finds_representatives(self):
+        flat, grid, n_unique, n_total = _make([4, 4])
+        dims = [tuple(r) for r in grid.tolist()]
+        counts = [t * h * w for t, h, w in dims]
+        reps, uniques = _group_duplicates(flat, dims, counts)
+        assert len(uniques) == n_unique
+        assert len(reps) == n_total
+        assert reps == [0, 0, 0, 0, 4, 4, 4, 4]
+
+    def test_group_duplicates_all_distinct_returns_every_index(self):
+        flat, grid, n_unique, n_total = _make([1, 1, 1])
+        dims = [tuple(r) for r in grid.tolist()]
+        counts = [t * h * w for t, h, w in dims]
+        reps, uniques = _group_duplicates(flat, dims, counts)
+        assert uniques == [0, 1, 2]
+        assert reps == [0, 1, 2]
+
+
+class TestDedupParity:
+    @pytest.mark.parametrize("mults", [[8], [4, 4], [8, 1, 3], [1, 1, 1]])
+    def test_dedup_forward_any_multiplicity_matches_undeduped(self, mults):
+        flat, grid, _, _ = _make(mults)
+        plain = _VisionTower()
+        expected = plain(flat, grid)
+
+        wrapped = _VisionTower()
+        wrapped.load_state_dict(plain.state_dict())
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        got = wrapped(flat, grid)
+
+        torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
+
+    @pytest.mark.parametrize("mults", [[8], [4, 4], [8, 1, 3]])
+    def test_model_output_return_each_field_expanded_at_its_own_granularity(
+        self, mults
+    ):
+        flat, grid, _, _ = _make(mults)
+        plain = _RealShapeTower()
+        expected = plain(flat, grid)
+
+        wrapped = _RealShapeTower()
+        wrapped.load_state_dict(plain.state_dict())
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_RealShapeTower])
+        got = wrapped(flat, grid)
+
+        assert type(got) is type(expected)
+        torch.testing.assert_close(
+            got.last_hidden_state, expected.last_hidden_state, rtol=1e-5, atol=1e-6
+        )
+        torch.testing.assert_close(
+            got.pooler_output, expected.pooler_output, rtol=1e-5, atol=1e-6
+        )
+
+    def test_tuple_return_with_deepstack_expanded_elementwise(self):
+        flat, grid, _, _ = _make([4, 4])
+        plain = _DeepstackTower()
+        exp_emb, exp_ds = plain(flat, grid)
+
+        wrapped = _DeepstackTower()
+        wrapped.load_state_dict(plain.state_dict())
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_DeepstackTower])
+        got_emb, got_ds = wrapped(flat, grid)
+
+        torch.testing.assert_close(got_emb, exp_emb, rtol=1e-5, atol=1e-6)
+        assert len(got_ds) == len(exp_ds)
+        torch.testing.assert_close(got_ds[0], exp_ds[0], rtol=1e-5, atol=1e-6)
+
+
+class TestLoadBearing:
+    def test_dedup_forward_repeated_images_tower_processes_fewer_rows(self):
+        """Fails if the wrapper is a no-op -- the point of the whole change."""
+        flat, grid, n_unique, n_total = _make([4, 4])
+        rows_per_image = flat.shape[0] // n_total
+
+        wrapped = _VisionTower()
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        wrapped(flat, grid)
+
+        assert wrapped.rows_seen == n_unique * rows_per_image
+        assert wrapped.rows_seen < flat.shape[0]
+
+    def test_dedup_forward_all_distinct_is_a_passthrough(self):
+        flat, grid, _, n_total = _make([1, 1, 1])
+        wrapped = _VisionTower()
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        wrapped(flat, grid)
+        assert wrapped.rows_seen == flat.shape[0]
+
+
+class TestFallbacks:
+    def test_input_requires_grad_falls_back_and_every_duplicate_gets_gradient(self):
+        flat, grid, _, _ = _make([4, 4])
+        flat = flat.clone().requires_grad_(True)
+
+        wrapped = _VisionTower()
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        wrapped(flat, grid).sum().backward()
+
+        assert wrapped.rows_seen == flat.shape[0]  # no dedup happened
+        per_image = flat.grad.reshape(8, -1).abs().sum(dim=1)
+        assert (per_image > 0).all()  # no duplicate was silently starved
+
+    def test_near_duplicates_differing_by_1e_3_are_not_merged(self):
+        flat, grid, _, n_total = _make([2])
+        rows = flat.shape[0] // n_total
+        flat[rows:] += 1e-3
+
+        wrapped = _VisionTower()
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        wrapped(flat, grid)
+        assert wrapped.rows_seen == flat.shape[0]
+
+    def test_single_image_batch_skips_the_wrapper(self):
+        flat, grid, _, _ = _make([1])
+        wrapped = _VisionTower()
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        wrapped(flat, grid)
+        assert wrapped.rows_seen == flat.shape[0]
+
+
+class TestParameterGradients:
+    def test_parameter_gradients_match_undeduped(self):
+        flat, grid, _, _ = _make([4, 4])
+
+        plain = _VisionTower()
+        plain(flat, grid).sum().backward()
+        expected = {n: p.grad.clone() for n, p in plain.named_parameters()}
+
+        wrapped = _VisionTower()
+        wrapped.load_state_dict(plain.state_dict())
+        type(wrapped).forward = dedup_vision_forward(_ORIGINALS[_VisionTower])
+        wrapped(flat, grid).sum().backward()
+
+        for n, p in wrapped.named_parameters():
+            torch.testing.assert_close(p.grad, expected[n], rtol=1e-4, atol=1e-6)
+
+
+class TestPatchVisionClass:
+    def test_patch_vision_class_replaces_forward(self):
+        original = _VisionTower.forward
+        assert _patch_vision_class(_VisionTower, "_VisionTower") is True
+        assert _VisionTower.forward is not original
+        assert getattr(_VisionTower, "_vision_dedup_patched", False) is True
+
+    def test_patch_vision_class_idempotent_only_wraps_once(self):
+        _patch_vision_class(_VisionTower, "_VisionTower")
+        first = _VisionTower.forward
+        assert _patch_vision_class(_VisionTower, "_VisionTower") is False
+        assert _VisionTower.forward is first
+
+
+class TestApplyVisionDedup:
+    def test_apply_patch_through_the_real_entry_point_does_not_raise(self):
+        """Goes through the registration path, not the wrapper directly.
+
+        A test that only constructs ``dedup_vision_forward`` stays green after
+        the entry point is deleted.
+        """
+        apply_vision_dedup()
+
+    def test_apply_patch_disabled_by_env_var_patches_nothing(self, monkeypatch):
+        monkeypatch.setenv("AREAL_VISION_DEDUP", "0")
+        assert apply_vision_dedup() == 0
+
+
+class TestComposesWithVisionSpShard:
+    """Both patches assign to ``cls.forward``. This is the stacking order the
+    engine produces: ``apply_monkey_patch`` (and therefore Vision SP Shard) runs
+    first, then ``apply_vision_dedup``, so dedup ends up on the outside.
+
+    At ``sp_size <= 1`` ``dp_vision_forward`` passes straight through, so this
+    runs on CPU with no process group and still exercises the real stacking.
+    """
+
+    def test_dedup_outside_sp_shard_matches_unpatched_output(self):
+        flat, grid, _, _ = _make([4, 4])
+        plain = _VisionTower()
+        expected = plain(flat, grid)
+
+        stacked = _VisionTower()
+        stacked.load_state_dict(plain.state_dict())
+        # order as in FSDPEngine.initialize
+        _VisionTower.forward = create_dp_vision_forward(_ORIGINALS[_VisionTower])
+        _VisionTower.forward = dedup_vision_forward(_VisionTower.forward)
+        got = stacked(flat, grid)
+
+        torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
+
+    def test_dedup_outside_sp_shard_still_deduplicates(self):
+        flat, grid, n_unique, n_total = _make([4, 4])
+        rows_per_image = flat.shape[0] // n_total
+
+        stacked = _VisionTower()
+        _VisionTower.forward = create_dp_vision_forward(_ORIGINALS[_VisionTower])
+        _VisionTower.forward = dedup_vision_forward(_VisionTower.forward)
+        stacked(flat, grid)
+
+        assert stacked.rows_seen == n_unique * rows_per_image
+
+
+class TestEngineWiring:
+    """The patch has to be applied by FSDPEngine.initialize, not just be applicable.
+
+    Reverting the call site leaves every CPU test above green, because they all
+    reach the wrapper directly. This is the repo's own way of covering an engine
+    -applied model patch -- `tests/test_tree_training.py` builds a real
+    FSDPEngine for exactly the same reason.
+    """
+
+    @pytest.mark.slow
+    @pytest.mark.gpu
+    def test_fsdp_engine_initialize_patches_the_vision_tower(self):
+        import os
+
+        import areal.models.transformers.vision_dedup as vd
+        from areal.api.alloc_mode import ModelAllocation
+        from areal.api.cli_args import (
+            MicroBatchSpec,
+            OptimizerConfig,
+            TrainEngineConfig,
+        )
+        from areal.api.io_struct import FinetuneSpec
+        from areal.engine import FSDPEngine
+
+        # Resolved inline rather than through tests.utils.get_model_path:
+        # importing areal.utils.testing_utils evaluates DENSE_MODEL_PATHS and
+        # MOE_MODEL_PATHS at module scope, which resolves eight checkpoints --
+        # including three 30B-class MoEs -- so on any machine without the CI
+        # model store the import alone starts fetching them. Only this model is
+        # needed here. The local path is the spelling the repo already uses
+        # (tests/test_packed_vs_padded_consistency.py).
+        local = "/storage/openpsi/models/Qwen2.5-VL-3B-Instruct"
+        model_path = local if os.path.exists(local) else "Qwen/Qwen2.5-VL-3B-Instruct"
+
+        # Clear the guard so this test cannot pass on a patch some earlier test
+        # left behind.
+        for module_path, class_name in vd._VISION_CLASSES:
+            try:
+                cls = getattr(importlib.import_module(module_path), class_name)
+            except (ImportError, AttributeError):
+                continue
+            if hasattr(cls, "_vision_dedup_patched"):
+                del cls._vision_dedup_patched
+
+        os.environ.update(
+            {
+                "WORLD_SIZE": "1",
+                "RANK": "0",
+                "LOCAL_RANK": "0",
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": "7931",
+            }
+        )
+        config = TrainEngineConfig(
+            backend="fsdp:d1",
+            experiment_name="test-vision-dedup",
+            trial_name="test",
+            path=model_path,
+            mb_spec=MicroBatchSpec(max_tokens_per_mb=256),
+            optimizer=OptimizerConfig(),
+            attn_impl="sdpa",
+        )
+        engine = FSDPEngine(config)
+        alloc = ModelAllocation.from_str("fsdp:d1p1t1")
+        ft_spec = FinetuneSpec(total_train_epochs=1, dataset_size=8, train_batch_size=8)
+        engine.create_process_group(alloc.parallel)
+        engine.initialize(addr=None, ft_spec=ft_spec, parallel_strategy=alloc.parallel)
+        try:
+            tower = importlib.import_module(
+                "transformers.models.qwen2_5_vl.modeling_qwen2_5_vl"
+            ).Qwen2_5_VisionTransformerPretrainedModel
+            assert getattr(tower, "_vision_dedup_patched", False) is True
+        finally:
+            engine.destroy()

--- a/tests/test_vision_dedup.py
+++ b/tests/test_vision_dedup.py
@@ -404,3 +404,36 @@ class TestEngineWiring:
             assert getattr(tower, "_vision_dedup_patched", False) is True
         finally:
             engine.destroy()
+
+
+class TestComposesWithVisionSpShardDistributed:
+    """The stacking above runs at ``sp_size=1``, where ``dp_vision_forward`` is a
+    passthrough. This launches a real two-rank sequence-parallel group so the
+    shard/all-gather path actually executes underneath the dedup wrapper.
+
+    gloo/CPU: the composition is about which wrapper sees which tensors and how
+    counts flow through the all-gather, none of which is device-specific.
+    """
+
+    def test_dedup_over_sp_shard_two_ranks_matches_unpatched(self):
+        import os
+        import subprocess
+
+        from areal.utils.network import find_free_ports
+
+        env = dict(os.environ, CUDA_VISIBLE_DEVICES="")
+        result = subprocess.run(
+            [
+                "torchrun",
+                "--nproc_per_node=2",
+                "--nnodes=1",
+                "--master-addr=localhost",
+                f"--master_port={find_free_ports(1)[0]}",
+                "tests/torchrun/run_vision_dedup_sp_shard.py",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if result.returncode != 0:
+            pytest.fail(result.stdout[-3000:] + result.stderr[-3000:])

--- a/tests/torchrun/run_vision_dedup_sp_shard.py
+++ b/tests/torchrun/run_vision_dedup_sp_shard.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Vision dedup stacked on Vision SP Shard, with a real sequence-parallel group.
+
+The two patches both replace ``VisionTransformer.forward``. ``FSDPEngine.initialize``
+applies Vision SP Shard first (inside ``apply_monkey_patch``) and vision dedup after,
+so dedup is the outer wrapper and deduplication happens *before* images are
+distributed across SP ranks. At ``sp_size=1`` ``dp_vision_forward`` is a passthrough,
+so that ordering is only meaningful once a real group exists -- which is what this
+runs.
+
+Deduplication also creates a case the unpatched path cannot reach: when a group of
+G duplicates collapses to fewer distinct images than there are SP ranks, a rank is
+left with no images at all and takes ``dp_vision_forward``'s empty-rank branch.
+
+Runs on gloo/CPU: the composition is about which wrapper sees which tensors and how
+counts flow through the all-gather, none of which is device-specific.
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+
+from areal.models.fsdp.ulysses import set_ulysses_sequence_parallel_group
+from areal.models.transformers.vision_dedup import dedup_vision_forward
+from areal.models.transformers.vision_sp_shard import create_dp_vision_forward
+
+
+class _Tower(torch.nn.Module):
+    """Merges 2x2 patches, like a Qwen2.5-VL vision tower with spatial_merge_size=2."""
+
+    def __init__(self, dim=8, out=6):
+        super().__init__()
+        self.proj = torch.nn.Linear(dim * 4, out)
+        self.spatial_merge_size = 2
+        self.config = type("Cfg", (), {"hidden_size": out, "out_hidden_size": out})()
+        self.rows_seen = 0
+
+    def forward(self, hidden_states, grid_thw=None, **kwargs):
+        self.rows_seen += hidden_states.shape[0]
+        return self.proj(hidden_states.reshape(hidden_states.shape[0] // 4, -1))
+
+
+_ORIGINAL_FORWARD = _Tower.forward
+
+
+def _make(mults, rows=8, dim=8, seed=0):
+    """``mults=[4, 4]`` means two distinct images, each repeated four times."""
+    g = torch.Generator().manual_seed(seed)
+    imgs, order = [], []
+    for gi, mult in enumerate(mults):
+        imgs.append(torch.randn(rows, dim, generator=g))
+        order.extend([gi] * mult)
+    flat = torch.cat([imgs[i] for i in order], dim=0)
+    grid = torch.tensor([[rows // 4, 2, 2]] * len(order))
+    return flat, grid, len(imgs)
+
+
+def _restore():
+    _Tower.forward = _ORIGINAL_FORWARD
+    for attr in ("_vision_sp_shard_patched", "_vision_dedup_patched"):
+        if hasattr(_Tower, attr):
+            delattr(_Tower, attr)
+
+
+def _run_case(mults, label):
+    flat, grid, n_unique = _make(mults)
+    rows_per_image = flat.shape[0] // len(grid)
+
+    # Every rank must hold the same tower weights. Under FSDP the SP ranks are
+    # weight-replicas, and Vision SP Shard relies on that: each rank encodes its
+    # own slice and the results are all-gathered into one sequence. Constructing
+    # the double with default (unseeded) init gave each rank different weights,
+    # so exactly half the gathered rows came from the peer's weights and the
+    # parity assertion failed at 50% -- a defect in the double, not in the code.
+    torch.manual_seed(1234)
+    _restore()
+    plain = _Tower()
+    expected = plain(flat, grid)
+
+    _restore()
+    stacked = _Tower()
+    stacked.load_state_dict(plain.state_dict())
+    # The order FSDPEngine.initialize produces.
+    _Tower.forward = create_dp_vision_forward(_ORIGINAL_FORWARD)
+    _Tower.forward = dedup_vision_forward(_Tower.forward)
+    got = stacked(flat, grid)
+
+    torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
+
+    # Rows this rank actually pushed through the tower, summed over ranks, must be
+    # the deduplicated total -- not the original one.
+    local = torch.tensor([float(stacked.rows_seen)])
+    dist.all_reduce(local)
+    assert local.item() == n_unique * rows_per_image, (
+        f"{label}: tower saw {local.item()} rows across ranks, "
+        f"expected {n_unique * rows_per_image}"
+    )
+    if dist.get_rank() == 0:
+        print(f"  {label}: OK  unique={n_unique} rows_across_ranks={local.item():.0f}")
+
+
+def main():
+    rank = int(os.environ["RANK"])
+    dist.init_process_group(
+        backend="gloo",
+        world_size=int(os.environ["WORLD_SIZE"]),
+        rank=rank,
+    )
+    set_ulysses_sequence_parallel_group(dist.group.WORLD)
+    try:
+        # Two distinct images, one per rank after dedup.
+        _run_case([4, 4], "2 distinct images across 2 SP ranks")
+        # One distinct image: dedup leaves fewer images than ranks, so one rank
+        # takes dp_vision_forward's empty-rank branch. Unreachable without dedup.
+        _run_case([8], "1 distinct image, one SP rank gets none")
+        if rank == 0:
+            print("vision dedup composes with Vision SP Shard at sp_size=2")
+    finally:
+        _restore()
+        set_ulysses_sequence_parallel_group(None)
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

A GRPO group shares one prompt and therefore one image, but every group member carries its own copy of `pixel_values` into the concatenated forward microbatch, so the vision tower encodes the same image once per member.

#1272 and #1291 made those tensors single-owner, removing the duplicated *storage*. The duplicated *computation* remains: `_prepare_multimodal_forward_inputs` concatenates the group's copies and the tower encodes all of them.

### What changed

1. `areal/models/transformers/vision_dedup.py` — wraps `VisionTransformer.forward`, encodes each distinct image once, expands the result back per output field.
2. `areal/engine/fsdp_engine.py` — applies it in `initialize()` after `apply_monkey_patch`, so this wrapper sits **outside** Vision SP Shard's and deduplication happens before images are distributed across SP ranks.
3. Detection is one on-device fingerprint per forward (one host sync, not one per image) that only buckets candidates; every candidate pair is confirmed with an exact `torch.equal`.
4. Falls back to the unmodified path when the input requires grad, when the geometry is unexpected, or when the return type is unrecognised. `AREAL_VISION_DEDUP=0` disables it.

## Related Issue

Not tied to a specific issue. Follows #1272 (FSDPEngine) and #1291 (MegatronEngine), which removed the duplicated storage of the same tensors.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Test Plan

```
pytest tests/test_vision_dedup.py -q
pytest tests/test_vision_sp_shard.py tests/test_fsdp_multimodal_batch.py -q
python3 -m examples.vlm.geometry3k_grpo --config <2-GPU geometry3k config>
```

## Test Result

Qwen2.5-VL-3B-Instruct, geometry3k, 2x A800 80GB PCIe, `sglang:d1` rollout + `fsdp:d1` train, `attn_impl=sdpa`, seed 1, 4 updates per run with the first discarded. Measured at `7cf3a68`, this branch's base. Legs differ only by `AREAL_VISION_DEDUP`; the checkout is byte-identical between them.

### Phase attribution, 8 paired runs

| phase | runs the vision tower | base | this branch | change |
|---|---|---|---|---|
| `train_step` | yes | 483.09 s | 419.36 s | **-13.19%** |
| `recompute_logp` | yes | 99.49 s | 87.29 s | **-12.26%** |
| `update_weights` | no | 6.63 s | 6.57 s | -0.78% |

### Per configuration

| n_samples | max_tokens_per_mb | runs | `train_step` | `recompute_logp` |
|---|---|---|---|---|
| 8 | 4096 | 1 | -6.57% | -8.00% |
| 16 | 4096 | 1 | -9.42% | -12.32% |
| 8 | 8192 | 3 | -11.00% / -14.92% / -16.15% | -7.82% / -11.13% / -13.25% |
| 16 | 8192 | 3 | -13.03% / -14.16% / -18.06% | -10.97% / -15.05% / -15.28% |

Every pair is negative in both phases. The gain tracks `max_tokens_per_mb`, not `n_samples`, because `allocate_balanced_mbs` packs by sequence length and ignores group membership. `max_tokens_per_mb=16384` OOMs on both legs on this card and is not a comparison.

### Peak allocated memory

Unchanged in all 8 pairs: 58.30 GB at `n_samples=8`, 60.60 GB at `n_samples=16`, largest difference 0.01 GB.

### Unit tests

| test | asserts |
|---|---|
| `TestDedupParity` (8 cases) | parity at `rtol=1e-5 atol=1e-6`, including the `ModelOutput` fields at two granularities and the `(embeddings, deepstack)` tuple |
| `TestLoadBearing` (2) | the tower processes fewer rows; fails if the wrapper is a no-op |
| `TestFallbacks` (3) | requires-grad, near-duplicates at 1e-3, single image |
| `test_parameter_gradients_match_undeduped` | parameter gradients unchanged |
| `TestComposesWithVisionSpShard` (2) | stacking with Vision SP Shard preserves output and still deduplicates |
| `test_fsdp_engine_initialize_patches_the_vision_tower` | goes through `FSDPEngine.initialize`, not the wrapper |
| `TestComposesWithVisionSpShardDistributed` | two-rank gloo group: dedup over the real shard/all-gather path, including the empty-rank branch only dedup can reach |

24 tests. Two revert checks: making the wrapper a passthrough turns exactly the two `TestLoadBearing` cases red, and removing the `initialize()` call turns exactly `TestEngineWiring` red. Nothing else moves in either.

### Scope

This changes the FSDP training path. `MegatronEngine` concatenates the same duplicated `pixel_values` in `extract_vision_from_multi_modal` and is not addressed here.

Results are not bit-identical: duplicate outputs come from one matmul instead of N, so summation order differs. The tests assert a tolerance rather than equality.

## Additional Context

No user-facing configuration is added, so no documentation page changed. `AREAL_VISION_DEDUP` is an escape hatch, documented in the module docstring.

`pre-commit run --all-files` passes every hook except `generate-cli-docs`, which fails with `ModuleNotFoundError: No module named 'mdformat'` on unmodified `7cf3a68` as well; this branch does not touch `areal/api/cli_args.py`.
