### PR TITLE
feat: support single-GPU GSM8K smoke runs

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import sys
 import warnings
 from dataclasses import MISSING as dataclass_missing
 from dataclasses import asdict, dataclass, field, fields
@@ -2008,7 +2009,7 @@ class PPOCriticConfig(TrainEngineConfig):
 
 def get_py_cmd(module: str, args: dict[str, Any]):
     # convert to flags
-    cmd = ["python3", "-m", module]
+    cmd = [sys.executable, "-m", module]
     for k, v in args.items():
         if v is None or v is False or v == "" or (isinstance(v, list) and not v):
             continue

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -360,11 +360,9 @@ class PPOTrainer:
             config.rollout, is_eval=False, lora_path=initial_lora_path
         )
 
-        self.eval_rollout = None
-        if not self._online_mode:
-            self.eval_rollout = self._init_rollout(
-                config.rollout, is_eval=True, lora_path=initial_lora_path
-            )
+        self.eval_rollout = self._maybe_init_eval_rollout(
+            config.rollout, lora_path=initial_lora_path
+        )
         if (
             self.config.teacher is not None
             and self.config.teacher.engine_type == "rollout"
@@ -1291,6 +1289,20 @@ class PPOTrainer:
             init_kwargs["role"] = "eval-rollout"
         controller.initialize(**init_kwargs)
         return controller
+
+    def _maybe_init_eval_rollout(
+        self,
+        rollout_config: InferenceEngineConfig,
+        lora_path: str | None = None,
+    ) -> InferenceEngine | RolloutController | None:
+        """Initialize an eval engine only when validation can actually run."""
+        if self._online_mode or self.valid_dataloader is None:
+            return None
+        return self._init_rollout(
+            rollout_config,
+            is_eval=True,
+            lora_path=lora_path,
+        )
 
     def _init_teacher_rollout(
         self, rollout_config: InferenceEngineConfig

--- a/areal/workflow/openai/math_agent.py
+++ b/areal/workflow/openai/math_agent.py
@@ -25,7 +25,7 @@ def math_reward_fn(completions: str, answer: str) -> float:
 
 
 class MathAgent:
-    def __init__(self, **kwargs):
+    def __init__(self, reward_max_workers: int | None = None, **kwargs):
         self.kwargs = kwargs.copy()
         max_new_tokens = self.kwargs.pop("max_new_tokens", None)
         self.kwargs.pop("max_turns", None)
@@ -33,7 +33,10 @@ class MathAgent:
             self.kwargs["max_tokens"] = max_new_tokens
         else:
             self.kwargs.pop("max_tokens", None)
-        self._reward_fn = AsyncRewardWrapper(math_reward_fn)
+        self._reward_fn = AsyncRewardWrapper(
+            math_reward_fn,
+            max_workers=reward_max_workers,
+        )
 
     async def run(self, data: dict, **extra_kwargs):
         http_client = extra_kwargs.get("http_client", None)

--- a/docs/en/tutorial/quickstart.md
+++ b/docs/en/tutorial/quickstart.md
@@ -15,8 +15,8 @@ To run the experiment, you will need:
   [examples/math/gsm8k_grpo.yaml](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
 
 Our training scripts will automatically download the dataset (openai/gsm8k) and model
-(Qwen/Qwen2-1.5B-Instruct). To run the example with default configuration, execute from
-the repository directory:
+(Qwen/Qwen2.5-1.5B-Instruct). To run the example with default configuration, execute
+from the repository directory:
 
 ```
 python3 examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml scheduler.type=local experiment_name=<your experiment name> trial_name=<your trial name>
@@ -24,6 +24,72 @@ python3 examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml schedul
 
 > **Note**: For distributed experiments across multiple nodes, see
 > [Distributed Experiments with Ray or Slurm](#distributed-experiments-with-ray-or-slurm).
+
+### Single-GPU smoke run
+
+AReaL can run one-rank SGLang rollout and one-rank FSDP training on the same GPU. The
+command below uses Qwen3-0.6B and stops after two training steps, making it suitable for
+validating a 32 GB workstation before starting a longer experiment. It is a smoke-test
+configuration, not a throughput-optimized training recipe.
+
+```bash
+python3 examples/math/gsm8k_rl.py \
+    --config examples/math/gsm8k_grpo.yaml \
+    scheduler.type=local \
+    experiment_name=gsm8k-grpo-single-gpu \
+    trial_name=smoke \
+    actor.path=Qwen/Qwen3-0.6B \
+    actor.backend=fsdp:d1 \
+    +actor.attn_impl=sdpa \
+    rollout.backend=sglang:d1 \
+    +rollout.setup_timeout=900 \
+    actor.weight_update_mode=disk \
+    enable_offload=false \
+    +total_train_steps=2 \
+    rollout.max_concurrent_rollouts=2 \
+    +reward_max_workers=1 \
+    gconfig.n_samples=2 \
+    gconfig.max_new_tokens=64 \
+    gconfig.max_tokens=512 \
+    actor.mb_spec.max_tokens_per_mb=512 \
+    actor.optimizer.type=adam_bf16 \
+    +actor.optimizer_dtype=bfloat16 \
+    train_dataset.batch_size=2 \
+    train_dataset.num_workers=0 \
+    train_dataset.pin_memory=false \
+    +train_dataset.scheduling_spec=null \
+    valid_dataset=null \
+    sglang.context_length=1024 \
+    sglang.mem_fraction_static=0.2 \
+    +sglang.max_prefill_tokens=1024 \
+    +sglang.attention_backend=torch_native \
+    +sglang.sampling_backend=pytorch \
+    cluster.n_nodes=1 \
+    cluster.n_gpus_per_node=1
+```
+
+The important settings are:
+
+- `actor.backend=fsdp:d1` and `rollout.backend=sglang:d1` start one rank of each service
+  on the only configured GPU.
+- `valid_dataset=null` skips the separate evaluation rollout in this training smoke
+  test.
+- `reward_max_workers=1` limits reward computation to one worker process, reducing host
+  memory use on a workstation.
+- `actor.weight_update_mode=disk` transfers updated weights without creating a same-GPU
+  NCCL group.
+- The BF16 optimizer and reduced batch, sequence, and SGLang memory settings keep the
+  smoke run within a 32 GB GPU budget.
+- `rollout.setup_timeout=900` leaves enough time for a cold SGLang startup on a new
+  machine.
+- The PyTorch attention and sampling backends favor compatibility over throughput for
+  the smoke run.
+- `sglang.mem_fraction_static` and `actor.mb_spec.max_tokens_per_mb` are the first
+  settings to reduce if the run is close to the GPU memory limit.
+
+Increase `total_train_steps`, sequence lengths, batch size, and model size only after
+this smoke run succeeds. See {doc}`../best_practices/handling_oom` for additional memory
+tuning guidance.
 
 ## Modifying configuration
 

--- a/docs/zh/tutorial/quickstart.md
+++ b/docs/zh/tutorial/quickstart.md
@@ -12,13 +12,69 @@ GSM8K。在继续之前，请确保已完成[安装和环境设置](installation
 - 配置文件 YAML：
   [examples/math/gsm8k_grpo.yaml](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
 
-我们的训练脚本会自动下载数据集（openai/gsm8k）和模型（Qwen/Qwen2-1.5B-Instruct）。要使用默认配置运行示例，请从仓库目录执行：
+我们的训练脚本会自动下载数据集（openai/gsm8k）和模型（Qwen/Qwen2.5-1.5B-Instruct）。要使用默认配置运行示例，请从仓库目录执行：
 
 ```
 python3 examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml scheduler.type=local experiment_name=<您的实验名称> trial_name=<您的试验名称>
 ```
 
 > **注意**：如需在多节点上运行分布式实验，请参阅[使用 Ray 或 Slurm 的分布式实验](#distributed-experiments-with-ray-or-slurm)。
+
+### 单 GPU 快速验证
+
+AReaL 可以在同一张 GPU 上运行单 rank 的 SGLang rollout 和单 rank 的 FSDP 训练。下面的命令使用 Qwen3-0.6B，并在两个训练
+step 后停止，适合在 32 GB 显存的工作站上验证环境。这是快速验证配置，不是针对吞吐量优化的训练配置。
+
+```bash
+python3 examples/math/gsm8k_rl.py \
+    --config examples/math/gsm8k_grpo.yaml \
+    scheduler.type=local \
+    experiment_name=gsm8k-grpo-single-gpu \
+    trial_name=smoke \
+    actor.path=Qwen/Qwen3-0.6B \
+    actor.backend=fsdp:d1 \
+    +actor.attn_impl=sdpa \
+    rollout.backend=sglang:d1 \
+    +rollout.setup_timeout=900 \
+    actor.weight_update_mode=disk \
+    enable_offload=false \
+    +total_train_steps=2 \
+    rollout.max_concurrent_rollouts=2 \
+    +reward_max_workers=1 \
+    gconfig.n_samples=2 \
+    gconfig.max_new_tokens=64 \
+    gconfig.max_tokens=512 \
+    actor.mb_spec.max_tokens_per_mb=512 \
+    actor.optimizer.type=adam_bf16 \
+    +actor.optimizer_dtype=bfloat16 \
+    train_dataset.batch_size=2 \
+    train_dataset.num_workers=0 \
+    train_dataset.pin_memory=false \
+    +train_dataset.scheduling_spec=null \
+    valid_dataset=null \
+    sglang.context_length=1024 \
+    sglang.mem_fraction_static=0.2 \
+    +sglang.max_prefill_tokens=1024 \
+    +sglang.attention_backend=torch_native \
+    +sglang.sampling_backend=pytorch \
+    cluster.n_nodes=1 \
+    cluster.n_gpus_per_node=1
+```
+
+关键配置如下：
+
+- `actor.backend=fsdp:d1` 和 `rollout.backend=sglang:d1` 会在唯一配置的 GPU 上分别启动单 rank
+  的训练与推理服务。
+- `valid_dataset=null` 在这次训练快速验证中跳过独立的评估 rollout。
+- `reward_max_workers=1` 将奖励计算限制为一个工作进程，降低工作站的系统内存占用。
+- `actor.weight_update_mode=disk` 通过磁盘传递更新后的权重，避免在同一张 GPU 上建立 NCCL 通信组。
+- BF16 优化器以及较小的 batch、序列长度和 SGLang 内存配置可使快速验证控制在 32 GB 显存以内。
+- `rollout.setup_timeout=900` 为新机器上 SGLang 的冷启动预留了足够时间。
+- PyTorch attention 和 sampling 后端优先保证快速验证的兼容性，而非吞吐量。
+- 当运行接近显存上限时，优先降低 `sglang.mem_fraction_static` 和 `actor.mb_spec.max_tokens_per_mb`。
+
+该快速验证成功后，再增加 `total_train_steps`、序列长度、batch size 和模型规模。更多显存调优方法请参阅
+{doc}`../best_practices/handling_oom`。
 
 ## 修改配置
 

--- a/examples/math/gsm8k_config.py
+++ b/examples/math/gsm8k_config.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field
+
+from areal.api.cli_args import GRPOConfig
+
+
+@dataclass
+class GSM8KGRPOConfig(GRPOConfig):
+    reward_max_workers: int | None = field(
+        default=None,
+        metadata={"help": "Maximum worker processes used to compute math rewards."},
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.reward_max_workers is not None and self.reward_max_workers <= 0:
+            raise ValueError(
+                "reward_max_workers must be positive when set, got "
+                f"{self.reward_max_workers}"
+            )

--- a/examples/math/gsm8k_rl.py
+++ b/examples/math/gsm8k_rl.py
@@ -1,13 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 
+from examples.math.gsm8k_config import GSM8KGRPOConfig
+
 from areal import PPOTrainer
-from areal.api.cli_args import GRPOConfig, load_expr_config
+from areal.api.cli_args import load_expr_config
 from areal.dataset import get_custom_dataset
 from areal.utils.hf_utils import load_hf_tokenizer
 
 
 def main(args):
-    config, _ = load_expr_config(args, GRPOConfig)
+    config, _ = load_expr_config(args, GSM8KGRPOConfig)
     tokenizer = load_hf_tokenizer(config.tokenizer_path)
 
     train_dataset = get_custom_dataset(
@@ -15,17 +19,20 @@ def main(args):
         dataset_config=config.train_dataset,
         tokenizer=tokenizer,
     )
-    valid_dataset = get_custom_dataset(
-        split="test",
-        dataset_config=config.valid_dataset,
-        tokenizer=tokenizer,
-    )
+    valid_dataset = None
+    if config.valid_dataset is not None:
+        valid_dataset = get_custom_dataset(
+            split="test",
+            dataset_config=config.valid_dataset,
+            tokenizer=tokenizer,
+        )
 
     workflow_kwargs = dict(
         temperature=config.gconfig.temperature,
         top_p=config.gconfig.top_p,
         max_tokens=config.gconfig.max_tokens,
         max_completion_tokens=config.gconfig.max_new_tokens,
+        reward_max_workers=config.reward_max_workers,
     )
     eval_workflow_kwargs = workflow_kwargs.copy()
     eval_workflow_kwargs["temperature"] = 0.6

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from areal.api.cli_args import get_py_cmd
+
+
+def test_get_py_cmd_uses_current_python_interpreter():
+    cmd = get_py_cmd("example.module", {"flag": "value"})
+
+    assert cmd == [sys.executable, "-m", "example.module", "--flag", "value"]

--- a/tests/test_math_agent.py
+++ b/tests/test_math_agent.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+
+from examples.math.gsm8k_config import GSM8KGRPOConfig
+
+from areal.workflow.openai import math_agent
+
+
+def test_math_agent_configures_reward_worker_count(monkeypatch):
+    """The reward pool size is configurable and is not sent to OpenAI."""
+    reward_wrapper = Mock()
+    monkeypatch.setattr(math_agent, "AsyncRewardWrapper", reward_wrapper)
+
+    agent = math_agent.MathAgent(reward_max_workers=1, temperature=0.8)
+
+    reward_wrapper.assert_called_once_with(
+        math_agent.math_reward_fn,
+        max_workers=1,
+    )
+    assert agent.kwargs == {"temperature": 0.8}
+
+
+def test_gsm8k_config_rejects_nonpositive_reward_worker_count():
+    """GSM8K rejects invalid reward worker limits during config loading."""
+    with pytest.raises(ValueError, match="reward_max_workers must be positive"):
+        GSM8KGRPOConfig(reward_max_workers=0)

--- a/tests/test_optional_eval_rollout.py
+++ b/tests/test_optional_eval_rollout.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+
+from areal.trainer.rl_trainer import PPOTrainer
+
+
+@pytest.mark.parametrize(
+    "online_mode,has_valid_dataloader,expected_initialized",
+    [
+        (False, True, True),
+        (False, False, False),
+        (True, False, False),
+    ],
+)
+def test_eval_rollout_is_initialized_only_when_validation_can_run(
+    online_mode, has_valid_dataloader, expected_initialized
+):
+    trainer = object.__new__(PPOTrainer)
+    trainer._online_mode = online_mode
+    trainer.valid_dataloader = object() if has_valid_dataloader else None
+    eval_rollout = object()
+    trainer._init_rollout = Mock(return_value=eval_rollout)
+    rollout_config = object()
+
+    result = trainer._maybe_init_eval_rollout(rollout_config, lora_path="adapter")
+
+    if expected_initialized:
+        assert result is eval_rollout
+        trainer._init_rollout.assert_called_once_with(
+            rollout_config,
+            is_eval=True,
+            lora_path="adapter",
+        )
+    else:
+        assert result is None
+        trainer._init_rollout.assert_not_called()


### PR DESCRIPTION
## Description

This PR makes the GSM8K GRPO quickstart runnable as a two-step smoke test on a
single 32 GB GPU with one FSDP rank and one SGLang rank.

The single-GPU path uses disk-based weight synchronization so the separated
training and rollout processes do not create a same-GPU NCCL group. It also:

- avoids starting an unused evaluation rollout when `valid_dataset=null`;
- adds `reward_max_workers` so workstation runs can bound the math reward
  process pool;
- launches local Python modules with the active interpreter, preserving the
  selected virtual environment; and
- documents the validated command in both the English and Chinese quickstarts.

This is a compatibility-oriented smoke configuration for validating an
environment before longer experiments. It is not intended as a
throughput-optimized training recipe.

## Related Issue

Fixes #310

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Validation

The documented command was run from `main@6feff6df` plus this commit on an
NVIDIA GeForce RTX 5090 (32 GB) with Qwen3-0.6B. Both training steps completed,
the process exited with status 0, and no training or GPU process remained after
teardown. Peak observed device usage was 21.83 / 31.36 GiB.

```bash
python3 examples/math/gsm8k_rl.py \
    --config examples/math/gsm8k_grpo.yaml \
    scheduler.type=local \
    experiment_name=gsm8k-grpo-single-gpu \
    trial_name=smoke \
    actor.path=Qwen/Qwen3-0.6B \
    actor.backend=fsdp:d1 \
    +actor.attn_impl=sdpa \
    rollout.backend=sglang:d1 \
    +rollout.setup_timeout=900 \
    actor.weight_update_mode=disk \
    enable_offload=false \
    +total_train_steps=2 \
    rollout.max_concurrent_rollouts=2 \
    +reward_max_workers=1 \
    gconfig.n_samples=2 \
    gconfig.max_new_tokens=64 \
    gconfig.max_tokens=512 \
    actor.mb_spec.max_tokens_per_mb=512 \
    actor.optimizer.type=adam_bf16 \
    +actor.optimizer_dtype=bfloat16 \
    train_dataset.batch_size=2 \
    train_dataset.num_workers=0 \
    train_dataset.pin_memory=false \
    +train_dataset.scheduling_spec=null \
    valid_dataset=null \
    sglang.context_length=1024 \
    sglang.mem_fraction_static=0.2 \
    +sglang.max_prefill_tokens=1024 \
    +sglang.attention_backend=torch_native \
    +sglang.sampling_backend=pytorch \
    cluster.n_nodes=1 \
    cluster.n_gpus_per_node=1
```

Local checks:

- `32 passed` for the focused unit and regression test set;
- Ruff lint and format checks pass for all changed Python files;
- mdformat passes for both changed quickstart documents;
- SPDX license-header checks pass;
- generated CLI reference files remain unchanged; and
- `git diff --check` passes.

`pre-commit run --all-files` was attempted, but hook initialization could not
finish because the host timed out while fetching the clang-format mirror from
GitHub. The full documentation build was also attempted but could not start
because `uv` is not installed on the test host. These two checklist items are
left unchecked below.

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None.

## Additional Context

The PyTorch attention and sampling backends favor compatibility on workstation
GPUs. Users can tune the SGLang backends and increase batch size, sequence
length, model size, or training steps after the smoke run succeeds.

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
