### PR TITLE
fix(dataset): align VLM SFT loss masks with responses

### DIFF
--- a/areal/dataset/clevr_count_70k.py
+++ b/areal/dataset/clevr_count_70k.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 from datasets import load_dataset
 from PIL.Image import Image as ImageObject
 
+from areal.dataset.tokenization import get_multimodal_sft_loss_mask
 from areal.utils import logging
 
 logger = logging.getLogger("CLEVR70KDataset")
@@ -113,11 +114,12 @@ def get_clevr_count_70k_sft_dataset(
             if "image_grid_thw" in processed_input:
                 multi_modal_input["image_grid_thw"] = processed_input["image_grid_thw"]
             example["multi_modal_input"] = [multi_modal_input]
-            answer_token = tokenizer.encode(example["answer"])
-            loss_mask = [0] * (len(example["input_ids"]) - len(answer_token)) + [
-                1
-            ] * len(answer_token)
-            example["loss_mask"] = loss_mask
+            example["loss_mask"] = get_multimodal_sft_loss_mask(
+                input_ids=example["input_ids"],
+                prompt=example["problem"],
+                sequence=example["seq"],
+                tokenizer=tokenizer,
+            )
             return example
 
         dataset = dataset.map(

--- a/areal/dataset/geometry3k.py
+++ b/areal/dataset/geometry3k.py
@@ -8,6 +8,8 @@ from PIL import Image
 from PIL.Image import Image as ImageObject
 from torchvision import transforms
 
+from areal.dataset.tokenization import get_multimodal_sft_loss_mask
+
 
 def pad_to_square(img: Image.Image, fill=(0, 0, 0)) -> Image.Image:
     w, h = img.size
@@ -104,11 +106,12 @@ def get_geometry3k_sft_dataset(
                 "image_grid_thw"
             ].squeeze(0)
         example["multi_modal_input"] = [multi_modal_input]
-        answer_token = tokenizer.encode(example["answer"])
-        loss_mask = [0] * (len(example["input_ids"]) - len(answer_token)) + [1] * len(
-            answer_token
+        example["loss_mask"] = get_multimodal_sft_loss_mask(
+            input_ids=example["input_ids"],
+            prompt=example["problem"],
+            sequence=example["seq"],
+            tokenizer=tokenizer,
         )
-        example["loss_mask"] = loss_mask
         return example
 
     dataset = dataset.map(

--- a/areal/dataset/tokenization.py
+++ b/areal/dataset/tokenization.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+def _common_prefix_length(left: list[int], right: list[int]) -> int:
+    for index, (left_id, right_id) in enumerate(zip(left, right)):
+        if left_id != right_id:
+            return index
+    return min(len(left), len(right))
+
+
+def get_multimodal_sft_loss_mask(
+    input_ids,
+    prompt: str,
+    sequence: str,
+    tokenizer,
+) -> list[int]:
+    """Build an SFT mask when a processor may expand prompt-side image tokens."""
+    prompt_token = tokenizer.encode(prompt)
+    sequence_token = tokenizer.encode(sequence)
+    prompt_length = _common_prefix_length(prompt_token, sequence_token)
+
+    # Multimodal processors may expand an image placeholder into several tokens.
+    # Geometry3K and CLEVR keep every image in the prompt, so the resulting length
+    # difference belongs entirely to the masked prompt prefix.
+    prompt_length += len(input_ids) - len(sequence_token)
+    if not 0 <= prompt_length <= len(input_ids):
+        raise ValueError(
+            "Cannot align the tokenized prompt with the processed input sequence"
+        )
+
+    return [0] * prompt_length + [1] * (len(input_ids) - prompt_length)

--- a/tests/test_vlm_sft_dataset.py
+++ b/tests/test_vlm_sft_dataset.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from datasets import Dataset
+from PIL import Image
+
+from areal.dataset import clevr_count_70k, geometry3k
+
+
+class _FakeTokenizer:
+    eos_token = "<eos>"
+
+    def __init__(self, add_bos_by_default):
+        self._add_bos_by_default = add_bos_by_default
+
+    def encode(self, text, add_special_tokens=True):
+        if text == "answer":
+            token_ids = [20, 21]
+        elif text == "wxyz":
+            token_ids = [30, 21, 22, 23]
+        elif text.endswith("proo"):
+            token_ids = [10, 11, 12, 13]
+        elif text.endswith("proowxyz<eos>"):
+            token_ids = [10, 11, 12, 50, 21, 22, 23, 99]
+        elif text.endswith("question"):
+            token_ids = [10, 11]
+        elif text.endswith("questionanswer<eos>"):
+            token_ids = [10, 11, 20, 21, 99]
+        else:
+            raise ValueError(f"Unexpected text: {text}")
+        if add_special_tokens and self._add_bos_by_default:
+            return [1, *token_ids]
+        return token_ids
+
+
+class _FakeProcessor:
+    def __init__(self, add_bos_by_default):
+        self.tokenizer = _FakeTokenizer(add_bos_by_default)
+        self.image_processor = SimpleNamespace(image_processor_type="qwen")
+
+    def __call__(self, **kwargs):
+        input_ids = self.tokenizer.encode(kwargs["text"][0])
+        image_offset = 2 if self.tokenizer._add_bos_by_default else 1
+        input_ids[image_offset:image_offset] = [70, 71]
+        return {
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.zeros(1),
+        }
+
+
+@pytest.mark.parametrize(
+    ("module", "loader"),
+    [
+        (geometry3k, geometry3k.get_geometry3k_sft_dataset),
+        (clevr_count_70k, clevr_count_70k.get_clevr_count_70k_sft_dataset),
+    ],
+)
+@pytest.mark.parametrize("add_bos_by_default", [False, True])
+@pytest.mark.parametrize(
+    ("problem", "answer", "expected_token_ids"),
+    [
+        ("<image>question", "answer", [20, 21, 99]),
+        ("<image>proo", "wxyz", [50, 21, 22, 23, 99]),
+    ],
+)
+def test_vlm_sft_loss_mask_includes_full_answer_and_eos(
+    monkeypatch,
+    module,
+    loader,
+    add_bos_by_default,
+    problem,
+    answer,
+    expected_token_ids,
+):
+    """The SFT target includes the answer, EOS, and any boundary-merged token."""
+    dataset = Dataset.from_list(
+        [
+            {
+                "images": [Image.new("RGB", (4, 4))],
+                "problem": problem,
+                "answer": answer,
+            }
+        ]
+    )
+    monkeypatch.setattr(module, "load_dataset", lambda **kwargs: dataset)
+    monkeypatch.setattr(module, "convert_image", lambda image, *args: image)
+    if module is clevr_count_70k:
+        monkeypatch.setattr(module.os, "cpu_count", lambda: 1)
+
+    sample = loader(
+        path="unused",
+        split="train",
+        processor=_FakeProcessor(add_bos_by_default),
+    )[0]
+
+    input_ids = sample["input_ids"]
+    trained_token_ids = [
+        token_id
+        for token_id, include_in_loss in zip(input_ids, sample["loss_mask"])
+        if include_in_loss
+    ]
+    assert trained_token_ids == expected_token_ids


### PR DESCRIPTION
## Description

Geometry3K and CLEVR Count 70K build `problem + answer + EOS`, but derive
the SFT loss-mask tail from `tokenizer.encode(answer)`. With tokenizers that do
not inject a BOS token, this masks the first response token and supervises EOS in
its place. It also misses tokens merged across the prompt/response boundary.

This change derives the supervised boundary from the common token prefix of the
raw prompt and full sequence, then adjusts it for prompt-side image-token
expansion performed by the multimodal processor. The resulting mask supervises:

- every response token;
- the terminal EOS token;
- any token spanning the prompt/response boundary.

Both VLM dataset loaders use the shared alignment helper.

## Related Issue

Related to #1427, which identifies the same prompt/response token-boundary issue
for GSM8K and lists these VLM loaders as follow-up scope.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable; no public interface or configuration change)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Test Plan

```bash
PYTHONPATH=. python -m pytest \
  tests/test_vlm_sft_dataset.py \
  tests/test_geometry3k_agent.py \
  tests/test_clevr_reward.py -q
pre-commit run --all-files
```

Run a Qwen2.5-VL-7B forward smoke test on an RTX 5090 using labels produced by
the corrected dataset mask.

## Test Result

- 14 related tests passed.
- All pre-commit hooks passed.
- Qwen2.5-VL-7B supervised token IDs were `[220, 17, 151645]`, decoding to
  ` 2<|im_end|>`; the leading response token and terminal token were both kept.
- The RTX 5090 forward pass produced a finite loss (`6.136836528778076`) with
  `15851.3 MiB` peak allocated memory.

## Additional Context

No documentation update is required because this corrects internal label
construction without changing a public API or configuration.

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
