### PR TITLE
feat(workflow): support turn-level rewards and raw reward preservation in MultiTurnWorkflow

### DIFF
--- a/areal/infra/workflow_executor.py
+++ b/areal/infra/workflow_executor.py
@@ -197,7 +197,11 @@ def check_trajectory_format(
                     f"The first dim of tensor `{key}` is {value.shape[0]}, "
                     f"rather than the batch size of input_ids ({inferred_batch_size})."
                 )
-            if value.ndim >= 2 and value.shape[1] != max_seqlen:
+            if (
+                key != "turn_rewards"
+                and value.ndim >= 2
+                and value.shape[1] != max_seqlen
+            ):
                 logger.warning(
                     f"The second dim of tensor `{key}` is {value.shape[1]}, "
                     f"rather than the max seqlen of input_ids ({max_seqlen})."

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -471,7 +471,15 @@ class PPOActor:
 
         # Pop keys that are no longer needed after advantage computation
         # Note: "versions" is kept if needed for approximation/metrics in loss function
-        for key in ["rewards", "tot_rewards", "kl_rewards", "is_truncated"]:
+        for key in [
+            "rewards",
+            "original_rewards",
+            "turn_rewards",
+            "step_rewards",
+            "tot_rewards",
+            "kl_rewards",
+            "is_truncated",
+        ]:
             data.pop(key, None)
         # Megatron keeps the full batch on CPU and streams only the current
         # microbatch to the accelerator. Stage before the outer PPO split so

--- a/areal/trainer/ppo/critic.py
+++ b/areal/trainer/ppo/critic.py
@@ -57,6 +57,9 @@ class PPOCritic:
 
         for key in [
             "rewards",
+            "original_rewards",
+            "turn_rewards",
+            "step_rewards",
             "tot_rewards",
             "kl_rewards",
             "versions",

--- a/areal/workflow/multi_turn.py
+++ b/areal/workflow/multi_turn.py
@@ -16,6 +16,12 @@ from areal.utils.hf_utils import apply_chat_template
 logger = logging.getLogger("MultiTurnWorkflow")
 
 
+DEFAULT_MULTI_TURN_RETRY_PROMPT = (
+    "Your answer is either wrong or not parsable to the reward function. You may misunderstand the original question. "
+    "Please carefully read the original question, check the previous errors, and try to answer it again."
+)
+
+
 class MultiTurnWorkflow(RolloutWorkflow):
     """Multi-attempt workflow that retries generation until the reward is positive."""
 
@@ -26,6 +32,7 @@ class MultiTurnWorkflow(RolloutWorkflow):
         tokenizer: PreTrainedTokenizerFast,
         max_turns: int,
         turn_discount: float,
+        retry_prompt: str | None = None,
     ):
         if max_turns <= 0:
             raise ValueError("max_turns must be positive")
@@ -37,6 +44,7 @@ class MultiTurnWorkflow(RolloutWorkflow):
         self.tokenizer = tokenizer
         self.max_turns = max_turns
         self.turn_discount = turn_discount
+        self.retry_prompt = retry_prompt or DEFAULT_MULTI_TURN_RETRY_PROMPT
         self.async_reward_fn = AsyncRewardWrapper(reward_fn)
 
         # Create tokens that should be amended if the answer is incorrect.
@@ -46,8 +54,7 @@ class MultiTurnWorkflow(RolloutWorkflow):
         messages += [
             {
                 "role": "user",
-                "content": "Your answer is either wrong or not parsable to the reward function. You may misunderstand the original question. "
-                "Please carefully read the original question, check the previous errors, and try to answer it again.",
+                "content": self.retry_prompt,
             }
         ]
         s2 = apply_chat_template(
@@ -70,7 +77,9 @@ class MultiTurnWorkflow(RolloutWorkflow):
         # Run multi-turn rollout until correct
         t = 0
         reward = 0.0
+        raw_reward = 0.0
         discount = 1.0
+        turn_rewards_list: list[float] = []
         prompt_str = ""
         completions_str = ""
         is_truncated = False
@@ -96,6 +105,8 @@ class MultiTurnWorkflow(RolloutWorkflow):
                 resp.output_tokens,
                 **data,
             )
+            raw_reward = float(reward)
+            turn_rewards_list.append(float(raw_reward * discount))
             # Amend results
             input_len = len(resp.input_tokens) - len(seq)
             assert len(seq) == 0 or resp.input_tokens[:-input_len] == seq, (
@@ -122,12 +133,16 @@ class MultiTurnWorkflow(RolloutWorkflow):
                 input_ids += self.multi_turn_prompt_ids
                 discount *= self.turn_discount
 
-        reward = float(reward * discount)
+        discounted_reward = float(raw_reward * discount)
 
         # Log reward.
         stats_tracker.get(workflow_context.stat_scope()).scalar(
-            reward=reward, num_turns=t
+            reward=discounted_reward, num_turns=t
         )
+
+        step_rewards = [0.0] * len(seq)
+        if len(step_rewards) > 0 and discounted_reward != 0.0:
+            step_rewards[-1] = discounted_reward
 
         res = dict(
             input_ids=torch.tensor(seq, dtype=torch.int32),
@@ -135,7 +150,10 @@ class MultiTurnWorkflow(RolloutWorkflow):
             loss_mask=torch.tensor(loss_mask, dtype=torch.int32),
             versions=torch.tensor(versions, dtype=torch.int32),
             turn_ids=torch.tensor(turn_ids, dtype=torch.int32),
-            rewards=torch.tensor(reward, dtype=torch.float32),
+            rewards=torch.tensor(discounted_reward, dtype=torch.float32),
+            original_rewards=torch.tensor(raw_reward, dtype=torch.float32),
+            turn_rewards=torch.tensor(turn_rewards_list, dtype=torch.float32),
+            step_rewards=torch.tensor(step_rewards, dtype=torch.float32),
             attention_mask=torch.ones(len(seq), dtype=torch.bool),
             is_truncated=torch.tensor(is_truncated, dtype=torch.bool),
         )

--- a/tests/test_multiturn_workflow.py
+++ b/tests/test_multiturn_workflow.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import torch
+
+from areal.api import ModelResponse
+from areal.api.cli_args import GenerationHyperparameters, PPOCriticConfig
+from areal.infra.workflow_executor import check_trajectory_format
+from areal.trainer.ppo.critic import PPOCritic
+from areal.workflow.multi_turn import (
+    DEFAULT_MULTI_TURN_RETRY_PROMPT,
+    MultiTurnWorkflow,
+)
+
+
+def _make_dummy_tokenizer():
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "decoded"
+    tokenizer.eos_token_id = 0
+    return tokenizer
+
+
+@pytest.mark.asyncio
+async def test_multiturn_workflow_single_turn_rewards():
+    tokenizer = _make_dummy_tokenizer()
+    workflow = object.__new__(MultiTurnWorkflow)
+    workflow.tokenizer = tokenizer
+    workflow.gconfig = GenerationHyperparameters(max_new_tokens=4)
+    workflow.max_turns = 3
+    workflow.turn_discount = 0.9
+    workflow.multi_turn_prompt_ids = [99]
+    workflow.async_reward_fn = AsyncMock(return_value=1.0)
+
+    engine = MagicMock()
+    engine.agenerate = AsyncMock(
+        return_value=ModelResponse(
+            input_tokens=[1, 2],
+            output_tokens=[3, 4],
+            output_logprobs=[0.0, 0.0],
+            output_versions=[0, 0],
+            stop_reason="stop",
+        )
+    )
+
+    with (
+        patch("areal.workflow.multi_turn.apply_chat_template", return_value=[1, 2]),
+        patch("areal.workflow.multi_turn.stats_tracker"),
+        patch("areal.workflow.multi_turn.workflow_context"),
+    ):
+        data = {"messages": [{"role": "user", "content": "hi"}]}
+        traj = await workflow.arun_episode(engine, data)
+
+    # 1 turn executed
+    assert engine.agenerate.await_count == 1
+    assert traj["rewards"].shape == (1,)
+    assert traj["rewards"].item() == 1.0
+    assert traj["original_rewards"].shape == (1,)
+    assert traj["original_rewards"].item() == 1.0
+
+    # turn_rewards has 1 element
+    assert traj["turn_rewards"].shape == (1, 1)
+    torch.testing.assert_close(traj["turn_rewards"], torch.tensor([[1.0]]))
+
+    # step_rewards has seq length (4 tokens: 2 prompt + 2 output)
+    assert traj["step_rewards"].shape == (1, 4)
+    expected_step_rewards = torch.tensor([[0.0, 0.0, 0.0, 1.0]])
+    torch.testing.assert_close(traj["step_rewards"], expected_step_rewards)
+
+
+@pytest.mark.asyncio
+async def test_multiturn_workflow_multi_turn_reward_attribution():
+    tokenizer = _make_dummy_tokenizer()
+    workflow = object.__new__(MultiTurnWorkflow)
+    workflow.tokenizer = tokenizer
+    workflow.gconfig = GenerationHyperparameters(max_new_tokens=4)
+    workflow.max_turns = 3
+    workflow.turn_discount = 0.8
+    workflow.multi_turn_prompt_ids = [99]
+    # Turn 0 fails (0.0), Turn 1 succeeds (1.0)
+    workflow.async_reward_fn = AsyncMock(side_effect=[0.0, 1.0])
+
+    engine = MagicMock()
+    engine.agenerate = AsyncMock(
+        side_effect=[
+            ModelResponse(
+                input_tokens=[1, 2],
+                output_tokens=[3],
+                output_logprobs=[0.0],
+                output_versions=[0],
+                stop_reason="stop",
+            ),
+            ModelResponse(
+                input_tokens=[1, 2, 3, 0, 99],
+                output_tokens=[4, 5],
+                output_logprobs=[0.0, 0.0],
+                output_versions=[0, 0],
+                stop_reason="stop",
+            ),
+        ]
+    )
+
+    with (
+        patch("areal.workflow.multi_turn.apply_chat_template", return_value=[1, 2]),
+        patch("areal.workflow.multi_turn.stats_tracker"),
+        patch("areal.workflow.multi_turn.workflow_context"),
+    ):
+        data = {"messages": [{"role": "user", "content": "hi"}]}
+        traj = await workflow.arun_episode(engine, data)
+
+    # 2 turns executed
+    assert engine.agenerate.await_count == 2
+    # Discounted reward: 1.0 * 0.8 = 0.8
+    assert pytest.approx(traj["rewards"].item()) == 0.8
+    # Original raw reward: 1.0
+    assert pytest.approx(traj["original_rewards"].item()) == 1.0
+
+    # turn_rewards has 2 entries: [0.0, 0.8]
+    assert traj["turn_rewards"].shape == (1, 2)
+    torch.testing.assert_close(traj["turn_rewards"], torch.tensor([[0.0, 0.8]]))
+
+    # step_rewards has reward attributed to the final action token
+    assert traj["step_rewards"].shape[0] == 1
+    assert pytest.approx(traj["step_rewards"][0, -1].item()) == 0.8
+    assert pytest.approx(traj["step_rewards"][0, :-1].sum().item()) == 0.0
+
+
+def test_multiturn_workflow_custom_retry_prompt():
+    tokenizer = _make_dummy_tokenizer()
+    with patch("areal.workflow.multi_turn.apply_chat_template", return_value=[10, 20, 30]):
+        # Default prompt
+        wf_default = MultiTurnWorkflow(
+            reward_fn=lambda *args, **kwargs: 1.0,
+            gconfig=GenerationHyperparameters(),
+            tokenizer=tokenizer,
+            max_turns=2,
+            turn_discount=1.0,
+        )
+        assert wf_default.retry_prompt == DEFAULT_MULTI_TURN_RETRY_PROMPT
+
+        # Custom prompt
+        custom_prompt = "Try fixing the syntax error in your function."
+        wf_custom = MultiTurnWorkflow(
+            reward_fn=lambda *args, **kwargs: 1.0,
+            gconfig=GenerationHyperparameters(),
+            tokenizer=tokenizer,
+            max_turns=2,
+            turn_discount=1.0,
+            retry_prompt=custom_prompt,
+        )
+        assert wf_custom.retry_prompt == custom_prompt
+
+
+def test_check_trajectory_format_exempts_turn_rewards():
+    logger = MagicMock()
+    # Batch with max_seqlen=5, but turn_rewards is [1, 2] (2 turns)
+    data = {
+        "input_ids": torch.zeros((1, 5), dtype=torch.long),
+        "attention_mask": torch.ones((1, 5), dtype=torch.bool),
+        "turn_rewards": torch.tensor([[0.0, 1.0]], dtype=torch.float32),
+    }
+    check_trajectory_format(data, logger=logger)
+    # Ensure no warning was logged for turn_rewards having shape != max_seqlen
+    for call in logger.warning.call_args_list:
+        assert "turn_rewards" not in str(call)
+
+
+def test_critic_pops_all_reward_metadata():
+    engine = MagicMock()
+    engine.train_batch.return_value = {}
+    critic = PPOCritic(PPOCriticConfig(backend="fsdp:d1", ppo_n_minibatches=1), engine)
+    data = {
+        "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
+        "attention_mask": torch.ones((1, 3), dtype=torch.bool),
+        "values": torch.tensor([[0.5, 0.5, 0.5]], dtype=torch.float32),
+        "returns": torch.tensor([[1.0, 1.0, 1.0]], dtype=torch.float32),
+        "loss_mask": torch.tensor([[0, 1, 1]], dtype=torch.int32),
+        "rewards": torch.tensor([1.0]),
+        "original_rewards": torch.tensor([1.0]),
+        "turn_rewards": torch.tensor([[0.0, 1.0]]),
+        "step_rewards": torch.tensor([[0.0, 0.0, 1.0]]),
+    }
+    critic._ppo_update(data)
+    # Ensure all reward metadata keys were removed before staging
+    assert "turn_rewards" not in data
+    assert "step_rewards" not in data
+    assert "original_rewards" not in data
+    assert "rewards" not in data


### PR DESCRIPTION
## Description

In multi-turn agent rollouts (such as iterative coding, tool calling, and multi-attempt reasoning workflows), tracking credit across multiple turns and preserving undiscounted task ground truth is essential.

Previously in `MultiTurnWorkflow` (`areal/workflow/multi_turn.py`):
1. **Raw Ground Truth Was Lost**: `reward = float(reward * discount)` scaled the terminal reward, but the undiscounted ground truth was not recorded in the output dictionary. Downstream filtering and evaluation metrics could not verify whether the problem was solved independently of the turn discount decay.
2. **Turn-Level Reward Attribution Was Missing**: Although `MultiTurnWorkflow` assigned `turn_ids` to generated tokens, it did not emit a `turn_rewards` tensor. When training with turn-level GAE (`gae_timestep_unit='turn'`), `PPOActor` could not attribute returns across turns.
3. **Hardcoded Retry Prompt**: The multi-attempt retry prompt was hardcoded with no way to customize error messages for domain-specific environments.
4. **Trajectory Format Warnings**: 2D `turn_rewards` tensors (`[bs, num_turns]`) caused spurious shape warnings in `check_trajectory_format` because `num_turns != max_seqlen`.
5. **Actor/Critic Batch Staging**: New reward metadata keys were not popped before tensor microbatching in actor and critic trainers.

This PR addresses these limitations:
- **Customizable Retry Prompt**: Adds optional `retry_prompt` parameter in `MultiTurnWorkflow.__init__` (defaulting to the canonical prompt).
- **Raw Reward Preservation**: Records `original_rewards` tensor with the un-discounted task reward, matching `RLVRWorkflow` and OpenAI proxy interfaces.
- **Turn-Level & Step-Level Rewards**: Constructs and emits `turn_rewards` (shape `[1, num_turns]`) and `step_rewards` (token-aligned shape `[1, seq_len]`), directly feeding turn-level GAE credit assignment.
- **Warning Suppression**: Exempts `turn_rewards` from the `max_seqlen` tensor dimension warning in `check_trajectory_format`.
- **Clean Batch Staging**: Defensively pops `original_rewards`, `turn_rewards`, and `step_rewards` in `PPOActor._train_batch` and `PPOCritic._ppo_update` before microbatch dispatch.

## Verification Plan

- [x] Unit test suite in `tests/test_multiturn_workflow.py`:
  - `test_multiturn_workflow_single_turn_rewards`: verifies single-turn execution yields identical `rewards`, `original_rewards`, and `turn_rewards`.
  - `test_multiturn_workflow_multi_turn_reward_attribution`: verifies 2-turn execution where Turn 0 fails and Turn 1 succeeds with discount; verifies `original_rewards == 1.0`, `rewards == 0.8`, `turn_rewards == [0.0, 0.8]`, and `step_rewards[-1] == 0.8`.
  - `test_multiturn_workflow_custom_retry_prompt`: verifies custom retry prompt injection.
  - `test_check_trajectory_format_exempts_turn_rewards`: verifies no warnings are logged for `[bs, num_turns]` tensors.
  - `test_critic_pops_all_reward_metadata`: verifies all metadata is removed before critic engine staging.
- [x] Ran `uv run pytest tests/test_multiturn_workflow.py tests/test_ppo_actor_truncation.py` (12 passed).
- [x] Passed all 16 `pre-commit` hooks (`ruff check`, `ruff format`, `check-yaml`, etc.).