### PR TITLE
feat(v2): add `areal weight-update` operator console

### DIFF
--- a/areal/v2/cli/cli.py
+++ b/areal/v2/cli/cli.py
@@ -7,6 +7,7 @@ import click
 from areal.v2.cli.agent import agent
 from areal.v2.cli.inference import inf
 from areal.v2.cli.training import train
+from areal.v2.cli.weight_update import weight_update
 from areal.version import __version__
 
 
@@ -22,3 +23,4 @@ def cli() -> None:
 cli.add_command(agent)
 cli.add_command(inf)
 cli.add_command(train)
+cli.add_command(weight_update)

--- a/areal/v2/cli/weight_update/__init__.py
+++ b/areal/v2/cli/weight_update/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from areal.v2.cli.weight_update.commands.pairs import pairs_cmd
+from areal.v2.cli.weight_update.commands.ps import ps_cmd
+from areal.v2.cli.weight_update.commands.status import status_cmd
+from areal.v2.cli.weight_update.config import load_click_default_map
+
+
+@click.group(
+    name="weight-update",
+    help="Inspect weight-update services. Read-only: the gateway belongs to "
+    "the training controller that started it.",
+)
+@click.option(
+    "--config",
+    "config_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Extra TOML file merged on top of ~/.areal/weight-update/config.toml.",
+)
+@click.pass_context
+def weight_update(ctx: click.Context, config_file: Path | None) -> None:
+    ctx.default_map = load_click_default_map(extra=config_file)
+
+
+weight_update.add_command(status_cmd)
+weight_update.add_command(pairs_cmd)
+weight_update.add_command(ps_cmd)

--- a/areal/v2/cli/weight_update/client.py
+++ b/areal/v2/cli/weight_update/client.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from areal.v2.cli.client import BaseHTTPClient
+
+
+class WeightUpdateClient(BaseHTTPClient):
+    """Read-only view of a weight-update gateway."""
+
+    def pairs(self, *, timeout: float = 5.0) -> list[dict[str, Any]]:
+        return self._get("/pairs", timeout=timeout).get("pairs", [])

--- a/areal/v2/cli/weight_update/commands/__init__.py
+++ b/areal/v2/cli/weight_update/commands/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/areal/v2/cli/weight_update/commands/pairs.py
+++ b/areal/v2/cli/weight_update/commands/pairs.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import click
+
+from areal.v2.cli.utils import json_or_table
+from areal.v2.cli.weight_update.common import resolve_target
+
+
+@click.command(
+    name="pairs", help="List (train, inference) pairs connected to a gateway."
+)
+@click.option("--service", default=None, help="Target service instance.")
+@click.option(
+    "--gateway", default=None, help="Gateway base URL, e.g. http://host:7080."
+)
+@click.option("--admin-api-key", "admin_api_key", default=None, help="Admin API key.")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON.")
+def pairs_cmd(
+    service: str | None, gateway: str | None, admin_api_key: str | None, as_json: bool
+) -> None:
+    raise SystemExit(
+        do_pairs(as_json, service=service, gateway=gateway, admin_api_key=admin_api_key)
+    )
+
+
+def do_pairs(
+    as_json: bool,
+    *,
+    service: str | None = None,
+    gateway: str | None = None,
+    admin_api_key: str | None = None,
+) -> int:
+    client, _ = resolve_target(service, gateway, admin_api_key)
+    payload = client.pairs()
+    json_or_table(payload, as_json=as_json, table_renderer=_print_pairs)
+    return 0
+
+
+def _print_pairs(rows: list[dict]) -> None:
+    if not rows:
+        click.echo("no pairs connected")
+        return
+    cols = ("NAME", "MODE", "TRAIN", "INFER", "VERSION", "COLOCATE")
+    table = [
+        (
+            row.get("pair_name", ""),
+            row.get("mode", ""),
+            str(row.get("train_world_size", 0)),
+            str(row.get("inference_world_size", 0)),
+            str(row.get("last_version", 0)),
+            "yes" if row.get("colocate") else "no",
+        )
+        for row in rows
+    ]
+    widths = [max(len(r[i]) for r in (cols, *table)) for i in range(len(cols))]
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    click.echo(fmt.format(*cols))
+    for row in table:
+        click.echo(fmt.format(*row))

--- a/areal/v2/cli/weight_update/commands/ps.py
+++ b/areal/v2/cli/weight_update/commands/ps.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import click
+
+from areal.v2.cli.utils import json_or_table
+from areal.v2.cli.weight_update.lifecycle import wu_lifecycle
+
+
+@click.command(name="ps", help="List weight-update services known to this machine.")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON.")
+@click.option("--all", "include_all", is_flag=True, help="Include stale services.")
+def ps_cmd(as_json: bool, include_all: bool) -> None:
+    raise SystemExit(do_ps(as_json, include_all) or 0)
+
+
+def do_ps(as_json: bool, include_all: bool = False) -> int:
+    rows = []
+    for name in wu_lifecycle.list_services():
+        try:
+            state = wu_lifecycle.load_state(name)
+        except Exception:
+            # A half-written file should not hide the services that do parse;
+            # report it as a row instead of aborting the listing.
+            if include_all:
+                rows.append({"service": name, "gateway": "", "status": "unreadable"})
+            continue
+        alive = state.gateway_alive()
+        if not (alive or include_all):
+            continue
+        rows.append(
+            {
+                "service": state.service,
+                "gateway": state.gateway.url,
+                "launch_mode": state.launch_mode,
+                "started_at": state.started_at,
+                "status": "up" if alive else "unreachable",
+            }
+        )
+    json_or_table(rows, as_json=as_json, table_renderer=_print_ps)
+    return 0
+
+
+def _print_ps(rows: list[dict]) -> None:
+    if not rows:
+        click.echo("no weight-update services on this machine")
+        return
+    cols = ("SERVICE", "GATEWAY", "LAUNCH", "STATUS")
+    table = [
+        (r["service"], r.get("gateway", ""), r.get("launch_mode", ""), r["status"])
+        for r in rows
+    ]
+    widths = [max(len(r[i]) for r in (cols, *table)) for i in range(len(cols))]
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    click.echo(fmt.format(*cols))
+    for row in table:
+        click.echo(fmt.format(*row))

--- a/areal/v2/cli/weight_update/commands/status.py
+++ b/areal/v2/cli/weight_update/commands/status.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import click
+
+from areal.v2.cli.client import ServiceHTTPError, ServiceUnreachable
+from areal.v2.cli.utils import json_or_table
+from areal.v2.cli.weight_update.common import resolve_target
+
+
+@click.command(name="status", help="Show whether a weight-update gateway is reachable.")
+@click.option("--service", default=None, help="Target service instance.")
+@click.option(
+    "--gateway", default=None, help="Gateway base URL, e.g. http://host:7080."
+)
+@click.option("--admin-api-key", "admin_api_key", default=None, help="Admin API key.")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON.")
+def status_cmd(
+    service: str | None, gateway: str | None, admin_api_key: str | None, as_json: bool
+) -> None:
+    raise SystemExit(
+        do_status(
+            as_json, service=service, gateway=gateway, admin_api_key=admin_api_key
+        )
+    )
+
+
+def do_status(
+    as_json: bool,
+    *,
+    service: str | None = None,
+    gateway: str | None = None,
+    admin_api_key: str | None = None,
+) -> int:
+    client, state = resolve_target(service, gateway, admin_api_key)
+
+    payload: dict = {
+        "service": state.service if state else None,
+        "gateway": client.base,
+        "launch_mode": state.launch_mode if state else "external",
+        "started_at": state.started_at if state else None,
+    }
+    try:
+        client.health()
+        payload["reachable"] = True
+    except (ServiceUnreachable, ServiceHTTPError) as exc:
+        payload["reachable"] = False
+        payload["error"] = str(exc)
+
+    try:
+        payload["pairs"] = len(client.pairs())
+    except (ServiceUnreachable, ServiceHTTPError):
+        payload["pairs"] = None
+
+    json_or_table(payload, as_json=as_json, table_renderer=_print_status)
+    # Exit non-zero when unreachable so `areal weight-update status` is usable
+    # as a health gate in a script.
+    return 0 if payload["reachable"] else 1
+
+
+def _print_status(row: dict) -> None:
+    click.echo(f"gateway      {row['gateway']}")
+    click.echo(f"service      {row['service'] or '(external)'}")
+    click.echo(f"launch mode  {row['launch_mode']}")
+    click.echo(f"reachable    {'yes' if row['reachable'] else 'no'}")
+    if not row["reachable"]:
+        click.echo(f"error        {row.get('error', '')}")
+    elif row["pairs"] is not None:
+        click.echo(f"pairs        {row['pairs']}")

--- a/areal/v2/cli/weight_update/common.py
+++ b/areal/v2/cli/weight_update/common.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import click
+
+from areal.v2.cli.weight_update.client import WeightUpdateClient
+from areal.v2.cli.weight_update.lifecycle import wu_lifecycle
+from areal.v2.cli.weight_update.state import ServiceState
+
+
+def resolve_target(
+    service: str | None, gateway: str | None, admin_api_key: str | None
+) -> tuple[WeightUpdateClient, ServiceState | None]:
+    """Return a client for the gateway to talk to, plus its state if local.
+
+    ``--gateway`` wins so an operator can reach a gateway this machine has no
+    state file for -- a split-cluster or remote setup, where the controller
+    that owns the process runs somewhere else. Otherwise the address comes
+    from the state file the controller wrote.
+    """
+    if gateway:
+        return WeightUpdateClient(gateway, admin_api_key), None
+
+    name = wu_lifecycle.resolve_service_name(service)
+    if not wu_lifecycle.state_path(name).exists():
+        raise click.ClickException(
+            f"no weight-update service named '{name}' is known to this machine. "
+            "Pass --gateway URL to reach one started elsewhere."
+        )
+    state = wu_lifecycle.load_state(name)
+    return WeightUpdateClient(
+        state.gateway.url, admin_api_key or state.admin_api_key
+    ), state

--- a/areal/v2/cli/weight_update/config.py
+++ b/areal/v2/cli/weight_update/config.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""User config loader for ``areal weight-update``.
+
+``~/.areal/weight-update/config.toml`` overrides built-in defaults:
+
+  [default]   service, gateway, admin_api_key
+
+Precedence (highest first): explicit CLI flag, config.toml, click default.
+A missing or malformed file is treated as empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from areal.v2.cli.config import BindingMap, ConfigLoader
+from areal.v2.cli.weight_update.state import WU_NAMESPACE
+
+WU_BINDINGS: BindingMap = {
+    ("default", "service"): (("status", "pairs"), "service"),
+    ("default", "gateway"): (("status", "pairs"), "gateway"),
+    ("default", "admin_api_key"): (("status", "pairs"), "admin_api_key"),
+}
+
+wu_config_loader = ConfigLoader(namespace=WU_NAMESPACE, bindings=WU_BINDINGS)
+
+
+def load_click_default_map(extra: Path | None = None) -> dict:
+    return wu_config_loader.load_click_default_map(extra=extra)

--- a/areal/v2/cli/weight_update/lifecycle.py
+++ b/areal/v2/cli/weight_update/lifecycle.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from areal.v2.cli.lifecycle import ServiceLifecycle
+from areal.v2.cli.weight_update.state import WU_NAMESPACE, ServiceState
+
+# ``stop_command`` names the verb a user would run to clear a stale slot. This
+# CLI has no stop: the gateway is the training controller's process, and the
+# controller removes the state file when it shuts down. Point at the training
+# side so the message is actionable rather than naming a verb that does not
+# exist.
+wu_lifecycle = ServiceLifecycle(
+    namespace=WU_NAMESPACE,
+    state_class=ServiceState,
+    stop_command="stop the training job that owns it",
+)

--- a/areal/v2/cli/weight_update/state.py
+++ b/areal/v2/cli/weight_update/state.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+
+from areal.v2.cli.client import ServiceHTTPError, ServiceUnreachable, request_json
+from areal.v2.cli.state import (
+    NamespacedStateStore,
+    ServiceStateBase,
+    SupportsComponentProbe,
+    atomic_write_json,
+)
+
+WU_NAMESPACE = "weight-update"
+
+store = NamespacedStateStore(WU_NAMESPACE)
+
+
+@dataclass
+class GatewayHandle:
+    url: str
+    pid: int = 0
+
+    @property
+    def addr(self) -> str:
+        return self.url
+
+
+@dataclass
+class ServiceState(ServiceStateBase):
+    """What the operator needs to reach a weight-update gateway.
+
+    Written by ``WeightUpdateController`` when it brings the gateway up, not by
+    this CLI -- in the v2 flow the gateway belongs to the training side. The
+    controller picks an ephemeral port when ``config.port`` is 0, so without
+    this file the address is only ever known inside that one process.
+    """
+
+    service: str
+    launch_mode: str
+    admin_api_key: str
+    gateway: GatewayHandle
+    started_at: float = field(default_factory=time.time)
+
+    def save(self) -> None:
+        atomic_write_json(store.service_state_path(self.service), asdict(self))
+        store.set_current_service(self.service)
+
+    @classmethod
+    def load(cls, service: str) -> ServiceState:
+        with open(store.service_state_path(service)) as f:
+            raw = json.load(f)
+        raw["gateway"] = GatewayHandle(**raw["gateway"])
+        return cls(**raw)
+
+    @classmethod
+    def remove(cls, service: str) -> None:
+        path = store.service_state_path(service)
+        if path.exists():
+            path.unlink()
+        store.clear_current_service(service)
+
+    def gateway_alive(self) -> bool:
+        """Probe ``/health`` rather than the recorded PID.
+
+        The CLI does not own this process. A PID written by a controller on
+        another host means nothing here, and a PID on this host may have been
+        reused since. Reachability is the only claim the operator can act on.
+        """
+        try:
+            request_json(f"{self.gateway.url}/health", timeout=2.0)
+            return True
+        except (ServiceUnreachable, ServiceHTTPError):
+            return False
+
+    def components(self) -> Iterable[tuple[str, SupportsComponentProbe]]:
+        yield "gateway", self.gateway

--- a/areal/v2/weight_update/controller/config.py
+++ b/areal/v2/weight_update/controller/config.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 @dataclass
 class WeightUpdateControllerConfig:
     host: str = "127.0.0.1"
+    # Names this controller's gateway in ~/.areal/weight-update/ so two
+    # jobs on one machine do not overwrite each other's discovery file.
+    service_name: str = "default"
     port: int = 0
     admin_api_key: str = "areal-admin-key"
     log_level: str = "warning"

--- a/areal/v2/weight_update/controller/controller.py
+++ b/areal/v2/weight_update/controller/controller.py
@@ -69,6 +69,10 @@ class WeightUpdateController:
         )
 
         self._gateway_url = f"http://{cfg.host}:{port}"
+        # Record where the gateway landed. cfg.port defaults to 0, so the port
+        # is chosen here and would otherwise be known only inside this process,
+        # leaving `areal weight-update` with no address to connect to.
+        self._write_discovery_state()
         self._session = httpx.Client()
         self._session.headers["Authorization"] = f"Bearer {cfg.admin_api_key}"
         self._wait_for_health()
@@ -92,6 +96,31 @@ class WeightUpdateController:
         raise TimeoutError(
             f"Gateway did not become healthy within {self.config.setup_timeout}s"
         )
+
+    def _write_discovery_state(self) -> None:
+        """Publish the gateway address for the operator CLI. Best effort."""
+        try:
+            from areal.v2.cli.weight_update.state import GatewayHandle, ServiceState
+
+            ServiceState(
+                service=self.config.service_name,
+                launch_mode="controller",
+                admin_api_key=self.config.admin_api_key,
+                gateway=GatewayHandle(
+                    url=self._gateway_url,
+                    pid=self._gateway_proc.pid if self._gateway_proc else 0,
+                ),
+            ).save()
+        except Exception:  # never fail a training run over a diagnostic file
+            logger.debug("Could not write weight-update discovery state", exc_info=True)
+
+    def _clear_discovery_state(self) -> None:
+        try:
+            from areal.v2.cli.weight_update.state import ServiceState
+
+            ServiceState.remove(self.config.service_name)
+        except Exception:
+            logger.debug("Could not clear weight-update discovery state", exc_info=True)
 
     def health_check(self) -> bool:
         try:
@@ -216,4 +245,5 @@ class WeightUpdateController:
                 logger.warning("Failed to kill gateway process", exc_info=True)
             self._gateway_proc = None
         self._gateway_url = ""
+        self._clear_discovery_state()
         logger.info("WeightUpdateController destroyed")

--- a/areal/v2/weight_update/gateway/app.py
+++ b/areal/v2/weight_update/gateway/app.py
@@ -6,6 +6,7 @@ import os
 import socket
 import time
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 from typing import Any
 
 import aiohttp  # pyright: ignore[reportMissingImports]
@@ -191,6 +192,24 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
     @app.get("/health")
     async def health() -> HealthResponse:
         return HealthResponse()
+
+    @app.get("/pairs")
+    async def list_pairs(request: Request) -> dict:
+        """Read-only view of the pairs this gateway currently holds.
+
+        The registry already tracks them, but every other endpoint needs a
+        pair name to be useful, so an operator has no way to ask which
+        (train, inference) pairs are connected or what version they last
+        synced. Admin-keyed like the rest of the surface: the payload carries
+        worker URLs and the rendezvous address.
+        """
+        _auth(request)
+        pairs = [
+            asdict(info)
+            for info in (registry.get_by_name(n) for n in registry.list_pairs())
+            if info is not None
+        ]
+        return {"pairs": pairs}
 
     @app.post("/connect")
     async def connect(request: Request, body: ConnectRequest) -> ConnectResponse:

--- a/docs/en/best_practices/cli_guide.md
+++ b/docs/en/best_practices/cli_guide.md
@@ -1,7 +1,7 @@
 # AReaL CLI Guide
 
-The `areal` CLI ships three top-level subcommand groups, one per service in the AReaL
-2.0 microservice architecture:
+The `areal` CLI ships four top-level subcommand groups, one per service in the AReaL 2.0
+microservice architecture:
 
 - **`areal train`** — resolve an experiment driver and config, forward hydra overrides,
   and hand off to the training script.
@@ -9,6 +9,8 @@ The `areal` CLI ships three top-level subcommand groups, one per service in the 
   workers, data proxies).
 - **`areal agent`** — launch and manage a local agent service (gateway, router, N
   worker/data-proxy pairs).
+- **`areal weight-update`** — inspect a running weight-update service (gateway, pairs).
+  Read-only: the gateway is started by the training controller.
 
 `areal inf` and `areal agent` share the same lifecycle model — `run`, `ps`, `status`,
 `logs`, `stop` — with per-service state stored under `~/.areal/` (override with the
@@ -509,3 +511,86 @@ The current `areal agent` does **not** include:
   running `status` or checking logs.
 - Distributed scheduling — only local processes on the local machine; k8s / slurm and
   friends are out of scope for the current CLI.
+
+## Weight Update CLI (`areal weight-update`)
+
+`areal weight-update` inspects a running weight-update service. Unlike `areal inf` and
+`areal agent` it does not launch anything: in the v2 flow the gateway is started by
+`WeightUpdateController` on the training side, and this CLI is read-only.
+
+### Basic concepts
+
+A weight-update service has one component, the `gateway`, which holds the registry of
+`(train, inference)` pairs and drives transfers between them.
+
+The controller picks an ephemeral port when `WeightUpdateControllerConfig.port` is `0`,
+so it records where the gateway landed in
+`~/.areal/weight-update/services/<service>.json` (override the root with `AREAL_HOME`)
+and removes that file on teardown. `service_name` on the controller config names the
+file, so two jobs on one machine do not overwrite each other.
+
+### Inspecting a service
+
+```bash
+areal weight-update ps                    # services this machine knows about
+areal weight-update ps --all              # include ones whose gateway is gone
+areal weight-update status --service default
+areal weight-update pairs --service default
+```
+
+`ps` columns: `SERVICE / GATEWAY / LAUNCH / STATUS`. `pairs` columns:
+`NAME / MODE / TRAIN / INFER / VERSION / COLOCATE`.
+
+`status` exits non-zero when the gateway does not answer, so it works as a gate:
+
+```bash
+areal weight-update status --service default || echo "gateway is down"
+```
+
+Every verb takes `--json`:
+
+```bash
+areal weight-update pairs --service default --json | jq -r '.[].pair_name'
+```
+
+### Reaching a gateway started elsewhere
+
+`--gateway` skips the state file, for a gateway whose controller runs on another host:
+
+```bash
+areal weight-update pairs \
+  --gateway http://10.0.0.4:7080 \
+  --admin-api-key "$AREAL_ADMIN_KEY"
+```
+
+### Configuration file
+
+`areal weight-update` reads `~/.areal/weight-update/config.toml` as defaults; an extra
+file can be passed in:
+
+```bash
+areal weight-update --config ./my-wu.toml status
+```
+
+```toml
+[default]
+service = "default"
+gateway = "http://10.0.0.4:7080"
+admin_api_key = "areal-admin-key"
+```
+
+Precedence: \*\*CLI flag > TOML passed via `--config` >
+`~/.areal/weight-update/config.toml`
+
+> hardcoded defaults\*\*.
+
+### Not implemented yet
+
+The current `areal weight-update` does **not** include:
+
+- `run` / `stop` — the gateway's lifetime belongs to the training controller that starts
+  it, so the CLI would be tearing down a process it does not own.
+- `logs` — the controller lets the gateway inherit its stdout instead of redirecting it
+  to a file, so the output is in the training log rather than under `~/.areal/`.
+- Any write verb (connect, disconnect, trigger an update) — those change what a training
+  run is doing, and the gateway already exposes them over HTTP for the controller.

--- a/docs/zh/best_practices/cli_guide.md
+++ b/docs/zh/best_practices/cli_guide.md
@@ -1,10 +1,11 @@
 # AReaL CLI 指南
 
-`areal` CLI 在 AReaL 2.0 微服务架构下提供三个顶层子命令组，每个对应一种服务：
+`areal` CLI 在 AReaL 2.0 微服务架构下提供四个顶层子命令组，每个对应一种服务：
 
 - **`areal train`** — 解析实验 driver 与配置文件，转发 hydra 覆盖参数，将控制权交给训练脚本。
 - **`areal inf`** — 启动并管理本机上的推理服务（gateway、router、model worker、data proxy）。
 - **`areal agent`** — 启动并管理本机上的 agent 服务（gateway、router、N 对 worker / data-proxy）。
+- **`areal weight-update`** — 查看正在运行的权重更新服务（gateway、配对）。只读：gateway 由训练 controller 拉起。
 
 `areal inf` 与 `areal agent` 共用同一套生命周期模型 —— `run`、`ps`、`status`、 `logs`、`stop`，每个服务的状态存放在
 `~/.areal/` 下（可通过 `AREAL_HOME` 环境变量覆盖）。`areal train` 有意保持无状态：它只是将 argv 传递给 Python
@@ -463,3 +464,76 @@ session_timeout = 1800
 - 会话级 CLI 操作（开启会话 / 设置奖励 / 导出轨迹）—— 这类操作与应用耦合很紧，由应用直接调用 gateway HTTP 处理。
 - 自动故障恢复 / 心跳监控 —— `status` 是按需查询，不会持续观察组件健康。worker 死掉后需要用户运行 `status` 或看日志才能发现。
 - 分布式调度 —— 只在本机启动本地进程；k8s / slurm 等超出当前 CLI 的范围。
+
+## 权重更新 CLI（`areal weight-update`）
+
+`areal weight-update` 用于查看正在运行的权重更新服务。与 `areal inf`、`areal agent` 不同，它不启动任何进程：在 v2 流程里
+gateway 由训练侧的 `WeightUpdateController` 拉起，本 CLI 是只读的。
+
+### 基础概念
+
+权重更新服务只有一个组件 `gateway`，它保存 `(train, inference)` 配对的注册表，并驱动两者之间的权重传输。
+
+当 `WeightUpdateControllerConfig.port` 为 `0` 时，controller 会选一个临时端口，因此它把 gateway 的地址写入
+`~/.areal/weight-update/services/<service>.json`（根目录可用 `AREAL_HOME` 覆盖），并在销毁时删除该文件。
+controller 配置里的 `service_name` 决定文件名，同一台机器上的两个作业因此不会互相覆盖。
+
+### 查看服务状态
+
+```bash
+areal weight-update ps                    # 本机已知的服务
+areal weight-update ps --all              # 包含 gateway 已经不在的服务
+areal weight-update status --service default
+areal weight-update pairs --service default
+```
+
+`ps` 的列：`SERVICE / GATEWAY / LAUNCH / STATUS`。 `pairs`
+的列：`NAME / MODE / TRAIN / INFER / VERSION / COLOCATE`。
+
+gateway 无响应时 `status` 以非零码退出，可以直接当作脚本里的判断条件：
+
+```bash
+areal weight-update status --service default || echo "gateway is down"
+```
+
+每个子命令都支持 `--json`：
+
+```bash
+areal weight-update pairs --service default --json | jq -r '.[].pair_name'
+```
+
+### 连接其他机器上的 gateway
+
+`--gateway` 跳过状态文件，用于 controller 跑在别的主机上的场景：
+
+```bash
+areal weight-update pairs \
+  --gateway http://10.0.0.4:7080 \
+  --admin-api-key "$AREAL_ADMIN_KEY"
+```
+
+### 配置文件
+
+`areal weight-update` 启动时读取 `~/.areal/weight-update/config.toml` 作为默认值，也可以额外传入配置文件：
+
+```bash
+areal weight-update --config ./my-wu.toml status
+```
+
+```toml
+[default]
+service = "default"
+gateway = "http://10.0.0.4:7080"
+admin_api_key = "areal-admin-key"
+```
+
+优先级：**命令行参数 > `--config` 传入的 TOML > `~/.areal/weight-update/config.toml` > 内置默认值**。
+
+### 尚未实现
+
+当前的 `areal weight-update` **不包含**：
+
+- `run` / `stop` —— gateway 的生命周期属于拉起它的训练 controller，CLI 去停一个不属于自己的进程并不合适。
+- `logs` —— controller 让 gateway 继承自己的 stdout，而不是重定向到文件，因此输出在训练日志里，不在 `~/.areal/` 下。
+- 任何写操作（connect、disconnect、触发一次更新）—— 这些会改变训练任务的行为，而且 gateway 已经通过 HTTP 把它们暴露给 controller
+  了。

--- a/tests/v2/cli/test_weight_update_cli.py
+++ b/tests/v2/cli/test_weight_update_cli.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``areal weight-update`` (CPU-only, no service processes).
+
+The gateway is stubbed at the HTTP-client boundary rather than launched: these
+verbs are pure read paths, and what is worth pinning is how they behave when
+the state file is missing, unreadable, or points at something that is not
+answering -- none of which a live gateway would reproduce on demand.
+
+Test naming convention: test_<what>_<condition>_<expected>()
+"""
+
+import json
+
+import pytest
+
+from areal.v2.cli.client import ServiceUnreachable
+from areal.v2.cli.weight_update import weight_update
+from areal.v2.cli.weight_update.commands import pairs as pairs_mod
+from areal.v2.cli.weight_update.commands import ps as ps_mod
+from areal.v2.cli.weight_update.commands import status as status_mod
+from areal.v2.cli.weight_update.state import GatewayHandle, ServiceState, store
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Every test gets its own ~/.areal. The store re-resolves paths on each
+    call, so setting the env var is enough -- no store rebuild needed."""
+    monkeypatch.setenv("AREAL_HOME", str(tmp_path))
+    yield
+
+
+def _write_state(service="default", url="http://127.0.0.1:7080"):
+    state = ServiceState(
+        service=service,
+        launch_mode="controller",
+        admin_api_key="k",
+        gateway=GatewayHandle(url=url, pid=4242),
+    )
+    state.save()
+    return state
+
+
+class TestState:
+    def test_state_round_trips_through_disk(self):
+        written = _write_state()
+        loaded = ServiceState.load("default")
+        assert loaded.gateway.url == written.gateway.url
+        assert loaded.gateway.pid == 4242
+        assert loaded.launch_mode == "controller"
+
+    def test_gateway_handle_exposes_addr_for_component_probe(self):
+        # ServiceStateBase.components() yields handles that scaffold probes
+        # structurally; it needs .addr and .pid, not a base class.
+        handle = GatewayHandle(url="http://h:1", pid=7)
+        assert handle.addr == "http://h:1" and handle.pid == 7
+
+    def test_remove_deletes_the_state_file(self):
+        _write_state()
+        assert store.service_state_path("default").exists()
+        ServiceState.remove("default")
+        assert not store.service_state_path("default").exists()
+
+
+class TestResolveTarget:
+    def test_no_state_and_no_gateway_flag_names_the_escape_hatch(self):
+        import click
+
+        with pytest.raises(click.ClickException) as err:
+            status_mod.do_status(False)
+        assert "--gateway" in str(err.value)
+
+    def test_gateway_flag_wins_over_local_state(self, monkeypatch):
+        _write_state(url="http://from-state:7080")
+        seen = {}
+
+        def fake_health(self, **kw):
+            seen["base"] = self.base
+            return {}
+
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.health", fake_health
+        )
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.pairs",
+            lambda self, **kw: [],
+        )
+        status_mod.do_status(True, gateway="http://explicit:9000")
+        assert seen["base"] == "http://explicit:9000"
+
+
+class TestStatus:
+    def test_unreachable_gateway_exits_non_zero(self, monkeypatch, capsys):
+        _write_state()
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.health",
+            lambda self, **kw: (_ for _ in ()).throw(ServiceUnreachable("refused")),
+        )
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.pairs",
+            lambda self, **kw: (_ for _ in ()).throw(ServiceUnreachable("refused")),
+        )
+        # Non-zero so the verb can gate a script, not just print a word.
+        assert status_mod.do_status(True) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["reachable"] is False and payload["pairs"] is None
+
+    def test_reachable_gateway_reports_pair_count_and_exits_zero(
+        self, monkeypatch, capsys
+    ):
+        _write_state()
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.health",
+            lambda self, **kw: {},
+        )
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.pairs",
+            lambda self, **kw: [{"pair_name": "a"}, {"pair_name": "b"}],
+        )
+        assert status_mod.do_status(True) == 0
+        assert json.loads(capsys.readouterr().out)["pairs"] == 2
+
+
+class TestPairs:
+    def test_pairs_renders_the_fields_an_operator_acts_on(self, monkeypatch, capsys):
+        _write_state()
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.pairs",
+            lambda self, **kw: [
+                {
+                    "pair_name": "actor",
+                    "mode": "awex",
+                    "train_world_size": 4,
+                    "inference_world_size": 2,
+                    "last_version": 17,
+                    "colocate": True,
+                }
+            ],
+        )
+        assert pairs_mod.do_pairs(False) == 0
+        out = capsys.readouterr().out
+        for token in ("actor", "awex", "17", "yes"):
+            assert token in out
+
+    def test_no_pairs_says_so_rather_than_printing_an_empty_table(
+        self, monkeypatch, capsys
+    ):
+        _write_state()
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.client.WeightUpdateClient.pairs",
+            lambda self, **kw: [],
+        )
+        pairs_mod.do_pairs(False)
+        assert "no pairs connected" in capsys.readouterr().out
+
+
+class TestPs:
+    def test_ps_with_no_services_says_so(self, capsys):
+        assert ps_mod.do_ps(False) == 0
+        assert "no weight-update services" in capsys.readouterr().out
+
+    def test_ps_marks_a_gateway_that_is_not_answering(self, monkeypatch, capsys):
+        _write_state()
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.state.ServiceState.gateway_alive",
+            lambda self: False,
+        )
+        ps_mod.do_ps(False, True)
+        assert "unreachable" in capsys.readouterr().out
+
+    def test_a_dead_service_is_hidden_until_all_is_passed(self, monkeypatch, capsys):
+        # Same default as `areal inf ps` and `areal agent ps`.
+        _write_state(service="dead")
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.state.ServiceState.gateway_alive",
+            lambda self: False,
+        )
+        ps_mod.do_ps(False, False)
+        assert "dead" not in capsys.readouterr().out
+        ps_mod.do_ps(False, True)
+        assert "dead" in capsys.readouterr().out
+
+    def test_unreadable_state_file_does_not_hide_the_others(self, monkeypatch, capsys):
+        _write_state(service="good")
+        bad = store.service_state_path("broken")
+        bad.write_text("{ not json")
+        monkeypatch.setattr(
+            "areal.v2.cli.weight_update.state.ServiceState.gateway_alive",
+            lambda self: True,
+        )
+        ps_mod.do_ps(False, True)
+        out = capsys.readouterr().out
+        assert "good" in out and "unreadable" in out
+
+
+class TestParser:
+    def test_group_exposes_exactly_the_first_cut_verbs(self):
+        # `logs` is deliberately absent: the controller inherits the gateway's
+        # stdout instead of redirecting it to a file, so adding the verb means
+        # changing where that output goes -- a separate change.
+        assert set(weight_update.commands) == {"status", "pairs", "ps"}
+
+    def test_the_installed_console_script_exposes_the_group(self):
+        # `areal` binds areal.v2.cli.main:cli. Importing the group directly
+        # stays green when the add_command line is deleted; this does not.
+        from areal.v2.cli.main import cli as console_entry
+
+        assert "weight-update" in console_entry.commands
+
+    def test_ps_matches_the_flags_of_the_sibling_namespaces(self):
+        from areal.v2.cli.inference.commands.ps import ps_cmd as inf_ps
+
+        mine = {o for p in ps_mod.ps_cmd.params for o in p.opts}
+        theirs = {o for p in inf_ps.params for o in p.opts}
+        assert mine == theirs, f"`weight-update ps` flags drifted: {mine ^ theirs}"
+
+    def test_every_verb_offers_json_output(self):
+        for name, cmd in weight_update.commands.items():
+            assert any("--json" in p.opts for p in cmd.params), (
+                f"{name} has no --json flag"
+            )

--- a/tests/v2/weight_update/test_controller_discovery.py
+++ b/tests/v2/weight_update/test_controller_discovery.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The controller publishes its gateway address so the operator CLI can find it.
+
+`WeightUpdateControllerConfig.port` defaults to 0, so the port is picked inside
+`initialize()` and is otherwise known only to that process.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from areal.v2.cli.weight_update.state import ServiceState
+from areal.v2.weight_update.controller.config import WeightUpdateControllerConfig
+from areal.v2.weight_update.controller.controller import WeightUpdateController
+
+
+@pytest.fixture(autouse=True)
+def isolated_state_dir(tmp_path, monkeypatch):
+    # The store re-resolves paths on every call, so the env var is enough.
+    monkeypatch.setenv("AREAL_HOME", str(tmp_path))
+    yield
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242):
+        self.pid = pid
+
+    def poll(self):
+        return None
+
+
+def _controller(**kw) -> WeightUpdateController:
+    """A controller with `initialize()`'s subprocess and health wait stubbed.
+
+    Everything else in `initialize()` runs, so the discovery write is exercised
+    where it actually sits rather than by calling the helper directly.
+    """
+    ctl = WeightUpdateController(WeightUpdateControllerConfig(**kw))
+    return ctl
+
+
+@pytest.fixture()
+def initialized(monkeypatch):
+    def _make(**kw):
+        ctl = _controller(**kw)
+        monkeypatch.setattr(
+            "areal.v2.weight_update.controller.controller.subprocess.Popen",
+            lambda *a, **k: _FakeProc(),
+        )
+        monkeypatch.setattr(
+            WeightUpdateController, "_wait_for_health", lambda self: None
+        )
+        ctl.initialize()
+        return ctl
+
+    return _make
+
+
+class TestDiscoveryFile:
+    def test_initialize_publishes_an_address_the_cli_can_load(self, initialized):
+        ctl = initialized(admin_api_key="k")
+        state = ServiceState.load("default")
+        assert state.gateway.url == ctl.gateway_url
+        assert state.gateway.url.startswith("http://127.0.0.1:")
+        assert state.gateway.url.rsplit(":", 1)[1] != "0"
+        assert state.launch_mode == "controller"
+        assert state.admin_api_key == "k"
+        assert state.gateway.pid == 4242
+
+    def test_service_name_keeps_two_jobs_on_one_machine_apart(self, initialized):
+        a = initialized(service_name="job-a")
+        b = initialized(service_name="job-b")
+        assert ServiceState.load("job-a").gateway.url == a.gateway_url
+        assert ServiceState.load("job-b").gateway.url == b.gateway_url
+        assert a.gateway_url != b.gateway_url
+
+    def test_destroy_removes_the_file(self, initialized, monkeypatch):
+        monkeypatch.setattr(
+            "areal.v2.weight_update.controller.controller.kill_process_tree",
+            lambda *a, **k: None,
+        )
+        initialized(service_name="job-a")
+        ServiceState.load("job-a")
+        # destroy() is the teardown path a training run takes.
+        ctl = WeightUpdateController(WeightUpdateControllerConfig(service_name="job-a"))
+        ctl.destroy()
+        with pytest.raises(FileNotFoundError):
+            ServiceState.load("job-a")
+
+
+class TestNeverBreaksTraining:
+    def test_a_failing_state_write_does_not_fail_initialize(
+        self, initialized, monkeypatch
+    ):
+        def boom(self):
+            raise OSError("read-only home")
+
+        monkeypatch.setattr(ServiceState, "save", boom)
+        ctl = initialized(service_name="job-a")
+        assert ctl.gateway_url.startswith("http://")
+        with pytest.raises(FileNotFoundError):
+            ServiceState.load("job-a")
+
+    def test_a_failing_state_remove_does_not_fail_destroy(
+        self, initialized, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "areal.v2.weight_update.controller.controller.kill_process_tree",
+            lambda *a, **k: None,
+        )
+        ctl = initialized(service_name="job-a")
+
+        def boom(cls, service):
+            raise OSError("read-only home")
+
+        monkeypatch.setattr(ServiceState, "remove", classmethod(boom))
+        ctl.destroy()
+        assert ctl.gateway_url == ""

--- a/tests/v2/weight_update/test_gateway_pairs.py
+++ b/tests/v2/weight_update/test_gateway_pairs.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+
+from areal.v2.weight_update.gateway.app import create_app
+from areal.v2.weight_update.gateway.config import PairInfo, WeightUpdateConfig
+
+ADMIN_HEADERS = {"Authorization": "Bearer test-key"}
+
+
+@pytest.fixture()
+def app():
+    return create_app(WeightUpdateConfig(admin_api_key="test-key"))
+
+
+@pytest.fixture()
+def client(app):
+    from starlette.testclient import TestClient
+
+    return TestClient(app)
+
+
+def _pair(name: str, **kw) -> PairInfo:
+    return PairInfo(
+        pair_name=name,
+        train_worker_urls=[f"http://train-{name}:8000"],
+        inference_worker_urls=[f"http://infer-{name}:8000"],
+        train_world_size=kw.pop("train_world_size", 2),
+        inference_world_size=kw.pop("inference_world_size", 1),
+        **kw,
+    )
+
+
+class TestListPairs:
+    def test_no_pairs_yields_an_empty_list(self, client):
+        assert client.get("/pairs", headers=ADMIN_HEADERS).json() == {"pairs": []}
+
+    def test_registered_pairs_are_reported_with_their_fields(self, app, client):
+        app.state.registry.register(
+            _pair("actor", master_addr="10.0.0.4", master_port=29500, last_version=17)
+        )
+        app.state.registry.register(_pair("critic", mode="disk", colocate=True))
+
+        resp = client.get("/pairs", headers=ADMIN_HEADERS)
+        assert resp.status_code == 200
+        by_name = {p["pair_name"]: p for p in resp.json()["pairs"]}
+        assert set(by_name) == {"actor", "critic"}
+
+        actor = by_name["actor"]
+        assert actor["last_version"] == 17
+        assert actor["master_addr"] == "10.0.0.4"
+        assert actor["master_port"] == 29500
+        assert actor["train_world_size"] == 2
+        assert actor["mode"] == "awex"
+        assert by_name["critic"]["mode"] == "disk"
+        assert by_name["critic"]["colocate"] is True
+
+    def test_unregistered_pairs_disappear_from_the_listing(self, app, client):
+        app.state.registry.register(_pair("actor"))
+        app.state.registry.unregister("actor")
+        assert client.get("/pairs", headers=ADMIN_HEADERS).json()["pairs"] == []
+
+    def test_reading_pairs_does_not_mutate_the_registry(self, app, client):
+        app.state.registry.register(_pair("actor"))
+        for _ in range(3):
+            client.get("/pairs", headers=ADMIN_HEADERS)
+        assert app.state.registry.list_pairs() == ["actor"]
+
+
+class TestAuth:
+    def test_no_key_is_rejected(self, client):
+        assert client.get("/pairs").status_code == 401
+
+    def test_wrong_key_is_rejected(self, client):
+        resp = client.get("/pairs", headers={"Authorization": "Bearer nope"})
+        assert resp.status_code == 403
+
+    def test_pair_contents_do_not_leak_to_an_unauthenticated_caller(self, app, client):
+        app.state.registry.register(_pair("actor", master_addr="10.0.0.4"))
+        assert "10.0.0.4" not in client.get("/pairs").text


### PR DESCRIPTION
## Description

`areal weight-update` is a fourth CLI namespace alongside `train`, `inf` and `agent`: a read-only console for a running weight-update service. It launches nothing — in the v2 flow the gateway belongs to the `WeightUpdateController` on the training side.

Two gaps had to close before a CLI could say anything.

1. **The gateway never exposed its pairs.** `PairRegistry` tracks them, but every other endpoint needs a pair name to be useful, so an operator had no way to ask what is connected. Adds `GET /pairs`, admin-keyed like the rest of the surface.
2. **The gateway address died with the process.** `WeightUpdateControllerConfig.port` defaults to `0`, so the port is picked inside `initialize()` and never leaves it. The controller now writes `~/.areal/weight-update/services/<name>.json` when the gateway comes up and removes it on `destroy()`. The write is best-effort and never fails a training run; a new `service_name` on the controller config keeps two jobs on one machine apart.

The CLI itself:

| verb | what it answers |
|---|---|
| `status` | is the gateway reachable, how many pairs. Exits non-zero when it is not, so it gates a script |
| `pairs` | `NAME / MODE / TRAIN / INFER / VERSION / COLOCATE` |
| `ps` | services this machine knows about; `--all` includes dead ones, matching `inf ps` |

`--gateway URL` skips the state file for a gateway whose controller runs on another host. Every verb takes `--json`. No `logs` verb: the controller lets the gateway inherit its stdout instead of redirecting it to a file, so adding it means moving that output, which belongs in its own change.

## Related Issue

Refs #1374 — the state layout and command shape follow the plan there.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

## Additional Context

### Test Plan

```bash
pytest tests/v2/cli tests/v2/weight_update \
  -m "not gpu and not multi_gpu and not slow and not integration"
```

Plus an end-to-end run: a real `WeightUpdateController`, the gateway subprocess it spawns, and the same click group the `areal` console script binds.

### Test Result

| suite | result |
|---|---|
| `tests/v2/cli` | 36 passed |
| `tests/v2/weight_update` | 67 passed, 33 deselected |

Reverting each changed file to `main` turns a named test red:

| file reverted | goes red |
|---|---|
| `areal/v2/cli/cli.py` | `test_the_installed_console_script_exposes_the_group` |
| `.../controller/controller.py` | 3 in `test_controller_discovery.py` |
| `.../controller/config.py` | 5 in `test_controller_discovery.py` |
| `.../gateway/app.py` | 5 in `test_gateway_pairs.py` |

Against a gateway the controller actually started:

| check | result |
|---|---|
| `GET /pairs` — no key / wrong key / admin key | 401 / 403 / 200 |
| discovery file URL vs `controller.gateway_url` | equal, port ≠ 0 |
| `status` gateway up / connection refused | exit 0 / exit 1 |
| `destroy()` | file removed, `status` then exits 1 |
| every command in the new docs section | 15/15 claims hold |
