### PR TITLE
perf: reduce duplicate VLM rollout processing and transfers

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -59,6 +59,7 @@ from areal.api.cli_args import GenerationHyperparameters
 from areal.experimental.openai.cache import InteractionCache
 from areal.experimental.openai.tool_call_parser import process_tool_calls
 from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.infra.processor_cache import ProcessorCallCache
 from areal.utils import logging
 from areal.utils.hf_utils import (
     apply_chat_template,
@@ -178,6 +179,54 @@ class _VisionPrompt:
     mm_token_type_ids: list[int] | None
     multi_modal_input: list[dict[str, Any]]
     collapsed_input_ids: list[int]
+
+    def copy_for_consumer(self) -> "_VisionPrompt":
+        """Copy mutable containers while sharing processor-produced tensors."""
+        return _VisionPrompt(
+            input_ids=list(self.input_ids),
+            mm_token_type_ids=(
+                list(self.mm_token_type_ids)
+                if self.mm_token_type_ids is not None
+                else None
+            ),
+            multi_modal_input=[dict(item) for item in self.multi_modal_input],
+            collapsed_input_ids=list(self.collapsed_input_ids),
+        )
+
+
+async def _acached_vision_prompt(
+    processor_cache: ProcessorCallCache | None,
+    process: Callable[..., _VisionPrompt],
+    *args: Any,
+    **kwargs: Any,
+) -> _VisionPrompt:
+    """Reuse identical prompts, including the actual parent tokens in concat mode."""
+    if processor_cache is None:
+        return await asyncio.to_thread(process, *args, **kwargs)
+
+    def cache_argument(value: Any) -> Any:
+        if isinstance(value, InteractionWithTokenLogpReward):
+            response = value.model_response
+            return (
+                value.messages,
+                value.output_message_list,
+                value.collapsed_input_ids,
+                value.mm_token_type_ids,
+                response.input_tokens if response is not None else None,
+                response.output_tokens_without_stop if response is not None else None,
+            )
+        return value
+
+    cache_key = processor_cache.make_key(
+        "openai_vision",
+        process,
+        [cache_argument(value) for value in args],
+        {key: cache_argument(value) for key, value in kwargs.items()},
+    )
+    cached_prompt = await processor_cache.aget_or_compute(
+        cache_key, lambda: process(*args, **kwargs)
+    )
+    return cached_prompt.copy_for_consumer()
 
 
 def _require_processor(processor: Any) -> None:
@@ -903,6 +952,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         top_p: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: InteractionCache | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[ChatCompletionChunk, None]: ...
 
@@ -926,6 +976,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         top_p: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: InteractionCache | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> ChatCompletion: ...
 
@@ -948,6 +999,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         top_p: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: InteractionCache | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> ChatCompletion | AsyncGenerator[ChatCompletionChunk, None]:
         """Override create method to use AReaL engine and cache responses."""
@@ -1013,7 +1065,8 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             _require_processor(self.processor)
         if self.chat_template_type == "hf":
             if has_images:
-                vision_prompt = await asyncio.to_thread(
+                vision_prompt = await _acached_vision_prompt(
+                    processor_cache,
                     _process_vision_prompt,
                     self.processor,
                     apply_chat_template(
@@ -1043,7 +1096,8 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
                 else messages_list
             )
             if has_images:
-                vision_prompt = await asyncio.to_thread(
+                vision_prompt = await _acached_vision_prompt(
+                    processor_cache,
                     concat_vision_prompt_with_parent,
                     concat_messages,
                     interaction.parent if interaction is not None else None,
@@ -1417,6 +1471,7 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
         frequency_penalty: float | None | NotGiven = NOT_GIVEN,
         extra_body: Body | None = None,
         areal_cache: dict[str, InteractionWithTokenLogpReward] | None = None,
+        processor_cache: ProcessorCallCache | None = None,
         **kwargs: Any,
     ) -> Response:
         """Override create method to use AReaL engine"""
@@ -1493,7 +1548,8 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
             _require_processor(self.processor)
         if self.chat_template_type == "hf":
             if has_images:
-                vision_prompt = await asyncio.to_thread(
+                vision_prompt = await _acached_vision_prompt(
+                    processor_cache,
                     _process_vision_prompt,
                     self.processor,
                     apply_chat_template(
@@ -1519,7 +1575,8 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
         elif self.chat_template_type == "concat":
             remaining = interaction.remaining_messages
             if has_images:
-                vision_prompt = await asyncio.to_thread(
+                vision_prompt = await _acached_vision_prompt(
+                    processor_cache,
                     concat_vision_prompt_with_parent,
                     remaining,
                     interaction.parent if interaction is not None else None,

--- a/areal/experimental/openai/proxy/client_session.py
+++ b/areal/experimental/openai/proxy/client_session.py
@@ -17,18 +17,22 @@ from tenacity import (
     wait_exponential,
 )
 
+from areal.infra.rpc.serialization import deserialize_value
 from areal.infra.utils.http import ensure_end_with_slash
 from areal.utils.logging import getLogger
 
 from .server import (
     EXPORT_TRAJECTORIES_PATHNAME,
     RL_END_SESSION_PATHNAME,
+    RL_FETCH_SHARED_TENSORS_PATHNAME,
     RL_SET_REWARD_PATHNAME,
     RL_START_SESSION_PATHNAME,
+    FetchSharedTensorsRequest,
     SetRewardRequest,
     StartSessionRequest,
     deserialize_interactions,
 )
+from .tensor_reference import SharedTensorResolver
 
 if TYPE_CHECKING:
     from ..types import InteractionWithTokenLogpReward
@@ -58,6 +62,12 @@ class OpenAIProxyClient:
         Unique identifier for this task
     admin_api_key : str
         Admin API key for management operations
+    processor_cache_group_id : str | None
+        Shared processor-cache identity for grouped rollout sessions.
+    processor_cache_group_size : int
+        Expected number of sessions sharing the processor cache.
+    shared_tensor_resolver : SharedTensorResolver | None
+        Group-local resolver used to fetch each referenced image tensor once.
 
     Example
     -------
@@ -85,11 +95,19 @@ class OpenAIProxyClient:
         base_url: str,
         task_id: str,
         admin_api_key: str,
+        processor_cache_group_id: str | None = None,
+        processor_cache_group_size: int = 1,
+        shared_tensor_resolver: SharedTensorResolver | None = None,
     ):
         self._session = session
         self.base_url = ensure_end_with_slash(base_url)
         self.task_id = task_id
         self._admin_api_key = admin_api_key
+        self._processor_cache_group_id = processor_cache_group_id
+        self._processor_cache_group_size = processor_cache_group_size
+        self._shared_tensor_resolver = shared_tensor_resolver
+        if processor_cache_group_id is not None and shared_tensor_resolver is None:
+            self._shared_tensor_resolver = SharedTensorResolver()
         self.session_id: str | None = None
         self._session_api_key: str | None = None
 
@@ -175,19 +193,55 @@ class OpenAIProxyClient:
             "session_id": self.session_id,
             "discount": discount,
             "style": style,
+            "supports_shared_tensor_references": (
+                self._processor_cache_group_id is not None
+            ),
         }
         headers = self._admin_auth_headers()
         async with self._session.post(url, json=payload, headers=headers) as resp:
             resp.raise_for_status()
             data = await resp.json()
-            return deserialize_interactions(data["interactions"])
+
+        serialized_interactions = data["interactions"]
+        tensor_group_id = data.get("tensor_reference_group_id")
+        if tensor_group_id is not None:
+            if self._shared_tensor_resolver is None:
+                raise RuntimeError(
+                    "Proxy returned shared tensor references without a resolver"
+                )
+
+            async def fetch_shared_tensors(ref_ids: list[str]):
+                fetch_payload = FetchSharedTensorsRequest(
+                    group_id=tensor_group_id,
+                    ref_ids=ref_ids,
+                )
+                async with self._session.post(
+                    f"{self.base_url}{RL_FETCH_SHARED_TENSORS_PATHNAME}",
+                    json=fetch_payload.model_dump(),
+                    headers=headers,
+                ) as response:
+                    response.raise_for_status()
+                    response_data = await response.json()
+                return deserialize_value(response_data["tensors"])
+
+            serialized_interactions = await self._shared_tensor_resolver.resolve(
+                serialized_interactions,
+                group_id=tensor_group_id,
+                fetch=fetch_shared_tensors,
+            )
+
+        return deserialize_interactions(serialized_interactions)
 
     async def __aenter__(self) -> OpenAIProxyClient:
         """Start the RL session via HTTP request."""
         data = await _start_session(
             self._session,
             url=f"{self.base_url}{RL_START_SESSION_PATHNAME}",
-            payload=StartSessionRequest(task_id=self.task_id),
+            payload=StartSessionRequest(
+                task_id=self.task_id,
+                processor_cache_group_id=self._processor_cache_group_id,
+                processor_cache_group_size=self._processor_cache_group_size,
+            ),
             headers=self._admin_auth_headers(),
         )
         self.session_id = data["session_id"]

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -33,6 +33,7 @@ from areal.experimental.openai.chat_template_patches import (
     apply_keep_all_reasoning_patches,
 )
 from areal.experimental.openai.client import ArealOpenAI
+from areal.infra.processor_cache import ProcessorCacheRegistry
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.utils.http import validate_admin_api_key
 from areal.utils import name_resolve, names, seeding
@@ -48,17 +49,23 @@ from .server import (
     EXPORT_TRAJECTORIES_PATHNAME,
     GRANT_CAPACITY_PATHNAME,
     RESPONSES_PATHNAME,
+    RL_END_PROCESSOR_CACHE_GROUP_PATHNAME,
     RL_END_SESSION_PATHNAME,
+    RL_FETCH_SHARED_TENSORS_PATHNAME,
     RL_SET_REWARD_PATHNAME,
     RL_START_SESSION_PATHNAME,
     ExportTrajectoriesRequest,
     ExportTrajectoriesResponse,
+    FetchSharedTensorsRequest,
+    FetchSharedTensorsResponse,
+    ProcessorCacheGroupRequest,
     SessionData,
     SetRewardRequest,
     StartSessionRequest,
     StartSessionResponse,
     serialize_interactions,
 )
+from .tensor_reference import GroupTensorStoreRegistry
 
 if TYPE_CHECKING:
     from areal.api import InferenceEngine
@@ -105,6 +112,8 @@ _lock = threading.Lock()
 _capacity = 0
 _last_cleanup_time: float = 0
 _session_timeout_seconds: int = 3600  # Default timeout (overridden by config)
+_processor_cache_registry = ProcessorCacheRegistry()
+_group_tensor_store_registry = GroupTensorStoreRegistry()
 
 # API key authentication
 # Initialized to a random value so pre-configuration requests cannot bypass auth.
@@ -444,7 +453,14 @@ def _cleanup_stale_sessions():
 
     for session_id in stale_sessions:
         logger.warning(f"Removing stale session: {session_id}")
-        _session_cache.pop(session_id, None)
+        session_data = _session_cache.pop(session_id, None)
+        if session_data is not None:
+            cache_group_id = session_data.take_processor_cache_group_id()
+            if cache_group_id is not None:
+                _processor_cache_registry.release(cache_group_id)
+
+    _processor_cache_registry.discard_stale(_session_timeout_seconds)
+    _group_tensor_store_registry.discard_stale(_session_timeout_seconds)
 
     # Clean up API key mappings for stale sessions
     if stale_sessions:
@@ -473,6 +489,15 @@ def start_session(request: StartSessionRequest) -> StartSessionResponse:
     """
     global _capacity
     task_id = request.task_id
+
+    if (
+        request.processor_cache_group_id is not None
+        and request.processor_cache_group_size < 2
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="processor_cache_group_size must be at least 2 for grouped caching",
+        )
 
     with _lock:
         # Periodically cleanup stale sessions
@@ -517,8 +542,19 @@ def start_session(request: StartSessionRequest) -> StartSessionResponse:
             ):
                 session_api_key = secrets.token_urlsafe(32)
 
+        processor_cache = None
+        if request.processor_cache_group_id is not None:
+            processor_cache = _processor_cache_registry.acquire(
+                request.processor_cache_group_id,
+                request.processor_cache_group_size,
+            )
+
         _capacity -= 1
-        _session_cache[session_id] = SessionData(session_id=session_id)
+        _session_cache[session_id] = SessionData(
+            session_id=session_id,
+            processor_cache=processor_cache,
+            processor_cache_group_id=request.processor_cache_group_id,
+        )
         _api_key_to_session[session_api_key] = session_id
         _session_to_api_key[session_id] = session_api_key
 
@@ -543,7 +579,36 @@ def end_session(session_id: str = Depends(_require_session_key)):
 
     # finish() outside lock to avoid holding lock during potential I/O
     session.finish()
+    cache_group_id = session.take_processor_cache_group_id()
+    if cache_group_id is not None:
+        _processor_cache_registry.release(cache_group_id)
     return {"message": "success", "interaction_count": interaction_count}
+
+
+@app.post(
+    f"/{RL_END_PROCESSOR_CACHE_GROUP_PATHNAME}",
+    dependencies=[Depends(_require_admin_key)],
+)
+def end_processor_cache_group(request: ProcessorCacheGroupRequest):
+    """Discard processor and shared-tensor state after a rollout group finishes."""
+    _processor_cache_registry.discard(request.group_id)
+    _group_tensor_store_registry.discard(request.group_id)
+    return {"message": "success"}
+
+
+@app.post(
+    f"/{RL_FETCH_SHARED_TENSORS_PATHNAME}",
+    dependencies=[Depends(_require_admin_key)],
+)
+def fetch_shared_tensors(
+    request: FetchSharedTensorsRequest,
+) -> FetchSharedTensorsResponse:
+    """Fetch each unique multimodal tensor once for a grouped rollout."""
+    try:
+        tensors = _group_tensor_store_registry.fetch(request.group_id, request.ref_ids)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FetchSharedTensorsResponse(tensors=serialize_value(tensors))
 
 
 @app.post(f"/{RL_SET_REWARD_PATHNAME}")
@@ -608,8 +673,12 @@ async def _call_client_create(
     session_data.update_last_access()
 
     sig = inspect.signature(create_fn)
+    supports_processor_cache = "processor_cache" in sig.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in sig.parameters.values()
+    )
     areal_client_ignored_args = ["model"] + (extra_ignored_args or [])
-    areal_client_disallowed_args = ["areal_cache"]
+    areal_client_disallowed_args = ["areal_cache", "processor_cache"]
     areal_client_allowed_args = list(
         k
         for k in sig.parameters.keys()
@@ -660,7 +729,13 @@ async def _call_client_create(
         kwargs["stream"] = True
 
     try:
-        return await create_fn(areal_cache=session_data.completions, **kwargs)
+        client_kwargs: dict[str, Any] = {
+            "areal_cache": session_data.completions,
+            **kwargs,
+        }
+        if supports_processor_cache:
+            client_kwargs["processor_cache"] = session_data.processor_cache
+        return await create_fn(**client_kwargs)
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
@@ -966,9 +1041,23 @@ async def export_trajectories(
         _session_cache.pop(session_id, None)
         _remove_api_keys_for_session(session_id)
 
-    # Serialize for HTTP transport
-    serialized = serialize_interactions(interactions)
-    return ExportTrajectoriesResponse(interactions=serialized)
+    # Grouped inline/subproc sessions export only multimodal tensor references.
+    # The workflow fetches each unique tensor once through the group endpoint.
+    tensor_reference_group_id = (
+        session_data.processor_cache_group_id
+        if request.supports_shared_tensor_references
+        else None
+    )
+    tensor_store = (
+        _group_tensor_store_registry.get_or_create(tensor_reference_group_id)
+        if tensor_reference_group_id is not None
+        else None
+    )
+    serialized = serialize_interactions(interactions, tensor_store=tensor_store)
+    return ExportTrajectoriesResponse(
+        interactions=serialized,
+        tensor_reference_group_id=tensor_reference_group_id,
+    )
 
 
 # =============================================================================

--- a/areal/experimental/openai/proxy/server.py
+++ b/areal/experimental/openai/proxy/server.py
@@ -13,6 +13,9 @@ from areal.experimental.openai.cache import InteractionCache
 
 if TYPE_CHECKING:
     from areal.experimental.openai.types import InteractionWithTokenLogpReward
+    from areal.infra.processor_cache import ProcessorCallCache
+
+    from .tensor_reference import GroupTensorStore
 
 # Session timeout for cleanup (1 hour)
 SESSION_TIMEOUT_SECONDS = 3600
@@ -28,6 +31,8 @@ class StartSessionRequest(BaseModel):
 
     task_id: str
     api_key: str | None = None  # Reuse a previously-issued key (refresh)
+    processor_cache_group_id: str | None = None
+    processor_cache_group_size: int = 1
 
 
 class StartSessionResponse(BaseModel):
@@ -35,6 +40,25 @@ class StartSessionResponse(BaseModel):
 
     session_id: str
     api_key: str
+
+
+class ProcessorCacheGroupRequest(BaseModel):
+    """Request to discard one completed or aborted processor-cache group."""
+
+    group_id: str
+
+
+class FetchSharedTensorsRequest(BaseModel):
+    """Request unique multimodal tensors referenced by grouped trajectories."""
+
+    group_id: str
+    ref_ids: list[str]
+
+
+class FetchSharedTensorsResponse(BaseModel):
+    """Response containing tensors keyed by their group-scoped references."""
+
+    tensors: dict[str, Any]
 
 
 class SetRewardRequest(BaseModel):
@@ -50,12 +74,14 @@ class ExportTrajectoriesRequest(BaseModel):
     session_id: str
     discount: float = 1.0
     style: str = "individual"
+    supports_shared_tensor_references: bool = False
 
 
 class ExportTrajectoriesResponse(BaseModel):
     """Response containing serialized interactions."""
 
     interactions: dict[str, Any]
+    tensor_reference_group_id: str | None = None
 
 
 # =============================================================================
@@ -66,8 +92,15 @@ class ExportTrajectoriesResponse(BaseModel):
 class SessionData:
     """Data associated with a single RL session."""
 
-    def __init__(self, session_id: str):
+    def __init__(
+        self,
+        session_id: str,
+        processor_cache: ProcessorCallCache | None = None,
+        processor_cache_group_id: str | None = None,
+    ):
         self.session_id = session_id
+        self.processor_cache = processor_cache
+        self.processor_cache_group_id = processor_cache_group_id
 
         self._completed = False
         self._completions = InteractionCache()
@@ -76,11 +109,21 @@ class SessionData:
         self._last_access_time = time.time()
         self._end_time = None
         self._lock = threading.Lock()
+        self._processor_cache_released = False
 
     def update_last_access(self):
         """Update the last access time for this session."""
         with self._lock:
             self._last_access_time = time.time()
+
+    def take_processor_cache_group_id(self) -> str | None:
+        """Detach the cache and return its group ID once for idempotent release."""
+        with self._lock:
+            if self._processor_cache_released:
+                return None
+            self._processor_cache_released = True
+            self.processor_cache = None
+            return self.processor_cache_group_id
 
     def is_stale(self, timeout_seconds: float = SESSION_TIMEOUT_SECONDS) -> bool:
         """Check if this session has been inactive for too long."""
@@ -191,6 +234,7 @@ def _resolve_blob_refs(value: Any, blobs: dict[str, Any]) -> Any:
 
 def serialize_interactions(
     interactions: dict[str, InteractionWithTokenLogpReward],
+    tensor_store: GroupTensorStore | None = None,
 ) -> dict[str, Any]:
     """Serialize interactions into a json-compatible format for HTTP transport."""
     from areal.infra.rpc.serialization import serialize_value
@@ -209,8 +253,10 @@ def serialize_interactions(
                 "interaction_id": interaction.interaction_id,
             }
             if multi_modal_input is not None:
-                entry["multi_modal_input"] = _dedup_multi_modal(
-                    multi_modal_input, blobs
+                entry["multi_modal_input"] = (
+                    multi_modal_input
+                    if tensor_store is not None
+                    else _dedup_multi_modal(multi_modal_input, blobs)
                 )
             result[key] = entry
         else:
@@ -220,6 +266,8 @@ def serialize_interactions(
                 "reward": interaction.reward,
                 "interaction_id": interaction.interaction_id,
             }
+    if tensor_store is not None:
+        result = tensor_store.encode_multimodal_tensors(result)
     return serialize_value(
         {"__format__": _MM_BLOB_FORMAT, "interactions": result, "blobs": blobs}
     )
@@ -265,6 +313,8 @@ def deserialize_interactions(
 
 RL_START_SESSION_PATHNAME = "rl/start_session"
 RL_END_SESSION_PATHNAME = "rl/end_session"
+RL_END_PROCESSOR_CACHE_GROUP_PATHNAME = "rl/end_processor_cache_group"
+RL_FETCH_SHARED_TENSORS_PATHNAME = "rl/fetch_shared_tensors"
 RL_SET_REWARD_PATHNAME = "rl/set_reward"
 CHAT_COMPLETIONS_PATHNAME = "chat/completions"
 RESPONSES_PATHNAME = "responses"

--- a/areal/experimental/openai/proxy/tensor_reference.py
+++ b/areal/experimental/openai/proxy/tensor_reference.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from threading import Lock
+from typing import Any, Literal
+
+import torch
+from pydantic import BaseModel
+
+from areal.utils.data import is_multi_modal_key
+
+
+class SharedTensorReference(BaseModel):
+    """JSON marker for one tensor stored in a proxy-side rollout group."""
+
+    type: Literal["areal_shared_tensor"] = "areal_shared_tensor"
+    ref_id: str
+
+
+class GroupTensorStore:
+    """Store unique multimodal tensors and replace them with lightweight refs."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        # A recreated store must not reuse references cached by group resolvers.
+        self._generation = uuid.uuid4().hex
+        self._ref_by_tensor_id: dict[int, str] = {}
+        self._tensor_by_ref: dict[str, torch.Tensor] = {}
+
+    def encode_multimodal_tensors(self, value: Any) -> Any:
+        """Replace tensors below ``multi_modal_input*`` keys with references."""
+        return self._encode(value, in_multimodal_value=False)
+
+    def fetch(self, ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        """Return requested tensors, rejecting unknown group-scoped refs."""
+        with self._lock:
+            missing = [
+                ref_id for ref_id in ref_ids if ref_id not in self._tensor_by_ref
+            ]
+            if missing:
+                raise KeyError(f"Unknown shared tensor references: {missing}")
+            return {ref_id: self._tensor_by_ref[ref_id] for ref_id in ref_ids}
+
+    def _encode(self, value: Any, *, in_multimodal_value: bool) -> Any:
+        if isinstance(value, torch.Tensor):
+            if not in_multimodal_value:
+                return value
+            return self._reference(value).model_dump()
+
+        if isinstance(value, dict):
+            return {
+                key: self._encode(
+                    item,
+                    in_multimodal_value=(
+                        in_multimodal_value or is_multi_modal_key(str(key))
+                    ),
+                )
+                for key, item in value.items()
+            }
+
+        if isinstance(value, list):
+            return [
+                self._encode(item, in_multimodal_value=in_multimodal_value)
+                for item in value
+            ]
+
+        if isinstance(value, tuple):
+            return [
+                self._encode(item, in_multimodal_value=in_multimodal_value)
+                for item in value
+            ]
+
+        return value
+
+    def _reference(self, tensor: torch.Tensor) -> SharedTensorReference:
+        tensor_id = id(tensor)
+        with self._lock:
+            ref_id = self._ref_by_tensor_id.get(tensor_id)
+            if ref_id is None:
+                ref_id = f"{self._generation}:tensor-{len(self._tensor_by_ref)}"
+                self._ref_by_tensor_id[tensor_id] = ref_id
+                # Keep a strong reference so Python cannot reuse ``tensor_id``
+                # during the lifetime of this rollout group.
+                self._tensor_by_ref[ref_id] = tensor
+        return SharedTensorReference(ref_id=ref_id)
+
+
+class GroupTensorStoreRegistry:
+    """Own proxy-side tensor stores until their rollout groups are finalized."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._stores: dict[str, GroupTensorStore] = {}
+        self._last_access: dict[str, float] = {}
+
+    def get_or_create(self, group_id: str) -> GroupTensorStore:
+        with self._lock:
+            store = self._stores.get(group_id)
+            if store is None:
+                store = GroupTensorStore()
+                self._stores[group_id] = store
+            self._last_access[group_id] = time.monotonic()
+            return store
+
+    def fetch(self, group_id: str, ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        with self._lock:
+            store = self._stores.get(group_id)
+            if store is None:
+                raise KeyError(f"Unknown shared tensor group: {group_id}")
+            self._last_access[group_id] = time.monotonic()
+        return store.fetch(ref_ids)
+
+    def discard(self, group_id: str) -> None:
+        with self._lock:
+            self._stores.pop(group_id, None)
+            self._last_access.pop(group_id, None)
+
+    def discard_stale(self, timeout_seconds: float) -> None:
+        cutoff = time.monotonic() - timeout_seconds
+        with self._lock:
+            stale_ids = [
+                group_id
+                for group_id, last_access in self._last_access.items()
+                if last_access < cutoff
+            ]
+            for group_id in stale_ids:
+                self._stores.pop(group_id, None)
+                self._last_access.pop(group_id, None)
+
+
+FetchSharedTensors = Callable[[list[str]], Awaitable[dict[str, torch.Tensor]]]
+
+
+class SharedTensorResolver:
+    """Resolve each group-scoped tensor ref once across concurrent sessions."""
+
+    def __init__(self) -> None:
+        self._values: dict[tuple[str, str], torch.Tensor] = {}
+        self._inflight: dict[tuple[str, str], asyncio.Future[torch.Tensor]] = {}
+
+    async def resolve(
+        self,
+        value: Any,
+        *,
+        group_id: str,
+        fetch: FetchSharedTensors,
+    ) -> Any:
+        """Fetch missing references once, then restore aliases in ``value``."""
+        ref_ids: list[str] = []
+        self._collect_ref_ids(value, ref_ids, in_multimodal_value=False)
+        if not ref_ids:
+            return value
+
+        owned: list[str] = []
+        futures: dict[str, asyncio.Future[torch.Tensor]] = {}
+        loop = asyncio.get_running_loop()
+        for ref_id in dict.fromkeys(ref_ids):
+            key = (group_id, ref_id)
+            cached = self._values.get(key)
+            if cached is not None:
+                future = loop.create_future()
+                future.set_result(cached)
+            else:
+                future = self._inflight.get(key)
+                if future is None:
+                    future = loop.create_future()
+                    self._inflight[key] = future
+                    owned.append(ref_id)
+            futures[ref_id] = future
+
+        if owned:
+            try:
+                fetched = await fetch(owned)
+                missing = [ref_id for ref_id in owned if ref_id not in fetched]
+                if missing:
+                    raise RuntimeError(
+                        f"Proxy omitted shared tensor references: {missing}"
+                    )
+                invalid = [
+                    ref_id
+                    for ref_id in owned
+                    if not isinstance(fetched[ref_id], torch.Tensor)
+                ]
+                if invalid:
+                    raise TypeError(
+                        f"Proxy returned non-tensor shared references: {invalid}"
+                    )
+            except BaseException as exc:
+                for ref_id in owned:
+                    key = (group_id, ref_id)
+                    future = self._inflight.pop(key)
+                    if not future.done():
+                        future.set_exception(exc)
+                        # The owner raises directly; retrieving the exception
+                        # prevents an unobserved-future warning without hiding it
+                        # from concurrent waiters.
+                        future.exception()
+                raise
+
+            for ref_id in owned:
+                key = (group_id, ref_id)
+                tensor = fetched[ref_id]
+                self._values[key] = tensor
+                future = self._inflight.pop(key)
+                future.set_result(tensor)
+
+        resolved = {
+            ref_id: await asyncio.shield(future) for ref_id, future in futures.items()
+        }
+        return self._replace_refs(value, resolved, in_multimodal_value=False)
+
+    def discard(self, group_id: str) -> None:
+        keys = [key for key in self._values if key[0] == group_id]
+        for key in keys:
+            self._values.pop(key, None)
+
+        inflight_keys = [key for key in self._inflight if key[0] == group_id]
+        if inflight_keys:
+            raise RuntimeError(
+                f"Cannot discard shared tensor group {group_id} while fetches are active"
+            )
+
+    @classmethod
+    def _collect_ref_ids(
+        cls,
+        value: Any,
+        result: list[str],
+        *,
+        in_multimodal_value: bool,
+    ) -> None:
+        if in_multimodal_value and cls._is_reference(value):
+            result.append(value["ref_id"])
+            return
+        if isinstance(value, dict):
+            for key, item in value.items():
+                cls._collect_ref_ids(
+                    item,
+                    result,
+                    in_multimodal_value=(
+                        in_multimodal_value or is_multi_modal_key(str(key))
+                    ),
+                )
+        elif isinstance(value, list):
+            for item in value:
+                cls._collect_ref_ids(
+                    item,
+                    result,
+                    in_multimodal_value=in_multimodal_value,
+                )
+
+    @classmethod
+    def _replace_refs(
+        cls,
+        value: Any,
+        resolved: dict[str, torch.Tensor],
+        *,
+        in_multimodal_value: bool,
+    ) -> Any:
+        if in_multimodal_value and cls._is_reference(value):
+            return resolved[value["ref_id"]]
+        if isinstance(value, dict):
+            return {
+                key: cls._replace_refs(
+                    item,
+                    resolved,
+                    in_multimodal_value=(
+                        in_multimodal_value or is_multi_modal_key(str(key))
+                    ),
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                cls._replace_refs(
+                    item,
+                    resolved,
+                    in_multimodal_value=in_multimodal_value,
+                )
+                for item in value
+            ]
+        return value
+
+    @staticmethod
+    def _is_reference(value: Any) -> bool:
+        return (
+            isinstance(value, dict)
+            and value.get("type") == "areal_shared_tensor"
+            and isinstance(value.get("ref_id"), str)
+        )

--- a/areal/experimental/openai/proxy/workflow.py
+++ b/areal/experimental/openai/proxy/workflow.py
@@ -17,8 +17,14 @@ from areal.utils import logging
 from areal.utils.perf_tracer import session_context, trace_session
 from areal.workflow.reward_metrics import log_reward_metrics
 
-from .client_session import OpenAIProxyClient
-from .server import DEFAULT_ADMIN_API_KEY, GRANT_CAPACITY_PATHNAME
+from .client_session import OpenAIProxyClient, post_json
+from .server import (
+    DEFAULT_ADMIN_API_KEY,
+    GRANT_CAPACITY_PATHNAME,
+    RL_END_PROCESSOR_CACHE_GROUP_PATHNAME,
+    ProcessorCacheGroupRequest,
+)
+from .tensor_reference import SharedTensorResolver
 
 if TYPE_CHECKING:
     from ..client import TRolloutEngine
@@ -82,6 +88,13 @@ def _wrap_run(agent: Any, data: dict[str, Any], extra_envs: dict[str, str]):
 
 
 class OpenAIProxyWorkflow(RolloutWorkflow):
+    """Run an agent through the v1 proxy.
+
+    Group-scoped processor caching is supported in ``inline`` and ``subproc``
+    modes. Online mode owns its sessions externally and does not receive the
+    rollout group's cache identity.
+    """
+
     def __init__(
         self,
         mode: str,
@@ -129,6 +142,7 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
         self.discount = discount
         self.export_style = export_style
         self.subproc_max_workers = subproc_max_workers
+        self._shared_tensor_resolver = SharedTensorResolver()
 
     @trace_session("run_agent")
     async def _run_agent(self, session_api_key: str, data: dict):
@@ -172,11 +186,40 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
         async with session.post(url, headers=headers) as resp:
             resp.raise_for_status()
 
+    def _processor_cache_group_id(
+        self, context: workflow_context.WorkflowContext
+    ) -> str | None:
+        if self.mode == "online" or context.group_size <= 1 or context.task_id is None:
+            return None
+        scope = "eval" if context.is_eval else "train"
+        return f"{scope}:{context.task_id}"
+
+    async def _afinalize_processor_cache_group(
+        self, context: workflow_context.WorkflowContext
+    ) -> None:
+        """Release processor and tensor-ref state after an inline/subproc group."""
+        group_id = self._processor_cache_group_id(context)
+        if group_id is None:
+            return
+
+        http_session = await workflow_context.get_aiohttp_session()
+        try:
+            await post_json(
+                http_session,
+                url=(f"{self.proxy_addr}/{RL_END_PROCESSOR_CACHE_GROUP_PATHNAME}"),
+                payload=ProcessorCacheGroupRequest(group_id=group_id),
+                headers={"Authorization": f"Bearer {self._admin_api_key}"},
+            )
+        finally:
+            self._shared_tensor_resolver.discard(group_id)
+
     @session_context()
     async def arun_episode(
         self, engine: TRolloutEngine, data: dict[str, Any]
     ) -> dict[str, InteractionWithTokenLogpReward] | None:
-        task_id = workflow_context.get().task_id
+        context = workflow_context.get()
+        task_id = context.task_id
+        processor_cache_group_id = self._processor_cache_group_id(context)
 
         http_session = await workflow_context.get_aiohttp_session()
 
@@ -228,6 +271,9 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
             base_url=self.proxy_addr,
             task_id=str(task_id),
             admin_api_key=self._admin_api_key,
+            processor_cache_group_id=processor_cache_group_id,
+            processor_cache_group_size=context.group_size,
+            shared_tensor_resolver=self._shared_tensor_resolver,
         )
         async with proxy_client:
             # Run the user code.

--- a/areal/infra/processor_cache.py
+++ b/areal/infra/processor_cache.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable, Hashable
+from concurrent.futures import Future
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, TypeVar, cast
+
+T = TypeVar("T")
+
+
+class ProcessorCallCache:
+    """Thread-safe single-flight cache for identical calls within one group."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._results: dict[Hashable, Any] = {}
+        self._inflight: dict[Hashable, Future[Any]] = {}
+        self._generation = 0
+        self._closed = False
+
+    def _claim(self, key: Hashable) -> tuple[Future[Any] | None, bool, int]:
+        with self._lock:
+            if self._closed:
+                return None, False, self._generation
+            if key in self._results:
+                future: Future[Any] = Future()
+                future.set_result(self._results[key])
+                return future, False, self._generation
+
+            future = self._inflight.get(key)
+            is_owner = future is None
+            if future is None:
+                future = Future()
+                self._inflight[key] = future
+            return future, is_owner, self._generation
+
+    def _publish_result(
+        self,
+        key: Hashable,
+        future: Future[Any],
+        generation: int,
+        result: Any,
+    ) -> None:
+        with self._lock:
+            if generation == self._generation:
+                self._results[key] = result
+            self._inflight.pop(key, None)
+            future.set_result(result)
+
+    def _publish_exception(
+        self, key: Hashable, future: Future[Any], exc: BaseException
+    ) -> None:
+        with self._lock:
+            self._inflight.pop(key, None)
+            future.set_exception(exc)
+
+    def get_or_compute(self, key: Hashable, factory: Callable[[], T]) -> T:
+        """Return a cached value, computing it once across concurrent callers."""
+        future, is_owner, generation = self._claim(key)
+        if future is None:
+            return factory()
+
+        if not is_owner:
+            return cast(T, future.result())
+
+        try:
+            result = factory()
+        except BaseException as exc:
+            self._publish_exception(key, future, exc)
+            raise
+
+        self._publish_result(key, future, generation, result)
+        return result
+
+    async def aget_or_compute(self, key: Hashable, factory: Callable[[], T]) -> T:
+        """Asynchronously compute once without occupying threads for waiters."""
+        future, is_owner, generation = self._claim(key)
+        if future is None:
+            return await asyncio.to_thread(factory)
+        if not is_owner:
+            return cast(T, await asyncio.shield(asyncio.wrap_future(future)))
+
+        try:
+            result = await asyncio.to_thread(factory)
+        except BaseException as exc:
+            self._publish_exception(key, future, exc)
+            raise
+
+        self._publish_result(key, future, generation, result)
+        return result
+
+    def close(self) -> None:
+        """Disable caching and drop results owned by a completed group."""
+        with self._lock:
+            self._closed = True
+            self._generation += 1
+            self._results.clear()
+
+    @classmethod
+    def make_key(cls, *values: Any) -> Hashable:
+        """Convert processor inputs into a stable, hashable cache key."""
+        return tuple(cls._freeze(value) for value in values)
+
+    @classmethod
+    def _freeze(cls, value: Any) -> Hashable:
+        if isinstance(value, dict):
+            return tuple(
+                sorted((str(key), cls._freeze(item)) for key, item in value.items())
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(cls._freeze(item) for item in value)
+        if isinstance(value, (set, frozenset)):
+            return tuple(sorted(repr(cls._freeze(item)) for item in value))
+        try:
+            hash(value)
+        except TypeError:
+            return repr(value)
+        return cast(Hashable, value)
+
+
+@dataclass
+class _RegistryEntry:
+    cache: ProcessorCallCache
+    expected_users: int
+    acquired_users: int = 0
+    active_users: int = 0
+    last_access_time: float = 0.0
+
+
+class ProcessorCacheRegistry:
+    """Own group caches that must be shared across proxy sessions."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._entries: dict[str, _RegistryEntry] = {}
+
+    def acquire(self, group_id: str, expected_users: int) -> ProcessorCallCache:
+        if expected_users < 2:
+            raise ValueError("A shared processor cache requires at least two users.")
+
+        with self._lock:
+            entry = self._entries.get(group_id)
+            if entry is None:
+                entry = _RegistryEntry(
+                    cache=ProcessorCallCache(),
+                    expected_users=expected_users,
+                )
+                self._entries[group_id] = entry
+            else:
+                entry.expected_users = max(entry.expected_users, expected_users)
+            entry.acquired_users += 1
+            entry.active_users += 1
+            entry.last_access_time = time.monotonic()
+            return entry.cache
+
+    def release(self, group_id: str) -> None:
+        with self._lock:
+            entry = self._entries.get(group_id)
+            if entry is None:
+                return
+            entry.active_users = max(0, entry.active_users - 1)
+            entry.last_access_time = time.monotonic()
+            if entry.acquired_users >= entry.expected_users and entry.active_users == 0:
+                self._entries.pop(group_id).cache.close()
+
+    def discard(self, group_id: str) -> None:
+        """Explicitly clear a completed or aborted group's cached results."""
+        with self._lock:
+            entry = self._entries.pop(group_id, None)
+            if entry is not None:
+                entry.cache.close()
+
+    def discard_stale(self, timeout_seconds: float) -> None:
+        cutoff = time.monotonic() - timeout_seconds
+        with self._lock:
+            stale_ids = [
+                group_id
+                for group_id, entry in self._entries.items()
+                if entry.last_access_time < cutoff
+            ]
+            for group_id in stale_ids:
+                self._entries.pop(group_id).cache.close()

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -83,10 +83,69 @@ class GroupedRolloutWorkflow(RolloutWorkflow):
         self, engine: InferenceEngine, data: dict[str, Any]
     ) -> dict[str, Any] | None:
         from areal.experimental.openai import InteractionWithTokenLogpReward
+        from areal.infra import workflow_context
+        from areal.infra.processor_cache import ProcessorCallCache
+        from areal.infra.workflow_context import WorkflowContext
 
-        results = await asyncio.gather(
-            *[self.workflow.arun_episode(engine, data) for _ in range(self.group_size)]
+        parent = workflow_context.get()
+        shared_processor_cache = ProcessorCallCache()
+        group_context = WorkflowContext(
+            is_eval=parent.is_eval,
+            task_id=parent.task_id,
+            group_size=self.group_size,
+            processor_cache=shared_processor_cache,
         )
+
+        async def run_sample(sample_idx: int) -> tuple[int, Any]:
+            workflow_context.set(
+                WorkflowContext(
+                    is_eval=group_context.is_eval,
+                    task_id=group_context.task_id,
+                    sample_idx=sample_idx,
+                    group_size=group_context.group_size,
+                    processor_cache=shared_processor_cache,
+                )
+            )
+            result = await self.workflow.arun_episode(engine, data)
+            return sample_idx, result
+
+        group_tasks = [
+            asyncio.create_task(run_sample(sample_idx))
+            for sample_idx in range(self.group_size)
+        ]
+        try:
+            indexed_results = await asyncio.gather(*group_tasks)
+        except BaseException:
+            # gather does not cancel siblings when a child fails or is cancelled.
+            for task in group_tasks:
+                if not task.done():
+                    task.cancel()
+            raise
+        finally:
+            try:
+                # Drain cancellation handlers before releasing shared resources.
+                await asyncio.gather(*group_tasks, return_exceptions=True)
+            finally:
+                finalizer = getattr(
+                    self.workflow, "_afinalize_processor_cache_group", None
+                )
+                if finalizer is not None:
+                    try:
+                        await finalizer(group_context)
+                    except Exception as exc:
+                        self.logger.warning(
+                            "Failed to finalize rollout group resources (%s: %s).",
+                            type(exc).__name__,
+                            exc,
+                        )
+        indexed_results.sort(key=lambda item: item[0])
+        sample_indices = [sample_idx for sample_idx, _ in indexed_results]
+        if sample_indices != list(range(self.group_size)):
+            raise RuntimeError(
+                "Grouped rollout returned invalid sample indices: "
+                f"expected {list(range(self.group_size))}, got {sample_indices}"
+            )
+        results = [result for _, result in indexed_results]
 
         valid_results = [r for r in results if r is not None]
 

--- a/areal/infra/rpc/guard/engine_blueprint.py
+++ b/areal/infra/rpc/guard/engine_blueprint.py
@@ -595,7 +595,15 @@ def call_engine_method():
         is_init = is_train and engine.initialized
         if not is_train or not is_init or engine.is_data_parallel_head():
             state = get_state()
-            result = RTensor.remotize(result, node_addr=state.node_addr)
+            # wait_for_task is the v1 rollout boundary that returns the grouped
+            # trajectory. Preserve its shared image tensors as RTensor shards;
+            # unrelated engine results keep the existing behavior.
+            preserve_output_tensor_aliases = method_name == "wait_for_task"
+            result = RTensor.remotize(
+                result,
+                node_addr=state.node_addr,
+                preserve_tensor_aliases=preserve_output_tensor_aliases,
+            )
             serialized_result = serialize_value(result)
         else:
             # Non-DP-head: result is discarded by controller. Skip remotize

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -383,11 +383,15 @@ class RTensor:
         return self.data
 
     @staticmethod
-    def remotize(obj: Any, node_addr: str) -> Any:
+    def remotize(
+        obj: Any, node_addr: str, *, preserve_tensor_aliases: bool = False
+    ) -> Any:
         """Convert tensors to RTensors in nested structures.
 
         For dict objects that look like trajectory dicts (contain attention_mask),
         trailing padding is trimmed before storage to keep each RTensor compact.
+        When ``preserve_tensor_aliases`` is enabled, repeated references to the
+        same tensor object share one stored shard for this root call.
 
         Parameters
         ----------
@@ -395,23 +399,44 @@ class RTensor:
             Object potentially containing tensors
         node_addr : str
             Node address for shard storage
+        preserve_tensor_aliases : bool, default=False
+            Preserve tensor object aliases as shared RTensor shards. Distinct
+            tensor objects are never merged, even when their values match.
 
         Returns
         -------
         Any
             Object with tensors converted to RTensors
         """
+        tensor_memo = {} if preserve_tensor_aliases else None
+        return RTensor._remotize_recursive(obj, node_addr, tensor_memo)
+
+    @staticmethod
+    def _remotize_recursive(
+        obj: Any,
+        node_addr: str,
+        tensor_memo: dict[int, tuple[torch.Tensor, RTensor]] | None,
+    ) -> Any:
         if obj is None:
             return None
 
         if isinstance(obj, torch.Tensor):
+            tensor_id = id(obj)
+            if tensor_memo is not None and tensor_id in tensor_memo:
+                return tensor_memo[tensor_id][1]
+
             tensor = obj.detach().cpu()
             shard_id = get_backend().store(tensor)
             shard = TensorShardInfo(
                 shard_id=shard_id,
                 node_addr=node_addr,
             )
-            return RTensor(shard=shard, data=tensor.to("meta"))
+            remote_tensor = RTensor(shard=shard, data=tensor.to("meta"))
+            if tensor_memo is not None:
+                # Compaction creates temporary tensor objects. Keep them alive
+                # until this root call ends so their Python IDs cannot be reused.
+                tensor_memo[tensor_id] = (obj, remote_tensor)
+            return remote_tensor
 
         if isinstance(obj, dict):
             # Compact trajectory dicts by trimming padding before storage.
@@ -427,27 +452,41 @@ class RTensor:
                 )
                 if compacted is not None:
                     obj = compacted[0]
-            return {k: RTensor.remotize(v, node_addr=node_addr) for k, v in obj.items()}
+            return {
+                k: RTensor._remotize_recursive(v, node_addr, tensor_memo)
+                for k, v in obj.items()
+            }
 
         if isinstance(obj, list):
-            return [RTensor.remotize(item, node_addr=node_addr) for item in obj]
+            return [
+                RTensor._remotize_recursive(item, node_addr, tensor_memo)
+                for item in obj
+            ]
 
         if isinstance(obj, tuple):
-            return tuple(RTensor.remotize(item, node_addr=node_addr) for item in obj)
+            return tuple(
+                RTensor._remotize_recursive(item, node_addr, tensor_memo)
+                for item in obj
+            )
 
         return obj
 
     @staticmethod
-    def localize(obj: Any) -> Any:
+    def localize(obj: Any, *, preserve_tensor_aliases: bool = False) -> Any:
         """Convert RTensors to local tensors in nested structures.
 
         Inverse of remotize() - fetches remote data and converts to local tensors.
         All remote fetches are batched concurrently for performance.
+        When ``preserve_tensor_aliases`` is enabled, RTensors that reference the
+        same shard are fetched once and resolve to the same local tensor object.
 
         Parameters
         ----------
         obj : Any
             Object potentially containing RTensors
+        preserve_tensor_aliases : bool, default=False
+            Preserve aliases represented by repeated shard IDs within this root
+            call. The default retains the existing localization behavior.
 
         Returns
         -------
@@ -457,6 +496,10 @@ class RTensor:
         # Pre-fetch all remote tensors concurrently
         rtensors: list[RTensor] = []
         RTensor._collect_all(obj, rtensors)
+        if preserve_tensor_aliases:
+            RTensor._localize_preserving_aliases(rtensors)
+            return RTensor._localize_recursive(obj)
+
         meta_rtensors = [rt for rt in rtensors if rt.data.is_meta]
         if meta_rtensors:
             # Resolve as many as possible from the client-side fetch buffer.
@@ -480,6 +523,46 @@ class RTensor:
 
         # Recursively replace RTensors with local tensors (all buffer hits now)
         return RTensor._localize_recursive(obj)
+
+    @staticmethod
+    def _localize_preserving_aliases(rtensors: list[RTensor]) -> None:
+        """Resolve each shard once and assign its tensor to every reference."""
+        references_by_shard: dict[Any, list[RTensor]] = {}
+        for rtensor in rtensors:
+            references_by_shard.setdefault(rtensor.shard.shard_id, []).append(rtensor)
+
+        misses: dict[Any, list[RTensor]] = {}
+
+        with _fetch_buffer_lock:
+            for shard_id, references in references_by_shard.items():
+                tensor = next(
+                    (
+                        rtensor.data
+                        for rtensor in references
+                        if not rtensor.data.is_meta
+                    ),
+                    None,
+                )
+                if tensor is None:
+                    tensor = _fetch_buffer.get(shard_id)
+
+                if tensor is not None:
+                    for rtensor in references:
+                        rtensor.data = tensor
+                else:
+                    misses[shard_id] = references
+
+        if not misses:
+            return
+
+        representatives = [references[0] for references in misses.values()]
+        results = get_backend().fetch([rtensor.shard for rtensor in representatives])
+        with _fetch_buffer_lock:
+            for references, tensor in zip(misses.values(), results, strict=True):
+                shard_id = references[0].shard.shard_id
+                _fetch_buffer[shard_id] = tensor
+                for rtensor in references:
+                    rtensor.data = tensor
 
     @staticmethod
     def _collect_all(obj: Any, result: list[RTensor]) -> None:

--- a/areal/infra/workflow_context.py
+++ b/areal/infra/workflow_context.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import aiohttp
 import httpx
 
+from areal.infra.processor_cache import ProcessorCallCache
 from areal.infra.utils.concurrent import register_loop_cleanup
 from areal.infra.utils.http import (
     DEFAULT_REQUEST_TIMEOUT,
@@ -31,10 +32,21 @@ class WorkflowContext:
         Whether the workflow is running in evaluation mode.
     task_id : int | None
         The task ID assigned by the workflow executor.
+    sample_idx : int | None
+        Index of this sample within its rollout group, when the workflow runs
+        under a grouped workflow. Gives group members a stable identity that
+        does not depend on completion order.
+    group_size : int
+        Number of samples in the current rollout group.
+    processor_cache : ProcessorCallCache | None
+        Group-scoped cache shared by candidate workflows in the same process.
     """
 
     is_eval: bool = False
     task_id: int | None = None
+    sample_idx: int | None = None
+    group_size: int = 1
+    processor_cache: ProcessorCallCache | None = None
 
 
 _current_context: ContextVar[WorkflowContext] = ContextVar(

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -28,6 +28,7 @@ from areal.utils.data import (
     KLEstimator,
     Normalization,
     batched_call,
+    is_multi_modal_key,
     split_padded_tensor_dict_into_mb_list,
 )
 from areal.utils.functional import (
@@ -372,9 +373,55 @@ class PPOActorController(TrainController):
         )
 
     def compute_advantages(self, *args, **kwargs):
-        return self._custom_function_call(
-            "compute_advantages", *args, rpc_meta={"broadcast": True}, **kwargs
+        if (
+            self.train_alloc.backend != "megatron"
+            or not args
+            or not isinstance(args[0], list)
+            or not all(isinstance(item, dict) for item in args[0])
+        ):
+            return self._custom_function_call(
+                "compute_advantages", *args, rpc_meta={"broadcast": True}, **kwargs
+            )
+
+        data = args[0]
+        multi_modal_payloads = [
+            {key: value for key, value in item.items() if is_multi_modal_key(key)}
+            for item in data
+        ]
+        if not any(multi_modal_payloads):
+            return self._custom_function_call(
+                "compute_advantages", *args, rpc_meta={"broadcast": True}, **kwargs
+            )
+
+        # Advantage computation never consumes vision inputs. Keep the original
+        # RTensor references on the controller so the grouped image shards do
+        # not make an unnecessary worker round trip before ppo_update.
+        rpc_data = [
+            {key: value for key, value in item.items() if not is_multi_modal_key(key)}
+            for item in data
+        ]
+        results = self._custom_function_call(
+            "compute_advantages",
+            rpc_data,
+            *args[1:],
+            rpc_meta={"broadcast": True},
+            **kwargs,
         )
+        if not isinstance(results, list) or len(results) != len(multi_modal_payloads):
+            raise RuntimeError(
+                "Megatron compute_advantages returned an invalid trajectory batch: "
+                f"expected {len(multi_modal_payloads)} items, got "
+                f"{type(results).__name__} of length "
+                f"{len(results) if isinstance(results, list) else 'unknown'}"
+            )
+        for result, payload in zip(results, multi_modal_payloads, strict=True):
+            if not isinstance(result, dict):
+                raise RuntimeError(
+                    "Megatron compute_advantages returned a non-dict trajectory: "
+                    f"{type(result).__name__}"
+                )
+            result.update(payload)
+        return results
 
     def ppo_update(self, *args, **kwargs) -> None:
         self._custom_function_call(

--- a/areal/workflow/vision_rlvr.py
+++ b/areal/workflow/vision_rlvr.py
@@ -9,6 +9,7 @@ from transformers import AutoProcessor, PreTrainedTokenizerFast
 
 from areal.api import AsyncRewardWrapper, InferenceEngine, ModelRequest, ModelResponse
 from areal.api.cli_args import GenerationHyperparameters
+from areal.infra import workflow_context
 from areal.utils import logging
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.hf_utils import collapsed_prompt_token_ids
@@ -115,12 +116,30 @@ class VisionRLVRWorkflow(RLVRWorkflow):
             self.async_reward_fn = AsyncRewardWrapper(self.reward_fn)
 
         processor_callable = cast(Callable[..., dict[str, Any]], self.processor)
-        processed_input = processor_callable(
-            images=data["images"],
-            text=data["messages"],
-            padding=False,
-            return_tensors="pt",
-        )
+
+        def process_input() -> dict[str, Any]:
+            return processor_callable(
+                images=data["images"],
+                text=data["messages"],
+                padding=False,
+                return_tensors="pt",
+            )
+
+        processor_cache = workflow_context.get().processor_cache
+        if processor_cache is None:
+            processed_input = process_input()
+        else:
+            cache_key = processor_cache.make_key(
+                "vision_rlvr",
+                id(self.processor),
+                id(data),
+            )
+            cached_input = await processor_cache.aget_or_compute(
+                cache_key, process_input
+            )
+            # Containers remain private to each candidate. Tensor values are treated
+            # as immutable and intentionally shared within the rollout group.
+            processed_input = dict(cached_input)
 
         input_ids: list[int] = processed_input["input_ids"].tolist()[0]
         mm_token_type_ids: list[int] = processed_input["mm_token_type_ids"].tolist()[0]

--- a/tests/experimental/openai/test_proxy_rollout_server.py
+++ b/tests/experimental/openai/test_proxy_rollout_server.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 import threading
 
 import pytest
+import torch
 
 from areal.experimental.openai.proxy import proxy_rollout_server as srv
-from areal.experimental.openai.proxy.server import SessionData
+from areal.experimental.openai.proxy.server import SessionData, deserialize_interactions
+from areal.experimental.openai.proxy.tensor_reference import (
+    GroupTensorStoreRegistry,
+    SharedTensorResolver,
+)
+from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.infra.processor_cache import ProcessorCacheRegistry
+from areal.infra.rpc.serialization import deserialize_value
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -26,6 +34,8 @@ def _reset_server_globals(monkeypatch):
     monkeypatch.setattr(srv, "_admin_api_key", _ADMIN_KEY)
     monkeypatch.setattr(srv, "_lock", threading.Lock())
     monkeypatch.setattr(srv, "_last_cleanup_time", 0.0)
+    monkeypatch.setattr(srv, "_processor_cache_registry", ProcessorCacheRegistry())
+    monkeypatch.setattr(srv, "_group_tensor_store_registry", GroupTensorStoreRegistry())
 
 
 httpx = pytest.importorskip("httpx")
@@ -205,6 +215,140 @@ class TestExportTrajectories:
             )
             assert resp_export.status_code == 200
             assert "interactions" in resp_export.json()
+
+    @pytest.mark.asyncio
+    async def test_group_exports_share_multimodal_tensor_reference(self):
+        """Two grouped sessions should export refs and fetch one tensor payload."""
+        group_id = "train:task-1"
+        pixel_values = torch.arange(12).reshape(1, 3, 2, 2)
+
+        for sample_idx in range(2):
+            session_id = f"task-1:{sample_idx}-0"
+            session = SessionData(
+                session_id=session_id,
+                processor_cache_group_id=group_id,
+            )
+            interaction = InteractionWithTokenLogpReward()
+            interaction.interaction_id = f"interaction-{sample_idx}"
+            interaction.messages = [{"role": "user", "content": "question"}]
+            interaction.output_message_list = [
+                {"role": "assistant", "content": "answer"}
+            ]
+            interaction.reward = 1.0
+            interaction._cache = {
+                "input_ids": torch.tensor([[sample_idx, 2]]),
+                "multi_modal_input": [{"pixel_values": pixel_values}],
+            }
+            session.completions[interaction.interaction_id] = interaction
+            session.finish()
+            srv._session_cache[session_id] = session
+
+        async with _client() as client:
+            responses = []
+            for sample_idx in range(2):
+                response = await client.post(
+                    "/export_trajectories",
+                    headers=_admin_headers(),
+                    json={
+                        "session_id": f"task-1:{sample_idx}-0",
+                        "supports_shared_tensor_references": True,
+                    },
+                )
+                assert response.status_code == 200
+                responses.append(response.json())
+
+            first_item = next(
+                iter(responses[0]["interactions"]["interactions"].values())
+            )
+            second_item = next(
+                iter(responses[1]["interactions"]["interactions"].values())
+            )
+            first_ref = first_item["multi_modal_input"][0]["pixel_values"]
+            second_ref = second_item["multi_modal_input"][0]["pixel_values"]
+            assert first_ref == second_ref
+            assert responses[0]["tensor_reference_group_id"] == group_id
+            assert "data" not in first_ref
+
+            fetch_response = await client.post(
+                "/rl/fetch_shared_tensors",
+                headers=_admin_headers(),
+                json={"group_id": group_id, "ref_ids": [first_ref["ref_id"]]},
+            )
+
+        assert fetch_response.status_code == 200
+        fetched = deserialize_value(fetch_response.json()["tensors"])
+        assert list(fetched) == [first_ref["ref_id"]]
+        torch.testing.assert_close(
+            fetched[first_ref["ref_id"]], pixel_values, rtol=0, atol=0
+        )
+        resolver = SharedTensorResolver()
+        fetches = []
+
+        async def fetch(ref_ids):
+            fetches.append(ref_ids)
+            return fetched
+
+        restored = [
+            deserialize_interactions(
+                await resolver.resolve(
+                    response["interactions"], group_id=group_id, fetch=fetch
+                )
+            )
+            for response in responses
+        ]
+        images = [
+            next(iter(items.values())).to_tensor_dict()["multi_modal_input"][0][
+                "pixel_values"
+            ]
+            for items in restored
+        ]
+        assert images[0] is images[1]
+        assert len(fetches) == 1
+
+    @pytest.mark.asyncio
+    async def test_group_export_without_reference_capability_keeps_inline_tensor(self):
+        """Legacy clients should continue receiving inline multimodal tensors."""
+        pixel_values = torch.arange(4)
+        session = SessionData(
+            session_id="legacy-session",
+            processor_cache_group_id="train:legacy-task",
+        )
+        interaction = InteractionWithTokenLogpReward()
+        interaction.interaction_id = "legacy-interaction"
+        interaction.messages = [{"role": "user", "content": "question"}]
+        interaction.output_message_list = [{"role": "assistant", "content": "answer"}]
+        interaction.reward = 1.0
+        interaction._cache = {
+            "input_ids": torch.tensor([[1, 2]]),
+            "multi_modal_input": [{"pixel_values": pixel_values}],
+        }
+        session.completions[interaction.interaction_id] = interaction
+        session.finish()
+        srv._session_cache[session.session_id] = session
+
+        async with _client() as client:
+            response = await client.post(
+                "/export_trajectories",
+                headers=_admin_headers(),
+                json={"session_id": session.session_id},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["interactions"]["__format__"] == "mm-blobs-v1"
+        serialized_image = next(iter(data["interactions"]["blobs"].values()))
+        assert serialized_image["type"] == "tensor"
+        assert serialized_image["data"] is not None
+        assert data["tensor_reference_group_id"] is None
+        restored = deserialize_interactions(data["interactions"])
+        torch.testing.assert_close(
+            restored["legacy-interaction"].to_tensor_dict()["multi_modal_input"][0][
+                "pixel_values"
+            ],
+            pixel_values,
+            rtol=0,
+            atol=0,
+        )
 
     @pytest.mark.asyncio
     async def test_export_rejects_non_admin_key(self, monkeypatch):

--- a/tests/experimental/openai/test_tensor_reference.py
+++ b/tests/experimental/openai/test_tensor_reference.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import torch
+
+from areal.experimental.openai.proxy.server import deserialize_interactions
+from areal.experimental.openai.proxy.tensor_reference import (
+    GroupTensorStore,
+    GroupTensorStoreRegistry,
+    SharedTensorResolver,
+)
+from areal.utils.data import concat_padded_tensors
+
+
+def _trajectory(
+    *, input_ids: torch.Tensor, pixel_values: torch.Tensor
+) -> dict[str, Any]:
+    return {
+        "input_ids": input_ids,
+        "multi_modal_input": [
+            {
+                "pixel_values": pixel_values,
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            }
+        ],
+    }
+
+
+def test_group_tensor_store_shared_image_returns_same_reference():
+    """Shared image tensors should use one ref while text remains untouched."""
+    store = GroupTensorStore()
+    pixel_values = torch.arange(12).reshape(1, 3, 2, 2)
+    first_ids = torch.tensor([[1, 2]])
+    second_ids = torch.tensor([[1, 3]])
+
+    first = store.encode_multimodal_tensors(
+        _trajectory(input_ids=first_ids, pixel_values=pixel_values)
+    )
+    second = store.encode_multimodal_tensors(
+        _trajectory(input_ids=second_ids, pixel_values=pixel_values)
+    )
+
+    first_ref = first["multi_modal_input"][0]["pixel_values"]
+    second_ref = second["multi_modal_input"][0]["pixel_values"]
+    assert first_ref == second_ref
+    assert first["input_ids"] is first_ids
+    assert second["input_ids"] is second_ids
+    fetched = store.fetch([first_ref["ref_id"]])
+    assert fetched[first_ref["ref_id"]] is pixel_values
+
+
+def test_group_tensor_store_equal_distinct_images_return_distinct_references():
+    """Equal-valued image tensors must not be merged without shared identity."""
+    store = GroupTensorStore()
+    first_image = torch.arange(4)
+    second_image = first_image.clone()
+
+    first = store.encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": first_image}]}
+    )
+    second = store.encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": second_image}]}
+    )
+
+    assert (
+        first["multi_modal_input"][0]["pixel_values"]["ref_id"]
+        != second["multi_modal_input"][0]["pixel_values"]["ref_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_tensor_resolver_concurrent_sessions_fetches_reference_once():
+    """Concurrent session exports should share one fetch and one tensor object."""
+    resolver = SharedTensorResolver()
+    ref = {"type": "areal_shared_tensor", "ref_id": "tensor-0"}
+    tensor = torch.arange(8)
+    fetch_calls: list[list[str]] = []
+    allow_fetch = asyncio.Event()
+
+    async def fetch(ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        fetch_calls.append(ref_ids)
+        await allow_fetch.wait()
+        return {"tensor-0": tensor}
+
+    def serialized_interaction(interaction_id: str) -> dict[str, Any]:
+        return {
+            interaction_id: {
+                "tensor_dict": {
+                    "input_ids": torch.tensor([[1, 2]]),
+                    "multi_modal_input": [{"pixel_values": ref}],
+                },
+                "reward": 1.0,
+                "interaction_id": interaction_id,
+            }
+        }
+
+    first_task = asyncio.create_task(
+        resolver.resolve(
+            serialized_interaction("interaction-0"),
+            group_id="train:task-1",
+            fetch=fetch,
+        )
+    )
+    await asyncio.sleep(0)
+    second_task = asyncio.create_task(
+        resolver.resolve(
+            serialized_interaction("interaction-1"),
+            group_id="train:task-1",
+            fetch=fetch,
+        )
+    )
+    await asyncio.sleep(0)
+    allow_fetch.set()
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert fetch_calls == [["tensor-0"]]
+    first_interaction = deserialize_interactions(first)["interaction-0"]
+    second_interaction = deserialize_interactions(second)["interaction-1"]
+    first_image = first_interaction.to_tensor_dict()["multi_modal_input"][0][
+        "pixel_values"
+    ]
+    second_image = second_interaction.to_tensor_dict()["multi_modal_input"][0][
+        "pixel_values"
+    ]
+    assert first_image is tensor
+    assert second_image is tensor
+    assert first_image is second_image
+
+    grouped = concat_padded_tensors(
+        [first_interaction.to_tensor_dict(), second_interaction.to_tensor_dict()]
+    )
+    assert grouped["multi_modal_input"][0]["pixel_values"] is tensor
+    assert grouped["multi_modal_input"][1]["pixel_values"] is tensor
+
+
+@pytest.mark.asyncio
+async def test_shared_tensor_resolver_ignores_reference_marker_in_text_payload():
+    """Reference-like user text must not enter multimodal tensor resolution."""
+    resolver = SharedTensorResolver()
+    value = {
+        "messages": [
+            {
+                "role": "user",
+                "content": {
+                    "type": "areal_shared_tensor",
+                    "ref_id": "user-provided-value",
+                },
+            }
+        ]
+    }
+
+    async def unexpected_fetch(_ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        raise AssertionError("text payload must not fetch shared tensors")
+
+    resolved = await resolver.resolve(
+        value,
+        group_id="train:task-1",
+        fetch=unexpected_fetch,
+    )
+
+    assert resolved is value
+
+
+def test_group_tensor_store_registry_discard_removes_references():
+    """Finalizing a group should release all proxy-side tensor references."""
+    registry = GroupTensorStoreRegistry()
+    store = registry.get_or_create("train:task-1")
+    encoded = store.encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": torch.arange(4)}]}
+    )
+    ref_id = encoded["multi_modal_input"][0]["pixel_values"]["ref_id"]
+
+    registry.discard("train:task-1")
+
+    with pytest.raises(KeyError, match="Unknown shared tensor group"):
+        registry.fetch("train:task-1", [ref_id])
+
+
+@pytest.mark.asyncio
+async def test_staggered_exports_after_cleanup_resolve_new_store_tensors(monkeypatch):
+    """A recreated store must not collide with an earlier export's cached refs."""
+    now = 0.0
+    monkeypatch.setattr(
+        "areal.experimental.openai.proxy.tensor_reference.time.monotonic", lambda: now
+    )
+    registry = GroupTensorStoreRegistry()
+    resolver = SharedTensorResolver()
+    group_id = "train:staggered"
+    fetch_calls = []
+
+    async def fetch(ref_ids: list[str]) -> dict[str, torch.Tensor]:
+        fetch_calls.append(ref_ids)
+        return registry.fetch(group_id, ref_ids)
+
+    first = registry.get_or_create(group_id).encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": torch.tensor([1])}]}
+    )
+    resolved_first = await resolver.resolve(first, group_id=group_id, fetch=fetch)
+
+    now = 61.0
+    registry.discard_stale(timeout_seconds=60)
+    with pytest.raises(KeyError, match="Unknown shared tensor group"):
+        registry.fetch(group_id, [])
+
+    later = registry.get_or_create(group_id).encode_multimodal_tensors(
+        {"multi_modal_input": [{"pixel_values": torch.tensor([99])}]}
+    )
+    first_ref = first["multi_modal_input"][0]["pixel_values"]["ref_id"]
+    later_ref = later["multi_modal_input"][0]["pixel_values"]["ref_id"]
+    assert later_ref != first_ref
+    with pytest.raises(KeyError, match="Unknown shared tensor references"):
+        registry.fetch(group_id, [first_ref])
+
+    resolved_later = await resolver.resolve(later, group_id=group_id, fetch=fetch)
+    resolved_again = await resolver.resolve(later, group_id=group_id, fetch=fetch)
+
+    assert fetch_calls == [[first_ref], [later_ref]]
+    torch.testing.assert_close(
+        resolved_first["multi_modal_input"][0]["pixel_values"],
+        torch.tensor([1]),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        resolved_later["multi_modal_input"][0]["pixel_values"],
+        torch.tensor([99]),
+        rtol=0,
+        atol=0,
+    )
+    assert (
+        resolved_again["multi_modal_input"][0]["pixel_values"]
+        is resolved_later["multi_modal_input"][0]["pixel_values"]
+    )

--- a/tests/experimental/openai/test_vision_processor_cache.py
+++ b/tests/experimental/openai/test_vision_processor_cache.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+import torch
+
+from tests.experimental.openai.test_vision_export import _EchoEngine
+from tests.experimental.openai.vision_stubs import (
+    IMAGE_PAD_ID,
+    PATCHES_PER_IMAGE,
+    StubProcessor,
+    StubTokenizer,
+    image_data_uri,
+    make_image,
+    user_message_with_image,
+)
+
+from areal.experimental.openai import ArealOpenAI
+from areal.experimental.openai.client import (
+    _acached_vision_prompt,
+    concat_vision_prompt_with_parent,
+)
+from areal.infra.processor_cache import ProcessorCallCache
+
+
+class CountingProcessor(StubProcessor):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        return super().__call__(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["hf", "concat"])
+@pytest.mark.parametrize("api", ["chat", "responses"])
+async def test_grouped_proxy_prompts_share_processing_and_keep_collapsed_tokens(
+    mode, api
+):
+    tokenizer = StubTokenizer()
+    processor = CountingProcessor()
+    cache = ProcessorCallCache()
+    clients = [
+        ArealOpenAI(
+            engine=_EchoEngine(tokenizer),
+            tokenizer=tokenizer,
+            processor=processor,
+            chat_template_type=mode,
+            api_key="test",
+        )
+        for _ in range(2)
+    ]
+    image = make_image(31)
+
+    async def generate(client):
+        if api == "chat":
+            response = await client.chat.completions.create(
+                messages=[user_message_with_image(image, "describe")],
+                model="default",
+                max_completion_tokens=8,
+                processor_cache=cache,
+            )
+        else:
+            response = await client.responses.create(
+                input=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_image", "image_url": image_data_uri(image)},
+                            {"type": "input_text", "text": "describe"},
+                        ],
+                    }
+                ],
+                model="default",
+                max_output_tokens=8,
+                tools=[],
+                processor_cache=cache,
+            )
+        return client.get_interaction(response.id)
+
+    try:
+        first, second = await asyncio.gather(*(generate(client) for client in clients))
+        assert processor.calls == 1
+        assert first.multi_modal_input is not second.multi_modal_input
+        assert first.multi_modal_input[0] is not second.multi_modal_input[0]
+        assert (
+            first.multi_modal_input[0]["pixel_values"]
+            is second.multi_modal_input[0]["pixel_values"]
+        )
+        for interaction in (first, second):
+            assert (
+                interaction.model_response.input_tokens.count(IMAGE_PAD_ID)
+                == PATCHES_PER_IMAGE
+            )
+            if mode == "concat":
+                assert interaction.collapsed_input_ids.count(IMAGE_PAD_ID) == 1
+        first.multi_modal_input[0]["extra"] = torch.tensor([1])
+        assert "extra" not in second.multi_modal_input[0]
+    finally:
+        await asyncio.gather(*(client.close() for client in clients))
+
+
+@pytest.mark.asyncio
+async def test_concat_cache_distinguishes_actual_parent_tokens():
+    tokenizer = StubTokenizer()
+    processor = CountingProcessor()
+    client = ArealOpenAI(
+        engine=_EchoEngine(tokenizer),
+        tokenizer=tokenizer,
+        processor=processor,
+        chat_template_type="concat",
+        api_key="test",
+    )
+    try:
+        response = await client.chat.completions.create(
+            messages=[user_message_with_image(make_image(7), "describe")],
+            model="default",
+            max_completion_tokens=8,
+        )
+        parent = client.get_interaction(response.id)
+        equal_parent = deepcopy(parent)
+        changed_parent = deepcopy(parent)
+        changed_parent.model_response.output_tokens[0] = 77
+        messages = [{"role": "user", "content": "continue"}]
+        cache = ProcessorCallCache()
+        before = processor.calls
+
+        async def prepare(candidate):
+            return await _acached_vision_prompt(
+                cache,
+                concat_vision_prompt_with_parent,
+                messages,
+                candidate,
+                tokenizer,
+                processor,
+            )
+
+        first, equal, changed = await asyncio.gather(
+            prepare(parent), prepare(equal_parent), prepare(changed_parent)
+        )
+        assert processor.calls - before == 2
+        assert first.input_ids == equal.input_ids
+        assert first.input_ids != changed.input_ids
+        assert (
+            first.multi_modal_input[0]["pixel_values"]
+            is equal.multi_modal_input[0]["pixel_values"]
+        )
+        expected = list(equal.collapsed_input_ids)
+        first.collapsed_input_ids.append(999)
+        assert equal.collapsed_input_ids == expected
+    finally:
+        await client.close()

--- a/tests/infra/rpc/test_engine_validation.py
+++ b/tests/infra/rpc/test_engine_validation.py
@@ -1,6 +1,7 @@
 import pytest
 from flask import Flask
 
+from areal.infra.rpc.guard import engine_blueprint
 from areal.infra.rpc.guard.app import GuardState
 from areal.infra.rpc.guard.engine_blueprint import engine_bp
 
@@ -44,3 +45,73 @@ def test_set_env_invalid_json(client):
     # Sending a string where an object is expected for 'env'
     resp = client.post("/set_env", json={"env": "not-a-dict"})
     assert resp.status_code == 400
+
+
+@pytest.mark.parametrize(
+    (
+        "method",
+        "cpu_staged_rpc_methods",
+        "expected_localize",
+        "expected_remotize",
+    ),
+    [
+        ("echo", frozenset(), [False, False], False),
+        ("echo", frozenset({"echo"}), [False, False], False),
+        ("wait_for_task", frozenset(), [False, False], True),
+    ],
+)
+def test_call_engine_scopes_alias_preservation_to_supported_v1_boundaries(
+    client,
+    monkeypatch,
+    method,
+    cpu_staged_rpc_methods,
+    expected_localize,
+    expected_remotize,
+):
+    """Only grouped rollout outputs preserve aliases without CPU staging."""
+
+    class FakeEngine:
+        def __init__(self):
+            self.cpu_staged_rpc_methods = cpu_staged_rpc_methods
+
+        def echo(self, value):
+            return value
+
+        def wait_for_task(self, value):
+            return value
+
+    localize_calls = []
+    remotize_calls = []
+
+    def fake_localize(obj, *, preserve_tensor_aliases=False):
+        localize_calls.append(preserve_tensor_aliases)
+        return obj
+
+    def fake_remotize(obj, node_addr, *, preserve_tensor_aliases=False):
+        remotize_calls.append(preserve_tensor_aliases)
+        return obj
+
+    monkeypatch.setitem(engine_blueprint._engines, "test", FakeEngine())
+    monkeypatch.setattr(
+        engine_blueprint, "_submit_to_engine_thread", lambda _name, func: func()
+    )
+    monkeypatch.setattr(
+        engine_blueprint.RTensor, "localize", staticmethod(fake_localize)
+    )
+    monkeypatch.setattr(
+        engine_blueprint.RTensor, "remotize", staticmethod(fake_remotize)
+    )
+
+    response = client.post(
+        "/call",
+        json={
+            "method": method,
+            "engine_name": "test",
+            "args": ["payload"],
+            "kwargs": {},
+        },
+    )
+
+    assert response.status_code == 200
+    assert localize_calls == expected_localize
+    assert remotize_calls == [expected_remotize]

--- a/tests/test_grouped_rollout_workflow.py
+++ b/tests/test_grouped_rollout_workflow.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from tests.experimental.openai.vision_stubs import (
+    IMAGE_PLACEHOLDER,
+    StubProcessor,
+    StubTokenizer,
+    make_image,
+)
+
+from areal.api import ModelResponse, RolloutWorkflow
+from areal.api.cli_args import GenerationHyperparameters
+from areal.infra import workflow_context
+from areal.infra.remote_inf_engine import GroupedRolloutWorkflow
+from areal.workflow.vision_rlvr import VisionRLVRWorkflow
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["child_error", "child_cancel", "parent_cancel"])
+async def test_group_failure_cancels_siblings_before_finalizing(failure):
+    """Failed or cancelled groups must not wait forever on unfinished siblings."""
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    never_set = asyncio.Event()
+    finalized = []
+    original_error = ValueError("candidate failed")
+
+    class FailingWorkflow(RolloutWorkflow):
+        async def arun_episode(self, engine, data):
+            if workflow_context.get().sample_idx == 0:
+                await sibling_started.wait()
+                if failure == "child_error":
+                    raise original_error
+                if failure == "child_cancel":
+                    raise asyncio.CancelledError()
+                await never_set.wait()
+            else:
+                sibling_started.set()
+                try:
+                    await never_set.wait()
+                except asyncio.CancelledError:
+                    # Include async teardown to verify it is drained as well.
+                    await asyncio.sleep(0)
+                    sibling_cancelled.set()
+                    raise
+
+        async def _afinalize_processor_cache_group(self, context):
+            finalized.append(sibling_cancelled.is_set())
+
+    workflow = GroupedRolloutWorkflow(FailingWorkflow(), group_size=2, logger=Mock())
+    task = asyncio.create_task(workflow.arun_episode(engine=None, data={}))
+    try:
+        await asyncio.wait_for(sibling_started.wait(), timeout=1)
+        if failure == "parent_cancel":
+            task.cancel()
+        error_type = ValueError if failure == "child_error" else asyncio.CancelledError
+        with pytest.raises(error_type) as exc_info:
+            # Shield keeps the timeout from making the broken implementation
+            # pass by cancelling its otherwise indefinitely waiting siblings.
+            await asyncio.wait_for(asyncio.shield(task), timeout=1)
+        if failure == "child_error":
+            assert exc_info.value is original_error
+        assert sibling_cancelled.is_set()
+        assert finalized == [True]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_grouped_vision_rollouts_share_images_only_within_group(monkeypatch):
+    """Identical candidates share processing; the next group computes afresh."""
+    calls = []
+
+    class Processor(StubProcessor):
+        def __call__(self, *args, **kwargs):
+            calls.append(1)
+            kwargs["text"] = [kwargs["text"]]
+            kwargs["images"] = [kwargs["images"]]
+            return super().__call__(*args, **kwargs)
+
+    tokenizer = StubTokenizer()
+    workflow = VisionRLVRWorkflow(
+        reward_fn=lambda **kwargs: 1,
+        gconfig=GenerationHyperparameters(),
+        tokenizer=tokenizer,
+        processor=Processor(),
+        enable_thinking=False,
+    )
+
+    async def collect(engine, request, prompt, data):
+        assert request.collapsed_input_ids is not None
+        return ModelResponse(
+            input_tokens=list(request.input_ids),
+            output_tokens=[11],
+            output_logprobs=[-0.1],
+            output_versions=[0],
+            stop_reason="length",
+            tokenizer=tokenizer,
+        ), 1.0
+
+    monkeypatch.setattr(workflow, "_collect_samples", collect)
+    grouped = GroupedRolloutWorkflow(workflow, 4, Mock())
+    data = {"images": make_image(7), "messages": f"{IMAGE_PLACEHOLDER} describe"}
+    first = await grouped.arun_episode(None, data)
+    second = await grouped.arun_episode(None, data)
+    assert calls == [1, 1]
+    for result in (first, second):
+        images = [item["pixel_values"] for item in result["multi_modal_input"]]
+        assert len(images) == 4
+        assert all(image is images[0] for image in images)
+    assert (
+        first["multi_modal_input"][0]["pixel_values"]
+        is not second["multi_modal_input"][0]["pixel_values"]
+    )
+    torch.testing.assert_close(first["input_ids"], second["input_ids"], rtol=0, atol=0)

--- a/tests/test_ppo_actor_controller.py
+++ b/tests/test_ppo_actor_controller.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import torch
+
+from areal.api import ParallelStrategy
+from areal.trainer.ppo.actor import PPOActorController
+
+
+def _make_controller(backend: str) -> PPOActorController:
+    controller = object.__new__(PPOActorController)
+    controller.train_alloc = SimpleNamespace(backend=backend)
+    return controller
+
+
+def test_megatron_compute_advantages_bypasses_multimodal_payload(monkeypatch):
+    """Megatron should keep vision RTensor references on the controller."""
+    controller = _make_controller("megatron")
+    pixel_values = torch.arange(4)
+    image_grid_thw = torch.tensor([[1, 2, 2]])
+    batch = [
+        {
+            "input_ids": torch.tensor([1, 2]),
+            "multi_modal_input": [
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                }
+            ],
+        },
+        {
+            "input_ids": torch.tensor([3, 4]),
+            "multi_modal_input": [
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                }
+            ],
+        },
+    ]
+    captured = {}
+
+    def fake_call(method, rpc_batch, *, rpc_meta):
+        captured["method"] = method
+        captured["batch"] = rpc_batch
+        captured["rpc_meta"] = rpc_meta
+        return [dict(item, advantages=torch.tensor([1.0])) for item in rpc_batch]
+
+    monkeypatch.setattr(controller, "_custom_function_call", fake_call)
+
+    result = controller.compute_advantages(batch)
+
+    assert captured["method"] == "compute_advantages"
+    assert captured["rpc_meta"] == {"broadcast": True}
+    assert all("multi_modal_input" not in item for item in captured["batch"])
+    assert result[0]["multi_modal_input"] is batch[0]["multi_modal_input"]
+    assert result[1]["multi_modal_input"] is batch[1]["multi_modal_input"]
+    assert "multi_modal_input" in batch[0]
+
+
+def test_non_megatron_compute_advantages_keeps_existing_payload(monkeypatch):
+    """Other v1 backends should retain their existing controller behavior."""
+    controller = _make_controller("fsdp")
+    batch = [{"multi_modal_input": [{"pixel_values": torch.arange(4)}]}]
+    expected = [{"status": "unchanged"}]
+    captured = {}
+
+    def fake_call(method, *args, rpc_meta, **kwargs):
+        captured["method"] = method
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        captured["rpc_meta"] = rpc_meta
+        return expected
+
+    monkeypatch.setattr(controller, "_custom_function_call", fake_call)
+
+    result = controller.compute_advantages(batch)
+
+    assert result is expected
+    assert captured["method"] == "compute_advantages"
+    assert captured["args"][0] is batch
+    assert captured["rpc_meta"] == {"broadcast": True}
+
+
+def test_megatron_advantages_reattach_images_after_balanced_dispatch(monkeypatch):
+    """Vision payloads follow original trajectory order after DP result merging."""
+    controller = _make_controller("megatron")
+    controller.train_alloc.parallel = ParallelStrategy(data_parallel_size=2)
+    controller.workers_is_dp_head = [True, False, True, False]
+    batch = [
+        {
+            "input_ids": torch.full((1, length), idx),
+            "attention_mask": torch.ones(1, length, dtype=torch.bool),
+            "multi_modal_input": [{"pixel_values": torch.tensor([idx])}],
+        }
+        for idx, length in enumerate([2, 9, 4, 7])
+    ]
+
+    def dispatch(method, rpc_batch, *, rpc_meta):
+        args, kwargs, indices = controller._prepare_dispatch(rpc_batch)
+        assert [idx for group in indices for idx in group] != list(range(4))
+        assert not kwargs
+        assert all(
+            "multi_modal_input" not in item for group in args[0] for item in group
+        )
+        worker_results = []
+        for group in args[0]:
+            worker_results.extend(
+                (
+                    [
+                        dict(item, advantages=item["input_ids"].float())
+                        for item in group
+                    ],
+                    None,
+                )
+            )
+        return controller._collect_results(worker_results, indices)
+
+    monkeypatch.setattr(controller, "_custom_function_call", dispatch)
+    result = controller.compute_advantages(batch)
+    for idx, item in enumerate(result):
+        assert item["multi_modal_input"] is batch[idx]["multi_modal_input"]
+        torch.testing.assert_close(
+            item["advantages"], batch[idx]["input_ids"].float(), rtol=0, atol=0
+        )

--- a/tests/test_processor_cache.py
+++ b/tests/test_processor_cache.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
+import pytest
+
+from areal.infra.processor_cache import ProcessorCacheRegistry, ProcessorCallCache
+
+
+def test_concurrent_sync_calls_compute_once():
+    cache = ProcessorCallCache()
+    entered = Event()
+    release = Event()
+    calls = []
+
+    def factory():
+        calls.append(1)
+        entered.set()
+        assert release.wait(5)
+        return object()
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(cache.get_or_compute, "key", factory) for _ in range(4)
+        ]
+        try:
+            assert entered.wait(5)
+        finally:
+            release.set()
+        results = [future.result(timeout=5) for future in futures]
+    assert calls == [1]
+    assert all(result is results[0] for result in results)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_does_not_cancel_shared_computation():
+    cache = ProcessorCallCache()
+    release = Event()
+    entered = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    value = object()
+
+    def factory():
+        loop.call_soon_threadsafe(entered.set)
+        assert release.wait(5)
+        return value
+
+    owner = asyncio.create_task(cache.aget_or_compute("key", factory))
+    try:
+        await asyncio.wait_for(entered.wait(), 5)
+        waiter = asyncio.create_task(cache.aget_or_compute("key", factory))
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+    finally:
+        release.set()
+    assert await asyncio.wait_for(owner, 5) is value
+    assert await cache.aget_or_compute("key", lambda: None) is value
+
+
+@pytest.mark.asyncio
+async def test_failed_processor_call_can_retry():
+    cache = ProcessorCallCache()
+
+    def fail():
+        raise ValueError("processor failed")
+
+    with pytest.raises(ValueError, match="processor failed"):
+        await cache.aget_or_compute("key", fail)
+    assert await cache.aget_or_compute("key", lambda: 42) == 42
+
+
+def test_registry_keeps_cache_between_staggered_sessions_and_closes_at_end():
+    registry = ProcessorCacheRegistry()
+    first = registry.acquire("group", 2)
+    value = first.get_or_compute("key", object)
+    registry.release("group")
+    second = registry.acquire("group", 2)
+    assert second is first
+    assert second.get_or_compute("key", object) is value
+    registry.release("group")
+    assert first.get_or_compute("key", object) is not value
+    assert registry.acquire("group", 2) is not first
+
+
+def test_registry_discard_closes_aborted_group():
+    registry = ProcessorCacheRegistry()
+    cache = registry.acquire("group", 4)
+    value = cache.get_or_compute("key", object)
+    registry.discard("group")
+    assert cache.get_or_compute("key", object) is not value
+    registry.release("group")

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 import uuid
+import weakref
 
 import aiohttp
 import orjson
@@ -56,6 +57,23 @@ class _FakeDeleteSession:
         if isinstance(item, BaseException):
             raise item
         return _FakeDeleteResponse(item)
+
+
+class _RecordingRTensorBackend:
+    def __init__(self):
+        self.tensors = {}
+        self.store_calls = []
+        self.fetch_calls = []
+
+    def store(self, tensor):
+        shard_id = f"shard-{len(self.store_calls)}"
+        self.store_calls.append(tensor)
+        self.tensors[shard_id] = tensor
+        return shard_id
+
+    def fetch(self, shards):
+        self.fetch_calls.append(shards)
+        return [self.tensors[shard.shard_id] for shard in shards]
 
 
 @pytest.fixture(scope="module")
@@ -719,8 +737,12 @@ class TestRTensorMemoryCleanup:
 class TestRemotize:
     """Test remotize method with various input types."""
 
-    def test_remotize_list_of_dicts(self, rpc_server):
+    @pytest.mark.parametrize("preserve_tensor_aliases", [False, True])
+    def test_remotize_list_of_dicts(self, monkeypatch, preserve_tensor_aliases):
         """Test remotizing list of dicts with different attention masks."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        monkeypatch.setattr("areal.infra.rpc.rtensor._fetch_buffer", {})
         # Create two trajectory dicts with different seqlens
         traj1 = {
             "attention_mask": torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]]),
@@ -735,7 +757,11 @@ class TestRemotize:
             "logits": torch.randn(3, 5).cpu(),
         }
 
-        result = RTensor.remotize([traj1, traj2], node_addr=rpc_server)
+        result = RTensor.remotize(
+            [traj1, traj2],
+            node_addr="node-a",
+            preserve_tensor_aliases=preserve_tensor_aliases,
+        )
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -748,6 +774,14 @@ class TestRemotize:
         # Verify size matches batch dimension
         assert result[0]["logits"].shape[0] == 2
         assert result[1]["logits"].shape[0] == 3
+
+        for original, remote, seqlen in zip(
+            [traj1, traj2], result, [3, 4], strict=True
+        ):
+            for key in original:
+                torch.testing.assert_close(
+                    remote[key].to_local(), original[key][:, :seqlen], rtol=0, atol=0
+                )
 
     def test_remotize_list_of_tensors(self, rpc_server):
         """Test remotizing list of standalone tensors."""
@@ -908,6 +942,158 @@ class TestRemotize:
         # attention_mask should be trimmed to [[1,1,1],[1,1,0]]
         expected_mask = torch.tensor([[1, 1, 1], [1, 1, 0]])
         assert torch.equal(localized["attention_mask"], expected_mask)
+
+
+class TestRTensorAliasPreservation:
+    def test_remotize_nested_trajectories_retains_temporary_sources(self, monkeypatch):
+        """Compacted sources stay alive across siblings, only until remotize ends."""
+        from areal.utils import data as data_utils
+
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        split_and_unpad = data_utils.split_and_unpad_tensor
+        source_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+        compaction_calls = 0
+
+        def track_compacted_sources(*args, **kwargs):
+            nonlocal compaction_calls
+            # Check lifetime directly, without relying on allocator-dependent
+            # ID reuse to expose an unrelated shard being returned.
+            assert all(ref() is not None for ref in source_refs)
+            compacted = split_and_unpad(*args, **kwargs)
+            source_refs.extend(weakref.ref(value) for value in compacted[0].values())
+            compaction_calls += 1
+            return compacted
+
+        monkeypatch.setattr(
+            data_utils, "split_and_unpad_tensor", track_compacted_sources
+        )
+        first = {
+            "attention_mask": torch.tensor([[1, 1, 0]]),
+            "input_ids": torch.tensor([[1, 2, 0]]),
+        }
+        second = {
+            "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+            "input_ids": torch.tensor([[99, 98, 97, 0]]),
+        }
+
+        result = RTensor.remotize(
+            [first, {"nested": [second]}],
+            node_addr="node-a",
+            preserve_tensor_aliases=True,
+        )
+
+        assert compaction_calls == 2
+        assert len(source_refs) == 4
+        assert all(ref() is None for ref in source_refs)
+        assert len(backend.store_calls) == 4
+        for original, remote, seqlen in (
+            (first, result[0], 2),
+            (second, result[1]["nested"][0], 3),
+        ):
+            for key in original:
+                torch.testing.assert_close(
+                    backend.tensors[remote[key].shard.shard_id],
+                    original[key][:, :seqlen],
+                    rtol=0,
+                    atol=0,
+                )
+
+    def test_remotize_shared_tensor_default_uses_distinct_shards(self, monkeypatch):
+        """Alias preservation should remain opt-in for existing callers."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        tensor = torch.arange(6)
+
+        result = RTensor.remotize([tensor, tensor], node_addr="node-a")
+
+        assert result[0].shard.shard_id != result[1].shard.shard_id
+        assert len(backend.store_calls) == 2
+
+    def test_remotize_shared_multimodal_tensors_stores_each_object_once(
+        self, monkeypatch
+    ):
+        """Shared group image tensors should map to one shard per object."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+
+        pixel_values = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+        image_grid_thw = torch.tensor([[1, 2, 2]])
+        trajectory = {
+            "attention_mask": torch.tensor([[1, 1, 0], [1, 1, 0]]),
+            "multi_modal_input": [
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                },
+                {
+                    "pixel_values": pixel_values,
+                    "image_grid_thw": image_grid_thw,
+                },
+            ],
+        }
+
+        result = RTensor.remotize(
+            trajectory,
+            node_addr="node-a",
+            preserve_tensor_aliases=True,
+        )
+
+        first, second = result["multi_modal_input"]
+        assert first["pixel_values"] is second["pixel_values"]
+        assert first["image_grid_thw"] is second["image_grid_thw"]
+        assert len(backend.store_calls) == 3
+
+    def test_remotize_equal_distinct_tensors_uses_distinct_shards(self, monkeypatch):
+        """Equal values should not merge when tensor identities differ."""
+        backend = _RecordingRTensorBackend()
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        first = torch.arange(6)
+        second = first.clone()
+
+        result = RTensor.remotize(
+            [first, second],
+            node_addr="node-a",
+            preserve_tensor_aliases=True,
+        )
+
+        assert result[0].shard.shard_id != result[1].shard.shard_id
+        assert len(backend.store_calls) == 2
+
+    def test_localize_repeated_shard_fetches_once_and_restores_aliases(
+        self, monkeypatch
+    ):
+        """Repeated shard references should share one fetch and local tensor."""
+        backend = _RecordingRTensorBackend()
+        backend.tensors["shared-image"] = torch.arange(12).reshape(3, 4)
+        monkeypatch.setattr("areal.infra.rpc.rtensor.get_backend", lambda: backend)
+        monkeypatch.setattr("areal.infra.rpc.rtensor._fetch_buffer", {})
+
+        def make_remote_tensor():
+            return RTensor(
+                shard=TensorShardInfo(
+                    shard_id="shared-image",
+                    node_addr="node-a",
+                ),
+                data=torch.empty(3, 4, device="meta"),
+            )
+
+        serialized_payload = serialize_value(
+            {
+                "args": [make_remote_tensor()],
+                "kwargs": {"image": make_remote_tensor()},
+            }
+        )
+        payload = deserialize_value(serialized_payload)
+
+        result = RTensor.localize(
+            payload,
+            preserve_tensor_aliases=True,
+        )
+
+        assert len(backend.fetch_calls) == 1
+        assert len(backend.fetch_calls[0]) == 1
+        assert result["args"][0] is result["kwargs"]["image"]
 
 
 class TestFetchBuffer:


### PR DESCRIPTION
## Description

Backport upstream #1671 to Ascend to reduce repeated image processing and tensor transfers across candidates in the same VLM rollout group. Grouped workflows reuse processor results, proxy exports share image references, and rollout RTensors preserve shared identities. Megatron advantage computation keeps vision payloads on the controller and reattaches their original references before PPO update.

The adaptation preserves Ascend's `mm-blobs-v1` serialization, collapsed prompt tokens, multi-turn token alignment, and existing NPU transfer behavior. It includes the upstream fixes for tensor-reference reuse after store eviction, sibling cancellation before group cleanup, and source-tensor lifetime during RTensor remotization. CPU microbatch staging from #1622 is outside this backport; ordinary training RPC inputs retain their current transfer path.

## Related Issue

Backport of https://github.com/areal-project/AReaL/pull/1671.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `ascend`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):** None.

## Additional Context

Validation: 228 selected regressions passed locally and in the node12 NPU container (Python 3.12.13, torch 2.10.0, torch-npu 2.10.0.post4, Transformers 5.8.1). Coverage includes processor cache concurrency, cancellation, grouped/legacy proxy exports, collapsed and multi-turn prompt handling, RTensor round trips, balanced DP result reattachment, and existing streaming/online proxy behavior. Ascend CPU CI automatically selects all five new test modules.

```bash
python -m pytest -q tests/test_grouped_rollout_workflow.py tests/test_processor_cache.py tests/test_ppo_actor_controller.py tests/test_rtensor.py tests/infra/rpc/test_engine_validation.py tests/experimental/openai/test_proxy_rollout_server.py tests/experimental/openai/test_tensor_reference.py tests/experimental/openai/test_vision_export.py tests/experimental/openai/test_vision_processor_cache.py tests/test_train_controller.py tests/test_vision_rlvr_collapsed_prompt.py tests/experimental/openai/test_streaming_chat_completions.py tests/experimental/openai/test_online_agent.py tests/experimental/openai/test_proxy_gateway.py
pre-commit run --all-files
```

A bounded two-rank NPU probe also passed Gloo CPU broadcast, CPU-to-NPU transfer, HCCL broadcast, and HCCL all-reduce with exact value/dtype checks for BF16 images, integer tokens, and boolean masks. Shared aliases still split during NPU transfer, consistent with retaining the existing transfer path. These checks do not establish a training throughput improvement.
