### PR TITLE
feat(trainer): support score reward clipping and teacher weight normalization in MOPD loss

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -3593,6 +3593,20 @@ class MOPDLossConfig:
         default=5.0,
         metadata={"help": "Positive cap applied to the behavior-policy ratio."},
     )
+    score_reward_min: float | None = field(
+        default=None,
+        metadata={"help": "Optional lower bound applied to the MOPD score reward."},
+    )
+    score_reward_max: float | None = field(
+        default=None,
+        metadata={"help": "Optional upper bound applied to the MOPD score reward."},
+    )
+    normalize_teacher_weights: bool = field(
+        default=False,
+        metadata={
+            "help": "Normalize teacher log-probabilities by teacher weight sum across heterogeneous routes."
+        },
+    )
 
     def __post_init__(self):
         for name in ("rl_coefficient", "distillation_coefficient"):
@@ -3614,6 +3628,28 @@ class MOPDLossConfig:
             raise ValueError(
                 "mopd.loss.importance_ratio_cap must be finite and positive"
             )
+        for name in ("score_reward_min", "score_reward_max"):
+            val = getattr(self, name)
+            if val is not None:
+                if not isinstance(val, (int, float)) or isinstance(val, bool):
+                    raise ValueError(
+                        f"mopd.loss.{name} must be a finite number or None"
+                    )
+                if not math.isfinite(val):
+                    raise ValueError(
+                        f"mopd.loss.{name} must be a finite number, got {val}"
+                    )
+        if (
+            self.score_reward_min is not None
+            and self.score_reward_max is not None
+            and self.score_reward_min > self.score_reward_max
+        ):
+            raise ValueError(
+                f"mopd.loss.score_reward_min ({self.score_reward_min}) cannot exceed "
+                f"mopd.loss.score_reward_max ({self.score_reward_max})"
+            )
+        if not isinstance(self.normalize_teacher_weights, bool):
+            raise ValueError("mopd.loss.normalize_teacher_weights must be a boolean")
 
 
 @dataclass

--- a/areal/trainer/mopd/loss.py
+++ b/areal/trainer/mopd/loss.py
@@ -39,14 +39,19 @@ def mopd_loss_fn(
     loss_mask: torch.Tensor,
     normalization_mask: torch.Tensor | None = None,
     importance_ratio_cap: float = DEFAULT_MOPD_IMPORTANCE_RATIO_CAP,
+    score_reward_min: float | None = None,
+    score_reward_max: float | None = None,
+    normalize_teacher_weights: bool = False,
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Compute a truncated-IS multi-teacher reverse-KL surrogate.
 
     ``teacher_logp_sum`` is ``sum_j(w_j * log pi_Tj)`` and
-    ``teacher_weight_sum`` is ``sum_j(w_j)`` at every response token. Teacher
-    weights are deliberately not normalized. The behavior-policy importance
-    ratio is capped with a stop-gradient weight to prevent exponential
-    overflow while retaining the score-function gradient.
+    ``teacher_weight_sum`` is ``sum_j(w_j)`` at every response token.
+    If ``normalize_teacher_weights`` is True, teacher log-probabilities are
+    normalized by the teacher weight sum to keep reward scales invariant across
+    heterogeneous routes. The behavior-policy importance ratio is capped with
+    a stop-gradient weight to prevent exponential overflow while retaining the
+    score-function gradient.
     """
     if (
         not isinstance(importance_ratio_cap, (int, float))
@@ -55,6 +60,30 @@ def mopd_loss_fn(
         or importance_ratio_cap <= 0
     ):
         raise ValueError("importance_ratio_cap must be a finite positive number")
+    if score_reward_min is not None:
+        if (
+            not isinstance(score_reward_min, (int, float))
+            or isinstance(score_reward_min, bool)
+            or not math.isfinite(score_reward_min)
+        ):
+            raise ValueError("score_reward_min must be a finite number or None")
+    if score_reward_max is not None:
+        if (
+            not isinstance(score_reward_max, (int, float))
+            or isinstance(score_reward_max, bool)
+            or not math.isfinite(score_reward_max)
+        ):
+            raise ValueError("score_reward_max must be a finite number or None")
+    if (
+        score_reward_min is not None
+        and score_reward_max is not None
+        and score_reward_min > score_reward_max
+    ):
+        raise ValueError(
+            f"score_reward_min ({score_reward_min}) cannot exceed score_reward_max ({score_reward_max})"
+        )
+    if not isinstance(normalize_teacher_weights, bool):
+        raise ValueError("normalize_teacher_weights must be a boolean")
     _validate_mopd_tensor_shapes(
         logprobs,
         old_logprobs,
@@ -96,11 +125,39 @@ def mopd_loss_fn(
     bounded_importance_weight = torch.exp(
         detached_log_ratio.clamp(max=math.log(importance_ratio_cap))
     )
-    score_reward = torch.where(
-        mask,
-        detached_teacher_logp - (detached_teacher_weight * safe_logprobs.detach()),
-        torch.zeros_like(logprobs),
+    if normalize_teacher_weights:
+        effective_teacher_weight = torch.where(
+            mask,
+            detached_teacher_weight.clamp_min(1e-8),
+            torch.ones_like(detached_teacher_weight),
+        )
+        score_reward = torch.where(
+            mask,
+            (detached_teacher_logp / effective_teacher_weight) - safe_logprobs.detach(),
+            torch.zeros_like(logprobs),
+        )
+    else:
+        score_reward = torch.where(
+            mask,
+            detached_teacher_logp - (detached_teacher_weight * safe_logprobs.detach()),
+            torch.zeros_like(logprobs),
+        )
+
+    score_reward_min_clipped = (
+        (score_reward < score_reward_min) & mask
+        if score_reward_min is not None
+        else torch.zeros_like(mask)
     )
+    score_reward_max_clipped = (
+        (score_reward > score_reward_max) & mask
+        if score_reward_max is not None
+        else torch.zeros_like(mask)
+    )
+    if score_reward_min is not None or score_reward_max is not None:
+        score_reward = torch.clamp(
+            score_reward, min=score_reward_min, max=score_reward_max
+        )
+
     # At forward time the carrier is exactly one. Its derivative is
     # d log pi_theta, preserving the score-function gradient even when
     # the detached importance ratio was clipped.
@@ -126,6 +183,8 @@ def mopd_loss_fn(
             torch.zeros_like(detached_teacher_weight),
         ),
         "reverse_kl": torch.where(mask, reverse_kl, torch.zeros_like(reverse_kl)),
+        "score_reward_min_clipped": score_reward_min_clipped,
+        "score_reward_max_clipped": score_reward_max_clipped,
     }
     return loss, stats
 
@@ -169,6 +228,9 @@ def compose_mopd_loss(
         loss_mask=loss_mask,
         normalization_mask=normalization_mask,
         importance_ratio_cap=config.importance_ratio_cap,
+        score_reward_min=config.score_reward_min,
+        score_reward_max=config.score_reward_max,
+        normalize_teacher_weights=config.normalize_teacher_weights,
     )
 
     if config.rl_coefficient == 0:

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -783,16 +783,25 @@ def grpo_loss_fn(
             n_valid_tokens=normalization_mask,
             n_mopd_tokens=normalization_mask,
         )
-        stats_tracker.stat(
-            mopd_loss=mopd_stats["loss_per_token"].float(),
-            mopd_reward=mopd_stats["score_reward"].float(),
-            mopd_importance_weight=mopd_stats["importance_weight"].float(),
-            mopd_teacher_weight_sum=mopd_stats["teacher_weight_sum"].float(),
-            new_logp=logprobs.detach(),
-            old_logp=behavior_logp,
-            entropy=entropy.detach().float(),
-            denominator="n_mopd_tokens",
-        )
+        mopd_stat_kwargs = {
+            "mopd_loss": mopd_stats["loss_per_token"].float(),
+            "mopd_reward": mopd_stats["score_reward"].float(),
+            "mopd_importance_weight": mopd_stats["importance_weight"].float(),
+            "mopd_teacher_weight_sum": mopd_stats["teacher_weight_sum"].float(),
+            "new_logp": logprobs.detach(),
+            "old_logp": behavior_logp,
+            "entropy": entropy.detach().float(),
+            "denominator": "n_mopd_tokens",
+        }
+        if "score_reward_min_clipped" in mopd_stats:
+            mopd_stat_kwargs["mopd_score_reward_min_clipped"] = mopd_stats[
+                "score_reward_min_clipped"
+            ].float()
+        if "score_reward_max_clipped" in mopd_stats:
+            mopd_stat_kwargs["mopd_score_reward_max_clipped"] = mopd_stats[
+                "score_reward_max_clipped"
+            ].float()
+        stats_tracker.stat(**mopd_stat_kwargs)
         return loss
 
     old_logp = input_data["logprobs"]
@@ -946,13 +955,22 @@ def grpo_loss_fn(
     if rkl_stat is not None:
         if mopd_stats:
             stats_tracker.denominator(n_mopd_tokens=mopd_normalization_mask.bool())
-            stats_tracker.stat(
-                mopd_loss=mopd_stats["loss_per_token"].float(),
-                mopd_reward=mopd_stats["score_reward"].float(),
-                mopd_importance_weight=mopd_stats["importance_weight"].float(),
-                mopd_teacher_weight_sum=mopd_stats["teacher_weight_sum"].float(),
-                denominator="n_mopd_tokens",
-            )
+            mopd_stat_kwargs = {
+                "mopd_loss": mopd_stats["loss_per_token"].float(),
+                "mopd_reward": mopd_stats["score_reward"].float(),
+                "mopd_importance_weight": mopd_stats["importance_weight"].float(),
+                "mopd_teacher_weight_sum": mopd_stats["teacher_weight_sum"].float(),
+                "denominator": "n_mopd_tokens",
+            }
+            if "score_reward_min_clipped" in mopd_stats:
+                mopd_stat_kwargs["mopd_score_reward_min_clipped"] = mopd_stats[
+                    "score_reward_min_clipped"
+                ].float()
+            if "score_reward_max_clipped" in mopd_stats:
+                mopd_stat_kwargs["mopd_score_reward_max_clipped"] = mopd_stats[
+                    "score_reward_max_clipped"
+                ].float()
+            stats_tracker.stat(**mopd_stat_kwargs)
         else:
             stats_tracker.stat(
                 rkl_loss=rkl_stat,

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -1151,11 +1151,14 @@ Configuration for multi-teacher on-policy distillation.
 
 Coefficients for joint RL and multi-teacher distillation training.
 
-| Parameter                  | Type  | Default | Description                                        |
-| -------------------------- | ----- | ------- | -------------------------------------------------- |
-| `rl_coefficient`           | float | `0.0`   | Coefficient applied to the RL objective.           |
-| `distillation_coefficient` | float | `1.0`   | Coefficient applied to the MOPD objective.         |
-| `importance_ratio_cap`     | float | `5.0`   | Positive cap applied to the behavior-policy ratio. |
+| Parameter                   | Type          | Default | Description                                                                            |
+| --------------------------- | ------------- | ------- | -------------------------------------------------------------------------------------- |
+| `rl_coefficient`            | float         | `0.0`   | Coefficient applied to the RL objective.                                               |
+| `distillation_coefficient`  | float         | `1.0`   | Coefficient applied to the MOPD objective.                                             |
+| `importance_ratio_cap`      | float         | `5.0`   | Positive cap applied to the behavior-policy ratio.                                     |
+| `score_reward_min`          | float \| None | `None`  | Optional lower bound applied to the MOPD score reward.                                 |
+| `score_reward_max`          | float \| None | `None`  | Optional upper bound applied to the MOPD score reward.                                 |
+| `normalize_teacher_weights` | boolean       | `False` | Normalize teacher log-probabilities by teacher weight sum across heterogeneous routes. |
 
 (section-mopd-teacher-engine)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -1149,11 +1149,14 @@ Configuration for multi-teacher on-policy distillation.
 
 Coefficients for joint RL and multi-teacher distillation training.
 
-| Parameter                  | Type  | Default | Description                                        |
-| -------------------------- | ----- | ------- | -------------------------------------------------- |
-| `rl_coefficient`           | float | `0.0`   | Coefficient applied to the RL objective.           |
-| `distillation_coefficient` | float | `1.0`   | Coefficient applied to the MOPD objective.         |
-| `importance_ratio_cap`     | float | `5.0`   | Positive cap applied to the behavior-policy ratio. |
+| Parameter                   | Type          | Default | Description                                                                            |
+| --------------------------- | ------------- | ------- | -------------------------------------------------------------------------------------- |
+| `rl_coefficient`            | float         | `0.0`   | Coefficient applied to the RL objective.                                               |
+| `distillation_coefficient`  | float         | `1.0`   | Coefficient applied to the MOPD objective.                                             |
+| `importance_ratio_cap`      | float         | `5.0`   | Positive cap applied to the behavior-policy ratio.                                     |
+| `score_reward_min`          | float \| None | `None`  | Optional lower bound applied to the MOPD score reward.                                 |
+| `score_reward_max`          | float \| None | `None`  | Optional upper bound applied to the MOPD score reward.                                 |
+| `normalize_teacher_weights` | boolean       | `False` | Normalize teacher log-probabilities by teacher weight sum across heterogeneous routes. |
 
 (section-mopd-teacher-engine)=
 

--- a/tests/test_mopd_config.py
+++ b/tests/test_mopd_config.py
@@ -462,3 +462,32 @@ def test_mopd_and_legacy_teacher_are_mutually_exclusive():
 
     with pytest.raises(ValueError, match="cannot be configured at the same time"):
         _ppo_config(_mopd_config(), teacher=legacy_teacher)
+
+
+def test_mopd_loss_config_score_reward_bounds_and_normalization():
+    # Valid bounds and normalization
+    cfg = MOPDLossConfig(
+        score_reward_min=-10.0,
+        score_reward_max=10.0,
+        normalize_teacher_weights=True,
+    )
+    assert cfg.score_reward_min == -10.0
+    assert cfg.score_reward_max == 10.0
+    assert cfg.normalize_teacher_weights is True
+
+    # Inverted bounds raise ValueError
+    with pytest.raises(
+        ValueError, match=r"score_reward_min.*cannot exceed.*score_reward_max"
+    ):
+        MOPDLossConfig(score_reward_min=5.0, score_reward_max=2.0)
+
+    # Non-finite bounds raise ValueError
+    with pytest.raises(ValueError, match="must be a finite number"):
+        MOPDLossConfig(score_reward_min=float("-inf"))
+
+    with pytest.raises(ValueError, match="must be a finite number"):
+        MOPDLossConfig(score_reward_max=float("nan"))
+
+    # Invalid normalize_teacher_weights raises ValueError
+    with pytest.raises(ValueError, match="must be a boolean"):
+        MOPDLossConfig(normalize_teacher_weights="true")  # type: ignore[arg-type]

--- a/tests/test_mopd_loss.py
+++ b/tests/test_mopd_loss.py
@@ -485,3 +485,159 @@ def test_mopd_loss_respects_behavioral_rejection_without_renormalizing(
         if "n_mopd_tokens" in call.kwargs
     )
     assert torch.equal(denominator_call.kwargs["n_mopd_tokens"], response_mask)
+
+
+def test_mopd_loss_score_reward_clipping():
+    """Score reward clipping clamps rewards and tracks clipped token masks."""
+    # Token 0: teacher_logp = -10.0, student_logp = -1.0 -> unclipped reward = -9.0 (exceeds min)
+    # Token 1: teacher_logp = -1.0, student_logp = -1.0 -> unclipped reward = 0.0 (in range)
+    # Token 2: teacher_logp = -0.5, student_logp = -5.0 -> unclipped reward = +4.5 (exceeds max)
+    logprobs = torch.tensor(
+        [[-1.0, -1.0, -5.0]], dtype=torch.float64, requires_grad=True
+    )
+    old_logprobs = torch.tensor([[-1.0, -1.0, -5.0]], dtype=torch.float64)
+    teacher_logp_sum = torch.tensor([[-10.0, -1.0, -0.5]], dtype=torch.float64)
+    teacher_weight_sum = torch.tensor([[1.0, 1.0, 1.0]], dtype=torch.float64)
+    loss_mask = torch.tensor([[True, True, True]])
+
+    loss, stats = mopd_loss_fn(
+        logprobs=logprobs,
+        old_logprobs=old_logprobs,
+        teacher_logp_sum=teacher_logp_sum,
+        teacher_weight_sum=teacher_weight_sum,
+        loss_mask=loss_mask,
+        score_reward_min=-3.0,
+        score_reward_max=2.0,
+    )
+
+    # Score reward must be clamped
+    expected_rewards = torch.tensor([[-3.0, 0.0, 2.0]], dtype=torch.float64)
+    torch.testing.assert_close(stats["score_reward"], expected_rewards)
+
+    # Clipping flags must match
+    assert torch.equal(
+        stats["score_reward_min_clipped"], torch.tensor([[True, False, False]])
+    )
+    assert torch.equal(
+        stats["score_reward_max_clipped"], torch.tensor([[False, False, True]])
+    )
+
+    # Gradient must flow to logprobs
+    loss.backward()
+    assert logprobs.grad is not None
+    assert torch.all(torch.isfinite(logprobs.grad))
+    assert logprobs.grad[0, 0] != 0
+    assert logprobs.grad[0, 1] == 0
+    assert logprobs.grad[0, 2] != 0
+
+
+def test_mopd_loss_teacher_weight_normalization():
+    """Normalizing teacher weights makes loss invariant to teacher weight scale."""
+    logprobs1 = torch.tensor([[-1.0, -2.0]], dtype=torch.float64, requires_grad=True)
+    logprobs2 = torch.tensor([[-1.0, -2.0]], dtype=torch.float64, requires_grad=True)
+    old_logp = torch.tensor([[-1.0, -2.0]], dtype=torch.float64)
+    loss_mask = torch.tensor([[True, True]])
+
+    # Route 1 has 1 teacher of weight 1.0
+    teacher_logp_base = torch.tensor([[-0.8, -1.5]], dtype=torch.float64)
+    w1 = 1.0
+    loss1, stats1 = mopd_loss_fn(
+        logprobs=logprobs1,
+        old_logprobs=old_logp,
+        teacher_logp_sum=teacher_logp_base * w1,
+        teacher_weight_sum=torch.full_like(teacher_logp_base, w1),
+        loss_mask=loss_mask,
+        normalize_teacher_weights=True,
+    )
+
+    # Route 2 has 3 teachers of total weight 3.0 with same average target
+    w2 = 3.0
+    loss2, stats2 = mopd_loss_fn(
+        logprobs=logprobs2,
+        old_logprobs=old_logp,
+        teacher_logp_sum=teacher_logp_base * w2,
+        teacher_weight_sum=torch.full_like(teacher_logp_base, w2),
+        loss_mask=loss_mask,
+        normalize_teacher_weights=True,
+    )
+
+    torch.testing.assert_close(loss1.detach(), loss2.detach(), rtol=1e-12, atol=1e-12)
+    torch.testing.assert_close(
+        stats1["score_reward"], stats2["score_reward"], rtol=1e-12, atol=1e-12
+    )
+
+    loss1.backward()
+    loss2.backward()
+    torch.testing.assert_close(logprobs1.grad, logprobs2.grad, rtol=1e-12, atol=1e-12)
+
+
+def test_mopd_loss_fn_bounds_validation():
+    (
+        logprobs,
+        old_logprobs,
+        teacher_logp_sum,
+        teacher_weight_sum,
+        loss_mask,
+    ) = _loss_inputs()
+
+    with pytest.raises(ValueError, match="score_reward_min.*cannot exceed"):
+        mopd_loss_fn(
+            logprobs=logprobs,
+            old_logprobs=old_logprobs,
+            teacher_logp_sum=teacher_logp_sum,
+            teacher_weight_sum=teacher_weight_sum,
+            loss_mask=loss_mask,
+            score_reward_min=5.0,
+            score_reward_max=-2.0,
+        )
+
+    with pytest.raises(ValueError, match="score_reward_min must be a finite number"):
+        mopd_loss_fn(
+            logprobs=logprobs,
+            old_logprobs=old_logprobs,
+            teacher_logp_sum=teacher_logp_sum,
+            teacher_weight_sum=teacher_weight_sum,
+            loss_mask=loss_mask,
+            score_reward_min=float("nan"),
+        )
+
+    with pytest.raises(ValueError, match="normalize_teacher_weights must be a boolean"):
+        mopd_loss_fn(
+            logprobs=logprobs,
+            old_logprobs=old_logprobs,
+            teacher_logp_sum=teacher_logp_sum,
+            teacher_weight_sum=teacher_weight_sum,
+            loss_mask=loss_mask,
+            normalize_teacher_weights=1,  # type: ignore[arg-type]
+        )
+
+
+def test_compose_mopd_loss_propagates_clipping_and_normalization():
+    (
+        logprobs,
+        old_logprobs,
+        teacher_logp_sum,
+        teacher_weight_sum,
+        loss_mask,
+    ) = _loss_inputs()
+
+    config = MOPDLossConfig(
+        score_reward_min=-1.0,
+        score_reward_max=1.0,
+        normalize_teacher_weights=True,
+    )
+
+    total_loss, stats = compose_mopd_loss(
+        rl_loss=torch.zeros(()),
+        config=config,
+        logprobs=logprobs,
+        old_logprobs=old_logprobs,
+        teacher_logp_sum=teacher_logp_sum,
+        teacher_weight_sum=teacher_weight_sum,
+        loss_mask=loss_mask,
+    )
+
+    assert "score_reward_min_clipped" in stats
+    assert "score_reward_max_clipped" in stats
+    assert stats["score_reward"].min() >= -1.0
+    assert stats["score_reward"].max() <= 1.0


### PR DESCRIPTION
## Description

In Multi-Teacher On-Policy Distillation (MOPD, #1592), the reverse-KL surrogate loss is computed from the teacher-vs-student score reward:

$$\text{score reward} = \sum_j w_j \log \pi_{Tj}(y_t) - \left(\sum_j w_j\right)\log \pi_\theta(y_t)$$

In real-world RL exploration, this formulation encounters two key stability challenges:
1. **Unbounded Negative Score Rewards**: When student models explore reasoning trajectories or formatting tokens not recognized or assigned very low probability by specialized teachers ($\log \pi_{Tj} \le -50$), `score_reward` drops to large negative magnitudes (e.g., $-50$ to $-100$). Multiplied by importance weights ($w_{\text{IS}} \in (0, 5]$), these outlier tokens inject huge loss spikes that destabilize training and can trigger catastrophic policy degradation.
2. **Gradient Imbalance Across Heterogeneous Teacher Routes**: Because `teacher_weight_sum` scales with $\sum_j w_j$, samples routed to 3 teachers ($w=1$ each) experience a 3x larger reward/gradient magnitude than samples routed to a single teacher ($w=1$), skewing training across heterogeneous dataset mixtures.

This PR adds:
- `score_reward_min` and `score_reward_max` bounds to `MOPDLossConfig` and `mopd_loss_fn` to bound outlier score rewards while retaining score-function gradient backpropagation through `score_function_carrier = torch.exp(safe_logprobs - safe_logprobs.detach())`.
- `normalize_teacher_weights` to `MOPDLossConfig` to normalize multi-teacher log-probabilities by the effective teacher weight sum:
$$\text{normalized teacher logp} = \frac{\sum_j w_j \log \pi_{Tj}}{\max(\sum_j w_j, 10^{-8})}, \quad \text{score reward} = \text{normalized teacher logp} - \log \pi_\theta$$
  making distillation rewards invariant to the arbitrary number or scale of teacher weights across heterogeneous routes.
- Diagnostic token flags `mopd_score_reward_min_clipped` and `mopd_score_reward_max_clipped` recorded in `stats_tracker` to give practitioners visibility into teacher-student distribution mismatches.
- Full 100% backward compatibility: with default configurations (`score_reward_min=None`, `score_reward_max=None`, `normalize_teacher_weights=False`), the objective and all numerical outputs are byte-for-byte identical to existing baseline.

## Related Issue

Part of 2026 H2 roadmap: RL post-training stability, multi-teacher distillation robustness, and student exploration stabilization.

## Type of Change

- [x] ✨ New feature

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh` / `generate_cli_docs.py`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

- Validated with unit tests in `tests/test_mopd_loss.py` covering score reward clipping, teacher weight normalization scale invariance, gradient backpropagation, and bounds validation.
- All 16 pre-commit hooks passed cleanly.