### PR TITLE
feat(openai): support zero-argument tools and XML-escaped parameter parsing in ToolCallParser

### DIFF
--- a/areal/experimental/openai/tool_call_parser.py
+++ b/areal/experimental/openai/tool_call_parser.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import html
 import json
 import re
 import traceback
@@ -22,7 +23,7 @@ _QWEN3_CODER_TOOL_CALL_RE = re.compile(
     re.DOTALL,
 )
 _QWEN3_CODER_FUNCTION_RE = re.compile(
-    r"<function=(?P<name>[^>\s]+)>\s*(?P<body>.*?)\s*</function>",
+    r"<function=(?P<name>[^/>\s]+)(?:/\s*>|>\s*(?P<body>.*?)\s*</function>)",
     re.DOTALL,
 )
 _QWEN3_CODER_PARAMETER_RE = re.compile(
@@ -103,12 +104,30 @@ def _tool_argument_schemas(tools: list[Any]) -> dict[str, dict[str, dict[str, An
     return schemas
 
 
+def _tool_required_parameters(tools: list[Any]) -> dict[str, set[str]]:
+    required_map: dict[str, set[str]] = {}
+    for tool_def in _iter_tool_definitions(tools):
+        name = tool_def.get("name")
+        if not isinstance(name, str):
+            continue
+        parameters = tool_def.get("parameters")
+        if isinstance(parameters, dict):
+            req = parameters.get("required")
+            if isinstance(req, list):
+                required_map[name] = {str(r) for r in req if isinstance(r, str)}
+            else:
+                required_map[name] = set()
+        else:
+            required_map[name] = set()
+    return required_map
+
+
 def _clean_qwen3_coder_parameter(raw_value: str) -> str:
     if raw_value.startswith("\n"):
         raw_value = raw_value[1:]
     if raw_value.endswith("\n"):
         raw_value = raw_value[:-1]
-    return raw_value
+    return html.unescape(raw_value)
 
 
 def _coerce_qwen3_coder_parameter(
@@ -185,6 +204,7 @@ def _process_tool_calls_qwen3_coder_xml(
         text, "<think>", "</think>"
     )
     arg_schemas = _tool_argument_schemas(tools)
+    required_params = _tool_required_parameters(tools)
 
     tool_calls: list[ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall]
     tool_calls = []
@@ -197,7 +217,7 @@ def _process_tool_calls_qwen3_coder_xml(
         body = tool_match.group("body")
         for fn_match in _QWEN3_CODER_FUNCTION_RE.finditer(body):
             tool_name = fn_match.group("name")
-            fn_body = fn_match.group("body")
+            fn_body = fn_match.group("body") or ""
             # A parameter value that itself contains a literal "</parameter>"
             # makes the non-greedy regex truncate at the wrong tag, silently
             # producing wrong arguments. When opening/closing tags are unbalanced
@@ -205,29 +225,45 @@ def _process_tool_calls_qwen3_coder_xml(
             if fn_body.count("<parameter=") != fn_body.count("</parameter>"):
                 return None, text, finish_reason
             args: dict[str, Any] = {}
-            for param_match in _QWEN3_CODER_PARAMETER_RE.finditer(fn_body):
-                param_name = param_match.group("name")
-                raw_param_value = param_match.group("value")
-                # A balanced count of tags still hides nested pairs, e.g. a
-                # value that contains its own "<parameter=...>...</parameter>".
-                # The non-greedy regex truncates the outer value at the inner
-                # closing tag, so treat any parameter marker inside the value as
-                # ambiguous and fall back to the backend parser.
-                if (
-                    "<parameter=" in raw_param_value
-                    or "</parameter>" in raw_param_value
-                ):
-                    return None, text, finish_reason
-                param_value = _clean_qwen3_coder_parameter(raw_param_value)
-                args[param_name] = _coerce_qwen3_coder_parameter(
-                    param_value,
-                    arg_schemas.get(tool_name, {}).get(param_name),
-                )
+            if "<parameter=" in fn_body:
+                for param_match in _QWEN3_CODER_PARAMETER_RE.finditer(fn_body):
+                    param_name = param_match.group("name")
+                    raw_param_value = param_match.group("value")
+                    # A balanced count of tags still hides nested pairs, e.g. a
+                    # value that contains its own "<parameter=...>...</parameter>".
+                    # The non-greedy regex truncates the outer value at the inner
+                    # closing tag, so treat any parameter marker inside the value as
+                    # ambiguous and fall back to the backend parser.
+                    if (
+                        "<parameter=" in raw_param_value
+                        or "</parameter>" in raw_param_value
+                    ):
+                        return None, text, finish_reason
+                    param_value = _clean_qwen3_coder_parameter(raw_param_value)
+                    args[param_name] = _coerce_qwen3_coder_parameter(
+                        param_value,
+                        arg_schemas.get(tool_name, {}).get(param_name),
+                    )
+            else:
+                stripped_body = fn_body.strip()
+                if stripped_body.startswith("{") and stripped_body.endswith("}"):
+                    try:
+                        decoded = json.loads(stripped_body)
+                        if isinstance(decoded, dict):
+                            args = decoded
+                    except (ValueError, json.JSONDecodeError):
+                        pass
 
-            # No parsed arguments means either a genuinely empty block or a
-            # truncated/malformed one. Skip it so process_tool_calls falls back
-            # to the sglang parser instead of committing empty arguments.
-            if not args:
+            # Validate whether parsed arguments satisfy the tool schema.
+            # If the tool requires specific parameters that are missing, skip it
+            # so process_tool_calls falls back to the backend parser.
+            # If the tool requires no parameters (or has no schema), an empty
+            # args dict is a valid invocation of a zero-argument tool.
+            if tool_name in required_params:
+                missing_required = required_params[tool_name] - set(args.keys())
+                if missing_required:
+                    continue
+            elif not args:
                 continue
 
             arguments = json.dumps(args, ensure_ascii=False)

--- a/tests/experimental/openai/test_tool_call_parser.py
+++ b/tests/experimental/openai/test_tool_call_parser.py
@@ -209,6 +209,148 @@ def test_qwen3_coder_xml_literal_closing_tag_is_not_silently_truncated():
     assert finish_reason == "stop"
 
 
+def test_qwen3_coder_xml_zero_argument_tool():
+    tools: list[ChatCompletionToolParam] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "pwd",
+                "description": "Print working directory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            },
+        }
+    ]
+    text = "Checking directory:\n<tool_call>\n<function=pwd>\n</function>\n</tool_call>"
+
+    tool_calls, new_text, finish_reason = (
+        parser_module._process_tool_calls_qwen3_coder_xml(
+            text=text,
+            tools=tools,
+            finish_reason="stop",
+        )
+    )
+
+    assert finish_reason == "tool_calls"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "pwd"
+    assert tool_calls[0].function.arguments == "{}"
+    assert "<tool_call>" not in new_text
+    assert "Checking directory:" in new_text
+
+
+def test_qwen3_coder_xml_self_closing_function_tag():
+    tools: list[ChatCompletionToolParam] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "git_status",
+                "description": "Check git repository status",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    text = "<tool_call>\n<function=git_status/>\n</tool_call>"
+
+    tool_calls, new_text, finish_reason = (
+        parser_module._process_tool_calls_qwen3_coder_xml(
+            text=text,
+            tools=tools,
+            finish_reason="stop",
+        )
+    )
+
+    assert finish_reason == "tool_calls"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "git_status"
+    assert tool_calls[0].function.arguments == "{}"
+
+
+def test_qwen3_coder_xml_json_body_fallback():
+    tools: list[ChatCompletionToolParam] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search web",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+    text = (
+        '<tool_call>\n<function=search>{"query": "AReaL RL"}</function>\n</tool_call>'
+    )
+
+    tool_calls, new_text, finish_reason = (
+        parser_module._process_tool_calls_qwen3_coder_xml(
+            text=text,
+            tools=tools,
+            finish_reason="stop",
+        )
+    )
+
+    assert finish_reason == "tool_calls"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "search"
+    assert json.loads(tool_calls[0].function.arguments) == {"query": "AReaL RL"}
+
+
+def test_qwen3_coder_xml_unescapes_xml_entities():
+    text = (
+        "<tool_call>\n<function=Bash>\n"
+        "<parameter=command>\n"
+        "cat file.py | grep &quot;foo &amp;&amp; bar&quot; &gt; out.txt\n"
+        "</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+
+    tool_calls, new_text, finish_reason = (
+        parser_module._process_tool_calls_qwen3_coder_xml(
+            text=text,
+            tools=QWEN3_CODER_TOOLS,
+            finish_reason="stop",
+        )
+    )
+
+    assert finish_reason == "tool_calls"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert (
+        json.loads(tool_calls[0].function.arguments)["command"]
+        == 'cat file.py | grep "foo && bar" > out.txt'
+    )
+
+
+def test_qwen3_coder_xml_missing_required_params_rejected():
+    text = (
+        "<tool_call>\n<function=Write>\n"
+        "<parameter=file_path>\na.py\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+
+    tool_calls, new_text, finish_reason = (
+        parser_module._process_tool_calls_qwen3_coder_xml(
+            text=text,
+            tools=QWEN3_CODER_TOOLS,
+            finish_reason="stop",
+        )
+    )
+
+    assert tool_calls is None
+    assert new_text == text
+    assert finish_reason == "stop"
+
+
 @pytest.mark.sglang
 @pytest.mark.parametrize("reasoning_parser", ["", None], ids=["empty", "none"])
 def test_process_tool_calls_without_reasoning_parser_returns_plain_text(


### PR DESCRIPTION
## Description

In agentic RL post-training and multi-turn evaluation, tool-calling agents frequently interact with zero-argument tools (e.g., `pwd`, `git_status`, `list_files`, `refresh`) or tools returning XML-escaped parameters.

Previously, `_process_tool_calls_qwen3_coder_xml` in `ToolCallParser` had the following limitations:
1. **Zero-argument tools dropped unconditionally**:
   ```python
   if not args:
       continue
   ```
   When a tool call contained no `<parameter=...>` tags (e.g., `<function=pwd></function>` or `<function=pwd/>`), `args` was empty (`{}`), causing the parser to silently skip the tool call and fall back to the backend parser (which often failed to parse Qwen3-coder XML format, causing lost tool calls and broken rollouts).
2. **Self-closing function tags unsupported**: Models occasionally emit self-closing function tags like `<function=git_status/>` when invoking tools with no arguments. The previous regex `r"<function=(?P<name>[^>\s]+)>(?P<body>.*?)</function>"` failed to match self-closing tags.
3. **Raw JSON payload bodies**: Certain models emit inline JSON arguments inside `<function=name>{"param": "val"}</function>`. Without parameter tags, this was also discarded.
4. **Unescaped XML entities**: Tool call arguments generated inside XML structures frequently have XML entities escaped (e.g., `&amp;` for `&`, `&quot;` for `"`, `&lt;` for `<`, `&gt;` for `>`). When passed to command executors (e.g. `cat file | grep "foo && bar" > out`), raw entity strings resulted in execution failures.

This PR addresses these issues:
1. Derives required and declared parameter schemas from `tools` via `_tool_required_parameters(tools)`.
2. Validates `args` against schema: zero-argument tools (or tools with empty `required: []`) now successfully emit valid tool calls with `arguments="{}"`. Missing required parameters are still correctly rejected to allow backend parser fallback.
3. Extends `_QWEN3_CODER_FUNCTION_RE` to match both `<function=name>...</function>` and self-closing `<function=name/>`.
4. Adds JSON body decoding fallback when `<parameter=` tags are not found in the function body.
5. Uses `html.unescape` in `_clean_qwen3_coder_parameter` so XML entities in parameter strings are decoded cleanly into executable strings.
6. Adds comprehensive unit test coverage in `tests/experimental/openai/test_tool_call_parser.py`.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

- Validated via `uv run pytest -q tests/experimental/openai/test_tool_call_parser.py` (8 passed, 8 skipped).
- All 16 pre-commit hooks passed cleanly across the entire repository.