### PR TITLE
feat: add training throughput, FLOPs and MoE balance metrics

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -7,6 +7,7 @@ import dataclasses
 import gc
 import math
 import os
+import re
 import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
@@ -129,10 +130,12 @@ from areal.utils.data import (
 from areal.utils.functional import gather_logprobs, gather_logprobs_entropy
 from areal.utils.hf_utils import load_hf_processor_and_tokenizer, load_hf_tokenizer
 from areal.utils.lr_scheduler import get_num_warmup_steps
+from areal.utils.moe_metrics import MoEMetrics
 from areal.utils.network import find_free_ports, format_host_for_url, gethostip
 from areal.utils.offload import is_tms_enabled, torch_memory_saver
 from areal.utils.perf_tracer import trace_perf, trace_scope
 from areal.utils.save_load import get_state_dict_from_repo_id_or_path
+from areal.utils.training_metrics import export_training_metrics, record_training_batch
 
 if TYPE_CHECKING:
     from areal.api import Scheduler
@@ -470,6 +473,24 @@ class FSDPEngine(TrainEngine):
 
         self._create_optimizer(ft_spec)
 
+        self._moe_metrics = MoEMetrics()
+        routers = []
+        for name, module in self.model.named_modules():
+            if type(module).__name__ in ("Qwen3MoeTopKRouter", "Qwen3_5MoeTopKRouter"):
+                match = re.search(r"layers\.(\d+)\.", name)
+                if match is not None:
+                    routers.append((match.group(1), module))
+        if routers:
+            num_experts = routers[0][1].num_experts
+
+            def extract_counts(output: tuple[torch.Tensor, ...]) -> torch.Tensor:
+                indices = output[2].reshape(-1)
+                return torch.zeros(
+                    num_experts, dtype=torch.int64, device=indices.device
+                ).scatter_add_(0, indices, torch.ones_like(indices, dtype=torch.int64))
+
+            self._moe_metrics.attach(self.model, routers, extract_counts)
+
         if self.config.fsdp.per_layer_optim_step:
             if self.optimizer_config.type != "adam":
                 raise ValueError(
@@ -506,6 +527,8 @@ class FSDPEngine(TrainEngine):
         return self._cpu_group
 
     def destroy(self):
+        if hasattr(self, "_moe_metrics"):
+            self._moe_metrics.close()
         self._initialized = False
         if hasattr(self, "optimizer"):
             del self.optimizer
@@ -778,38 +801,38 @@ class FSDPEngine(TrainEngine):
         loss_weight_fn: Callable[[dict[str, Any]], torch.Tensor],
     ) -> dict[str, float]:
         self._ensure_ready()
-        self.optimizer_zero_grad()
-
         input_batched, _ = self._normalize_batch_input(input_)
+        with record_training_batch(self, input_batched, self.model_config):
+            self.optimizer_zero_grad()
 
-        # Step 1: Prepare micro-batches
-        mb_list = self._prepare_mb_list(input_batched).to(self.device)
+            # Step 1: Prepare micro-batches
+            mb_list = self._prepare_mb_list(input_batched).to(self.device)
 
-        # Step 2: Compute total loss weight
-        total_loss_weight = compute_total_loss_weight(
-            mb_list, loss_weight_fn, self.dp_group
-        )
-
-        # Step 3: Forward-backward using process_output_fn callback
-        def process_output(
-            logits: torch.Tensor, ctx_dict: dict[str, Any]
-        ) -> torch.Tensor:
-            ctx = FSDPTrainContext(**ctx_dict)
-            return self._compute_logprobs_and_loss(
-                logits,
-                ctx,
-                loss_fn,
-                loss_weight_fn,
-                total_loss_weight,
-                loss_multiplier=self.parallel_helper.dp_size,
+            # Step 2: Compute total loss weight
+            total_loss_weight = compute_total_loss_weight(
+                mb_list, loss_weight_fn, self.dp_group
             )
 
-        self.forward_backward_batch(mb_list, process_output, forward_only=False)
+            # Step 3: Forward-backward using process_output_fn callback
+            def process_output(
+                logits: torch.Tensor, ctx_dict: dict[str, Any]
+            ) -> torch.Tensor:
+                ctx = FSDPTrainContext(**ctx_dict)
+                return self._compute_logprobs_and_loss(
+                    logits,
+                    ctx,
+                    loss_fn,
+                    loss_weight_fn,
+                    total_loss_weight,
+                    loss_multiplier=self.parallel_helper.dp_size,
+                )
 
-        # Step 4: Optimizer step
-        stats = self.optimizer_step()
-        stats["num_micro_batches"] = len(mb_list.mbs)
-        return stats
+            self.forward_backward_batch(mb_list, process_output, forward_only=False)
+
+            # Step 4: Optimizer step
+            stats = self.optimizer_step()
+            stats["num_micro_batches"] = len(mb_list.mbs)
+            return stats
 
     @torch.no_grad()
     def eval_batch(
@@ -921,9 +944,17 @@ class FSDPEngine(TrainEngine):
 
     def export_stats(self) -> dict[str, float]:
         with self._offload_aware_context():
-            return stats_tracker.export_all(
+            data = stats_tracker.export_all(
                 reduce_group=self.data_parallel_group,
             )
+            data.update(
+                self._moe_metrics.export(
+                    reduce_group=self.world_mesh["dp_sp"].get_group()
+                )
+            )
+            data.update(export_training_metrics(self))
+
+        return data
 
     def offload(self) -> None:
         """Offload model memory to CPU using torch_memory_saver.

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -144,10 +144,12 @@ from areal.utils.hf_utils import (
 )
 from areal.utils.lock import DistributedLock
 from areal.utils.lr_scheduler import get_num_warmup_steps
+from areal.utils.moe_metrics import MoEMetrics
 from areal.utils.network import find_free_ports, format_host_for_url, gethostip
 from areal.utils.offload import is_tms_enabled, torch_memory_saver
 from areal.utils.perf_tracer import trace_perf, trace_scope
 from areal.utils.seeding import get_seed
+from areal.utils.training_metrics import export_training_metrics, record_training_batch
 from areal.v2.weight_update.awex.delta_config import DTERuntimeConfig
 
 if TYPE_CHECKING:
@@ -704,6 +706,17 @@ class MegatronEngine(TrainEngine):
         self._mark_duplicated_params()
         self._create_optimizer(ft_spec)
         self._set_optimizer_grad_scale_func()
+
+        from megatron.core.transformer.moe.router import TopKRouter
+
+        self._moe_metrics = MoEMetrics()
+        for part in self.model:
+            routers = [
+                (str(module.layer_number - 1), module)
+                for module in part.modules()
+                if isinstance(module, TopKRouter) and not module.is_mtp_layer
+            ]
+            self._moe_metrics.attach(part, routers, lambda output: output[1].sum(dim=0))
         self._initialized = True
 
     def _set_optimizer_grad_scale_func(self) -> None:
@@ -942,6 +955,8 @@ class MegatronEngine(TrainEngine):
         return self._cpu_group
 
     def destroy(self):
+        if hasattr(self, "_moe_metrics"):
+            self._moe_metrics.close()
         self._initialized = False
         self.process_group_initialized = False
         # Drain any pending async checkpoint saves before tearing down process
@@ -1472,63 +1487,63 @@ class MegatronEngine(TrainEngine):
         self._ensure_ready()
         if self._weight_residency is not None:
             self._weight_residency.ensure_grad_buffers()
-        self.optimizer_zero_grad()
-
         input_batched, _ = self._normalize_batch_input(input_)
+        with record_training_batch(self, input_batched, self.hf_config):
+            self.optimizer_zero_grad()
 
-        # Step 1: Prepare micro-batches
-        mb_list = self._prepare_mb_list(tensor_container_to(input_batched, "cpu"))
+            # Step 1: Prepare micro-batches
+            mb_list = self._prepare_mb_list(tensor_container_to(input_batched, "cpu"))
 
-        # Step 2: Compute total loss weight.
-        # Use DP+CP group: after CP all-gather each rank computes the full-sequence
-        # loss, so all_gather's backward (reduce_scatter) sums cp_size identical
-        # gradients, amplifying by cp_size. Including CP in the weight all-reduce
-        # introduces a matching cp_size factor in the denominator, cancelling out.
-        total_loss_weight = compute_total_loss_weight(
-            mb_list,
-            loss_weight_fn,
-            mpu.get_data_parallel_group(with_context_parallel=True),
-            device=self.device,
-        )
-
-        # Step 3: Forward-backward using Megatron's pipeline function.
-        # `len(mb_list)` compensates Megatron Core's `output_tensor /= num_microbatches`
-        # applied in the 2-tuple `(loss, {})` branch of
-        # `megatron.core.pipeline_parallel.schedules._forward_step_helper`. Our
-        # per-microbatch loss is already globally normalized via `w_i / W_total`, so
-        # that extra division would shrink every gradient (and thus grad_norm and the
-        # effective optimizer step) by `num_microbatches`. MCore applies the dynamic
-        # FP16 loss scale through `model_config.grad_scale_func` to both the main loss
-        # and auxiliary losses such as MTP and MoE.
-        loss_multiplier = mpu.get_data_parallel_world_size() * len(mb_list)
-
-        def process_output(
-            output: torch.Tensor, inputs: dict[str, Any]
-        ) -> torch.Tensor:
-            return self._compute_logprobs_and_loss(
-                output,
-                inputs,
-                loss_fn,
+            # Step 2: Compute total loss weight.
+            # Use DP+CP group: after CP all-gather each rank computes the full-sequence
+            # loss, so all_gather's backward (reduce_scatter) sums cp_size identical
+            # gradients, amplifying by cp_size. Including CP in the weight all-reduce
+            # introduces a matching cp_size factor in the denominator, cancelling out.
+            total_loss_weight = compute_total_loss_weight(
+                mb_list,
                 loss_weight_fn,
-                total_loss_weight,
-                loss_multiplier=loss_multiplier,
+                mpu.get_data_parallel_group(with_context_parallel=True),
+                device=self.device,
             )
 
-        self.forward_backward_batch(
-            mb_list,
-            process_output,
-            forward_only=False,
-        )
+            # Step 3: Forward-backward using Megatron's pipeline function.
+            # `len(mb_list)` compensates Megatron Core's `output_tensor /= num_microbatches`
+            # applied in the 2-tuple `(loss, {})` branch of
+            # `megatron.core.pipeline_parallel.schedules._forward_step_helper`. Our
+            # per-microbatch loss is already globally normalized via `w_i / W_total`, so
+            # that extra division would shrink every gradient (and thus grad_norm and the
+            # effective optimizer step) by `num_microbatches`. MCore applies the dynamic
+            # FP16 loss scale through `model_config.grad_scale_func` to both the main loss
+            # and auxiliary losses such as MTP and MoE.
+            loss_multiplier = mpu.get_data_parallel_world_size() * len(mb_list)
 
-        # Step 4: Optimizer step
-        stats = self.optimizer_step()
-        stats["num_micro_batches"] = len(mb_list.mbs)
+            def process_output(
+                output: torch.Tensor, inputs: dict[str, Any]
+            ) -> torch.Tensor:
+                return self._compute_logprobs_and_loss(
+                    output,
+                    inputs,
+                    loss_fn,
+                    loss_weight_fn,
+                    total_loss_weight,
+                    loss_multiplier=loss_multiplier,
+                )
 
-        # Step 5: Surface the auxiliary MTP loss for logging (if enabled).
-        mtp_loss = self._collect_mtp_loss(len(mb_list.mbs))
-        if mtp_loss is not None:
-            stats["mtp_loss"] = mtp_loss
-        return stats
+            self.forward_backward_batch(
+                mb_list,
+                process_output,
+                forward_only=False,
+            )
+
+            # Step 4: Optimizer step
+            stats = self.optimizer_step()
+            stats["num_micro_batches"] = len(mb_list.mbs)
+
+            # Step 5: Surface the auxiliary MTP loss for logging (if enabled).
+            mtp_loss = self._collect_mtp_loss(len(mb_list.mbs))
+            if mtp_loss is not None:
+                stats["mtp_loss"] = mtp_loss
+            return stats
 
     def _collect_mtp_loss(self, num_microbatches: int) -> float | None:
         """Reduce and return the per-microbatch Multi-Token-Prediction loss.
@@ -1675,6 +1690,18 @@ class MegatronEngine(TrainEngine):
                 reduce_group=self.data_parallel_group,
                 key_sync_group=key_sync_group,
             )
+            data.update(
+                self._moe_metrics.export(
+                    reduce_group=mpu.get_tensor_and_data_parallel_group(
+                        with_context_parallel=True
+                    ),
+                    pp_group=mpu.get_pipeline_model_parallel_group(),
+                    replicas=1
+                    if self.tf_config.sequence_parallel
+                    else mpu.get_tensor_model_parallel_world_size(),
+                )
+            )
+            data.update(export_training_metrics(self))
         if mpu.get_pipeline_model_parallel_world_size() > 1:
             # Some log info only exist in last pipeline rank
             data_list = [data]

--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -106,7 +106,9 @@ from areal.utils.data import (
 from areal.utils.functional import gather_logprobs, gather_logprobs_entropy
 from areal.utils.hf_utils import load_hf_tokenizer
 from areal.utils.lock import DistributedLock
+from areal.utils.moe_metrics import MoEMetrics
 from areal.utils.offload import is_tms_enabled, torch_memory_saver
+from areal.utils.training_metrics import export_training_metrics, record_training_batch
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -370,6 +372,17 @@ class ArchonEngine(TrainEngine):
         self._materialize_and_load_weights()
         self._create_optimizer(ft_spec)
 
+        from areal.experimental.models.archon.moe import MoE
+
+        self._moe_metrics = MoEMetrics()
+        for part in self.model_parts:
+            layers = []
+            for layer_id, layer in part.layers.items():
+                for module in layer.modules():
+                    if isinstance(module, MoE):
+                        layers.append((str(layer_id), module))
+            self._moe_metrics.attach_buffers(part, layers)
+
         self.runner = create_runner(
             pp_enabled=self.parallel_dims.pp_enabled,
             model_parts=self.model_parts,
@@ -429,6 +442,8 @@ class ArchonEngine(TrainEngine):
 
     def destroy(self):
         """Clean up resources."""
+        if hasattr(self, "_moe_metrics"):
+            self._moe_metrics.close()
         if hasattr(self, "optimizer"):
             del self.optimizer
         if hasattr(self, "model") and self.model is not None:
@@ -530,34 +545,34 @@ class ArchonEngine(TrainEngine):
     ) -> dict[str, float]:
         """Train on a batch of data."""
         assert self._initialized
-        self.optimizer_zero_grad()
-
         input_batched, _ = self._normalize_batch_input(input_)
+        with record_training_batch(self, input_batched, self.model_config):
+            self.optimizer_zero_grad()
 
-        mb_list = self._prepare_mb_list(input_batched).to(self.device)
+            mb_list = self._prepare_mb_list(input_batched).to(self.device)
 
-        total_loss_weight = compute_total_loss_weight(
-            mb_list, loss_weight_fn, self.data_parallel_group
-        )
-
-        def process_output(
-            logits: torch.Tensor, ctx_dict: dict[str, Any]
-        ) -> torch.Tensor:
-            ctx = ArchonTrainContext(**ctx_dict)
-            return self._compute_logprobs_and_loss(
-                logits,
-                ctx,
-                loss_fn,
-                loss_weight_fn,
-                total_loss_weight,
-                loss_multiplier=self.data_parallel_world_size,
+            total_loss_weight = compute_total_loss_weight(
+                mb_list, loss_weight_fn, self.data_parallel_group
             )
 
-        self.forward_backward_batch(mb_list, process_output, forward_only=False)
+            def process_output(
+                logits: torch.Tensor, ctx_dict: dict[str, Any]
+            ) -> torch.Tensor:
+                ctx = ArchonTrainContext(**ctx_dict)
+                return self._compute_logprobs_and_loss(
+                    logits,
+                    ctx,
+                    loss_fn,
+                    loss_weight_fn,
+                    total_loss_weight,
+                    loss_multiplier=self.data_parallel_world_size,
+                )
 
-        stats = self.optimizer_step()
-        stats["num_micro_batches"] = len(mb_list.mbs)
-        return stats
+            self.forward_backward_batch(mb_list, process_output, forward_only=False)
+
+            stats = self.optimizer_step()
+            stats["num_micro_batches"] = len(mb_list.mbs)
+            return stats
 
     @torch.no_grad()
     def eval_batch(
@@ -848,6 +863,15 @@ class ArchonEngine(TrainEngine):
             data = stats_tracker.export_all(
                 reduce_group=self.data_parallel_group,
             )
+            data.update(
+                self._moe_metrics.export(
+                    reduce_group=self.parallel_dims.get_group("dp_cp"),
+                    pp_group=self.parallel_dims.get_group("pp")
+                    if self.parallel_dims.pp_enabled
+                    else None,
+                )
+            )
+            data.update(export_training_metrics(self))
         if self.parallel_dims.pp_enabled:
             data_list = [data]
             dist.broadcast_object_list(

--- a/areal/experimental/models/archon/moe/moe.py
+++ b/areal/experimental/models/archon/moe/moe.py
@@ -58,6 +58,7 @@ class MoE(nn.Module):
         shared_experts: Optional shared experts (always active).
         expert_bias: Buffer for load balancing (updated externally).
         tokens_per_expert: Buffer tracking expert usage (for load balancing).
+        routing_counts: Last router assignment counts, read by training diagnostics.
     """
 
     def __init__(self, moe_args: MoEArgs, dim: int, hidden_dim: int):
@@ -120,6 +121,7 @@ class MoE(nn.Module):
         # tokens_per_expert tracks usage for bias updates
         self.expert_bias: torch.Tensor | None
         self.tokens_per_expert: torch.Tensor
+        self.routing_counts: torch.Tensor
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through MoE layer.
@@ -144,6 +146,7 @@ class MoE(nn.Module):
         # Track expert usage for load balancing
         with torch.no_grad():
             self.tokens_per_expert.add_(num_tokens_per_expert.float())
+            self.routing_counts.copy_(num_tokens_per_expert)
 
         # Reorder tokens by expert (separate module for EP sequence parallel)
         # When ReordererSequenceParallel is applied, each rank processes
@@ -236,12 +239,17 @@ class MoE(nn.Module):
             )
 
     def init_buffers(self, buffer_device: torch.device | str):
-        """Initialize MoE buffers (tokens_per_expert, expert_bias).
+        """Initialize MoE routing diagnostics and load-balancing buffers.
 
         Args:
             buffer_device: Device for buffers.
         """
         with torch.device(buffer_device):
+            self.register_buffer(
+                "routing_counts",
+                torch.zeros(self.num_experts, dtype=torch.int64),
+                persistent=False,
+            )
             self.register_buffer(
                 "tokens_per_expert",
                 torch.zeros(self.num_experts, dtype=torch.float32),

--- a/areal/utils/flops.py
+++ b/areal/utils/flops.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model FLOPs registry. Estimators return forward + backward FLOPs per sequence.
+
+One multiply-add is two FLOPs; backward is estimated as twice forward.
+Counts describe useful dense-equivalent math, excluding recomputation, optimizer,
+normalization, softmax, activation functions, vision encoders and auxiliary MTP.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+FlopsEstimator = Callable[[int], float]
+FlopsFactory = Callable[[Any], FlopsEstimator]
+_FACTORIES: dict[str, FlopsFactory] = {}
+
+
+def register_flops_estimator(model_type: str, factory: FlopsFactory) -> None:
+    """Register a config -> (sequence length -> training FLOPs) factory.
+
+    Call in each training worker before engine initialization. A factory can close
+    over the actual model config, so local checkpoints and model variants work.
+    Explicit registration replaces the existing estimator for this architecture.
+    """
+    if not model_type or not callable(factory):
+        raise ValueError("A model_type and callable factory are required")
+    _FACTORIES[model_type] = factory
+
+
+def get_flops_estimator(config: Any) -> FlopsEstimator | None:
+    """Resolve a registered architecture using the actual text model config."""
+    config = getattr(config, "text_config", config)
+    factory = _FACTORIES.get(getattr(config, "model_type", ""))
+    return factory(config) if factory is not None else None
+
+
+def _qwen_moe_factory(config: Any, *, hybrid: bool) -> FlopsEstimator:
+    h = config.hidden_size
+    layers = config.num_hidden_layers
+    heads = config.num_attention_heads
+    kv_heads = config.num_key_value_heads
+    d = config.head_dim
+    # Gate/up/down projections for selected experts and the shared expert.
+    shared = getattr(config, "shared_expert_intermediate_size", 0) if hybrid else 0
+    mlp = 6 * h * (config.num_experts_per_tok * config.moe_intermediate_size + shared)
+    mlp += 2 * h * config.num_experts  # router projection
+    if shared:
+        mlp += 2 * h  # shared expert sigmoid gate projection
+    # Qwen3.5's Q projection also produces the attention output gate.
+    full_projection = 2 * h * d * ((3 if hybrid else 2) * heads + 2 * kv_heads)
+    full_layers = layers
+    linear = 0
+    if hybrid:
+        layer_types = getattr(config, "layer_types", None)
+        if layer_types:
+            if len(layer_types) != layers or any(
+                t not in ("full_attention", "linear_attention") for t in layer_types
+            ):
+                raise ValueError("Invalid Qwen3.5 layer_types for FLOPs estimation")
+            full_layers = layer_types.count("full_attention")
+        else:
+            full_layers = layers // getattr(config, "full_attention_interval", 4)
+        k = config.linear_num_key_heads * config.linear_key_head_dim
+        v = config.linear_num_value_heads * config.linear_value_head_dim
+        # Q/K/V, z, a/b and output projections, plus depthwise convolution.
+        linear = 2 * h * (2 * k + 3 * v + 2 * config.linear_num_value_heads)
+        linear += 2 * (2 * k + v) * config.linear_conv_kernel_dim
+        # Recurrent-equivalent delta rule: state prediction, rank-one update,
+        # query readout (three key_dim x value_dim multiply-adds per value head).
+        linear += (
+            6
+            * config.linear_num_value_heads
+            * config.linear_key_head_dim
+            * config.linear_value_head_dim
+        )
+    per_token = layers * mlp + full_layers * full_projection
+    per_token += (layers - full_layers) * linear
+    per_token += 2 * h * config.vocab_size  # LM head, including tied weights
+
+    def estimate(sequence_length: int) -> float:
+        if (
+            isinstance(sequence_length, bool)
+            or not isinstance(sequence_length, int)
+            or sequence_length < 0
+        ):
+            raise ValueError("sequence_length must be a nonnegative integer")
+        # Causal QK^T and AV: L(L+1)/2 attended pairs, two matmuls.
+        attention = (
+            full_layers * 2 * heads * d * sequence_length * (sequence_length + 1)
+        )
+        return float(3 * (per_token * sequence_length + attention))
+
+    return estimate
+
+
+def qwen3_moe_flops(config: Any) -> FlopsEstimator:
+    """Qwen3 MoE, including Qwen/Qwen3-30B-A3B."""
+    return _qwen_moe_factory(config, hybrid=False)
+
+
+def qwen3_5_moe_flops(config: Any) -> FlopsEstimator:
+    """Qwen3.5 hybrid MoE text backbone, including Qwen3.5-35B-A3B."""
+    return _qwen_moe_factory(config, hybrid=True)
+
+
+register_flops_estimator("qwen3_moe", qwen3_moe_flops)
+register_flops_estimator("qwen3_5_moe", qwen3_5_moe_flops)
+register_flops_estimator("qwen3_5_moe_text", qwen3_5_moe_flops)

--- a/areal/utils/moe_metrics.py
+++ b/areal/utils/moe_metrics.py
@@ -39,6 +39,9 @@ class MoEMetrics:
         routers: Iterable[tuple[str, nn.Module]],
         extract_counts: Callable[[Any], torch.Tensor],
     ) -> None:
+        routers = list(routers)
+        if not routers:
+            return
         in_forward = False
 
         def enter(module: nn.Module, args: tuple[Any, ...]) -> None:
@@ -76,6 +79,8 @@ class MoEMetrics:
         model's hook. This keeps all metrics accumulation outside fullgraph code.
         """
         layers = list(layers)
+        if not layers:
+            return
 
         def record(module: nn.Module, args: tuple[Any, ...], output: Any) -> None:
             if self.active:

--- a/areal/utils/moe_metrics.py
+++ b/areal/utils/moe_metrics.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""MoE routing diagnostics, independent of router auxiliary-loss/bias state."""
+
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+
+def normalize_expert_loads(counts: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return percentages summing to 100 and max / ideal load (1 is balanced)."""
+    counts = counts.to(torch.float64)
+    total = counts.sum()
+    denominator = total.clamp_min(1)
+    return 100 * counts / denominator, counts.max() * counts.numel() / denominator
+
+
+class MoEMetrics:
+    """Collect original model forwards only, excluding eval and layer recompute.
+
+    Register the enclosing model part, outside activation-checkpointed layers.
+    The router callback runs eagerly so compiled backward graphs cannot capture
+    and replay a metrics mutation. Loads include executed alignment padding and
+    count each top-k assignment separately; shared experts are excluded.
+    """
+
+    def __init__(self) -> None:
+        self.active = False
+        self.counts: dict[str, torch.Tensor] = {}
+        self._handles = []
+
+    def attach(
+        self,
+        model: nn.Module,
+        routers: Iterable[tuple[str, nn.Module]],
+        extract_counts: Callable[[Any], torch.Tensor],
+    ) -> None:
+        in_forward = False
+
+        def enter(module: nn.Module, args: tuple[Any, ...]) -> None:
+            nonlocal in_forward
+            in_forward = True
+
+        def leave(module: nn.Module, args: tuple[Any, ...], output: Any) -> None:
+            nonlocal in_forward
+            in_forward = False
+
+        self._handles.append(model.register_forward_pre_hook(enter))
+        self._handles.append(model.register_forward_hook(leave, always_call=True))
+
+        def make_hook(layer: str) -> Callable:
+            @torch.compiler.disable
+            def record(module: nn.Module, args: tuple[Any, ...], output: Any) -> None:
+                if self.active and in_forward:
+                    counts = extract_counts(output).detach().to(torch.int64)
+                    if layer not in self.counts:
+                        self.counts[layer] = counts.clone()
+                    else:
+                        self.counts[layer].add_(counts)
+
+            return record
+
+        for layer, router in routers:
+            self._handles.append(router.register_forward_hook(make_hook(layer)))
+
+    def attach_buffers(
+        self, model: nn.Module, layers: Iterable[tuple[str, nn.Module]]
+    ) -> None:
+        """Read last-forward routing buffers outside compiled/checkpointed layers.
+
+        Recompute may overwrite these buffers but never invokes the enclosing
+        model's hook. This keeps all metrics accumulation outside fullgraph code.
+        """
+        layers = list(layers)
+
+        def record(module: nn.Module, args: tuple[Any, ...], output: Any) -> None:
+            if self.active:
+                for layer, moe in layers:
+                    counts = moe.routing_counts.detach()
+                    if layer not in self.counts:
+                        self.counts[layer] = counts.clone()
+                    else:
+                        self.counts[layer].add_(counts)
+
+        self._handles.append(model.register_forward_hook(record))
+
+    @contextmanager
+    def measure(self) -> Iterator[None]:
+        self.active = True
+        try:
+            yield
+        finally:
+            self.active = False
+
+    def export(
+        self,
+        *,
+        reduce_group: dist.ProcessGroup | None,
+        pp_group: dist.ProcessGroup | None = None,
+        replicas: int = 1,
+    ) -> dict[str, float]:
+        result = {}
+        if self.counts:
+            layers = sorted(self.counts)
+            sizes = [self.counts[layer].numel() for layer in layers]
+            packed = torch.cat([self.counts[layer] for layer in layers])
+            if dist.is_initialized():
+                dist.all_reduce(packed, op=dist.ReduceOp.SUM, group=reduce_group)
+            for layer, counts in zip(
+                layers,
+                (packed.cpu().to(torch.float64) / replicas).split(sizes),
+                strict=True,
+            ):
+                percentages, ratio = normalize_expert_loads(counts)
+                prefix = f"moe_balance/layer_{layer}"
+                result[f"{prefix}/max_over_ideal"] = ratio.item()
+                for expert, (count, percent) in enumerate(
+                    zip(counts.tolist(), percentages.tolist(), strict=True)
+                ):
+                    result[f"{prefix}/expert_{expert}/tokens"] = count
+                    result[f"{prefix}/expert_{expert}/load_percent"] = percent
+        if pp_group is not None and dist.is_initialized():
+            stages = [None] * dist.get_world_size(pp_group)
+            dist.all_gather_object(stages, result, group=pp_group)
+            result = {key: value for stage in stages for key, value in stage.items()}
+        self.counts.clear()
+        return result
+
+    def close(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._handles.clear()
+
+
+def split_expert_load_metrics(
+    data: dict[str, float],
+) -> tuple[dict[str, float], list[list[float]]]:
+    """Separate per-expert rows from scalar metrics for W&B Table logging.
+
+    Rows are [layer, expert, tokens, load_percent], sorted numerically. Per-layer
+    max_over_ideal remains a scalar; no model-sized family of W&B scalar keys is
+    created for the expert matrix.
+    """
+    import re
+
+    pattern = re.compile(
+        r"^moe_balance/layer_(\d+)/expert_(\d+)/(tokens|load_percent)$"
+    )
+    scalars = {}
+    rows = {}
+    for key, value in data.items():
+        match = pattern.match(key)
+        if match is None:
+            scalars[key] = value
+            continue
+        layer, expert = int(match[1]), int(match[2])
+        row = rows.setdefault((layer, expert), [layer, expert, 0.0, 0.0])
+        row[2 if match[3] == "tokens" else 3] = value
+    return scalars, [rows[key] for key in sorted(rows)]

--- a/areal/utils/stats_logger.py
+++ b/areal/utils/stats_logger.py
@@ -14,6 +14,7 @@ from tensorboardX import SummaryWriter
 from areal.api import FinetuneSpec
 from areal.api.cli_args import BaseExperimentConfig, StatsLoggerConfig
 from areal.utils import logging
+from areal.utils.moe_metrics import split_expert_load_metrics
 from areal.utils.printing import tabulate_stats
 from areal.version import version_info
 
@@ -148,8 +149,18 @@ class StatsLogger:
             item = {k: v for k, v in item.items() if not k.endswith("__count")}
 
             logger.info(f"Stats ({i + 1}/{len(data)}):")
-            self.print_stats(item)
-            wandb.log(item, step=log_step + i)
+            scalar_item, expert_rows = split_expert_load_metrics(item)
+            self.print_stats(scalar_item)
+            wandb_item = dict(scalar_item)
+            if expert_rows:
+                # W&B's run-media Table limit defaults to 10,000 rows, below
+                # Qwen3.5's 40 x 256 experts. Preserve every expert in snapshots.
+                wandb.Table.MAX_ROWS = max(wandb.Table.MAX_ROWS, len(expert_rows))
+                wandb_item["moe_balance/expert_loads"] = wandb.Table(
+                    columns=["layer", "expert", "tokens", "load_percent"],
+                    data=expert_rows,
+                )
+            wandb.log(wandb_item, step=log_step + i)
             swanlab.log(item, step=log_step + i)
             if getattr(self, "_trackio_enabled", False):
                 trackio.log(item, step=log_step + i)

--- a/areal/utils/stats_logger.py
+++ b/areal/utils/stats_logger.py
@@ -165,7 +165,7 @@ class StatsLogger:
             if getattr(self, "_trackio_enabled", False):
                 trackio.log(item, step=log_step + i)
             if self.summary_writer is not None:
-                for key, val in item.items():
+                for key, val in scalar_item.items():
                     self.summary_writer.add_scalar(f"{key}", val, log_step + i)
         self._last_commit_step = log_step + len(data) - 1
 

--- a/areal/utils/training_metrics.py
+++ b/areal/utils/training_metrics.py
@@ -17,20 +17,39 @@ from areal.utils.flops import FlopsEstimator
 class TrainingMetrics:
     def __init__(self, estimator: FlopsEstimator | None) -> None:
         self.estimator = estimator
-        self._pending: list[tuple[torch.Tensor, float]] = []
+        self._pending: list[
+            tuple[torch.Tensor, float | tuple[torch.cuda.Event, torch.cuda.Event]]
+        ] = []
         self._totals = [0.0, 0.0, 0.0]
 
     @contextmanager
     def measure(
-        self, batch: dict[str, Any], synchronize: Callable[[], None]
+        self,
+        batch: dict[str, Any],
+        synchronize: Callable[[], None],
+        *,
+        device: torch.device | None = None,
     ) -> Iterator[None]:
         # Keep lengths on their existing device; transfer once at export.
         lengths = batch["attention_mask"].detach().bool().sum(dim=-1)
-        synchronize()
-        start = time.perf_counter()
-        yield
-        synchronize()
-        self._pending.append((lengths, time.perf_counter() - start))
+        device = lengths.device if device is None else device
+        if device.type == "cuda":
+            # Input masks can still be on CPU before microbatch preparation.
+            # Capture the training stream so both timestamps use the same stream.
+            stream = torch.cuda.current_stream(device)
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+            start_event.record(stream)
+            yield
+            end_event.record(stream)
+            self._pending.append((lengths, (start_event, end_event)))
+        else:
+            # Retain synchronized wall timing for backends without CUDA events.
+            synchronize()
+            start = time.perf_counter()
+            yield
+            synchronize()
+            self._pending.append((lengths, time.perf_counter() - start))
 
     def export(
         self,
@@ -43,7 +62,19 @@ class TrainingMetrics:
         timing_group is an explicit CPU group containing all training ranks.
         Empty intervals (e.g. evaluation-only exports) produce no metrics.
         """
-        elapsed = sum(t for _, t in self._pending)
+        # Wait once per device at export, covering events on all training streams.
+        # Event intervals still exclude side-stream work not joined by their stream.
+        devices = {
+            timing[1].device for _, timing in self._pending if isinstance(timing, tuple)
+        }
+        for device in devices:
+            torch.cuda.synchronize(device)
+        elapsed = sum(
+            timing[0].elapsed_time(timing[1]) / 1000
+            if isinstance(timing, tuple)
+            else timing
+            for _, timing in self._pending
+        )
         lengths = [n for lens, _ in self._pending for n in lens.cpu().tolist()]
         tokens = sum(lengths)
         flops = sum(self.estimator(n) for n in lengths) if self.estimator else 0.0
@@ -107,7 +138,9 @@ def record_training_batch(
         engine._training_metrics = TrainingMetrics(estimator)
     moe = getattr(engine, "_moe_metrics", None)
     with (
-        engine._training_metrics.measure(batch, current_platform.synchronize),
+        engine._training_metrics.measure(
+            batch, current_platform.synchronize, device=engine.device
+        ),
         moe.measure() if moe is not None else nullcontext(),
     ):
         yield

--- a/areal/utils/training_metrics.py
+++ b/areal/utils/training_metrics.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Training work accounting, reduced before forming throughput ratios."""
+
+import math
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from areal.utils.flops import FlopsEstimator
+
+
+class TrainingMetrics:
+    def __init__(self, estimator: FlopsEstimator | None) -> None:
+        self.estimator = estimator
+        self._pending: list[tuple[torch.Tensor, float]] = []
+        self._totals = [0.0, 0.0, 0.0]
+
+    @contextmanager
+    def measure(
+        self, batch: dict[str, Any], synchronize: Callable[[], None]
+    ) -> Iterator[None]:
+        # Keep lengths on their existing device; transfer once at export.
+        lengths = batch["attention_mask"].detach().bool().sum(dim=-1)
+        synchronize()
+        start = time.perf_counter()
+        yield
+        synchronize()
+        self._pending.append((lengths, time.perf_counter() - start))
+
+    def export(
+        self,
+        *,
+        dp_group: dist.ProcessGroup | None,
+        timing_group: dist.ProcessGroup | None,
+    ) -> dict[str, float]:
+        """Sum unique DP work; divide by MAX accumulated rank training time.
+
+        timing_group is an explicit CPU group containing all training ranks.
+        Empty intervals (e.g. evaluation-only exports) produce no metrics.
+        """
+        elapsed = sum(t for _, t in self._pending)
+        lengths = [n for lens, _ in self._pending for n in lens.cpu().tolist()]
+        tokens = sum(lengths)
+        flops = sum(self.estimator(n) for n in lengths) if self.estimator else 0.0
+        if not math.isfinite(flops) or flops < 0:
+            raise ValueError("FLOPs estimator must return finite nonnegative FLOPs")
+        device = "cpu"
+        if dist.is_initialized() and dist.get_backend(dp_group) != "gloo":
+            from areal.infra.platforms import current_platform
+
+            device = current_platform.device_type
+        # Ascend does not support float64 device tensors. FLOPs are estimates;
+        # retain exact integer token counts in a separate reduction on all backends.
+        flops_dtype = torch.float32 if device == "npu" else torch.float64
+        token_work = torch.tensor(tokens, dtype=torch.int64, device=device)
+        flop_work = torch.tensor(flops, dtype=flops_dtype, device=device)
+        duration = torch.tensor(elapsed, dtype=torch.float64, device="cpu")
+        if dist.is_initialized():
+            dist.all_reduce(token_work, op=dist.ReduceOp.SUM, group=dp_group)
+            dist.all_reduce(flop_work, op=dist.ReduceOp.SUM, group=dp_group)
+            dist.all_reduce(duration, op=dist.ReduceOp.MAX, group=timing_group)
+        elapsed = duration.item()
+        self._pending.clear()
+        if elapsed <= 0:
+            return {}
+        tokens, flops = token_work.item(), flop_work.item()
+        for i, value in enumerate((tokens, flops, elapsed)):
+            self._totals[i] += value
+        result = {
+            "train_perf/tokens": tokens,
+            "train_perf/seconds": elapsed,
+            "train_perf/tokens_per_second": tokens / elapsed,
+            "train_perf/total_tokens": self._totals[0],
+            "train_perf/total_seconds": self._totals[2],
+            "train_perf/cumulative_tokens_per_second": self._totals[0]
+            / self._totals[2],
+        }
+        if self.estimator is not None:
+            result.update(
+                {
+                    "train_perf/estimated_flops": flops,
+                    "train_perf/estimated_flops_per_second": flops / elapsed,
+                    "train_perf/cumulative_estimated_flops_per_second": self._totals[1]
+                    / self._totals[2],
+                }
+            )
+        return result
+
+
+@contextmanager
+def record_training_batch(
+    engine: Any, batch: dict[str, Any], model_config: Any
+) -> Iterator[None]:
+    """Shared engine integration; lazily initialize per-engine counters."""
+    from contextlib import nullcontext
+
+    from areal.infra.platforms import current_platform
+    from areal.utils.flops import get_flops_estimator
+
+    if not hasattr(engine, "_training_metrics"):
+        estimator = get_flops_estimator(model_config)
+        engine._training_metrics = TrainingMetrics(estimator)
+    moe = getattr(engine, "_moe_metrics", None)
+    with (
+        engine._training_metrics.measure(batch, current_platform.synchronize),
+        moe.measure() if moe is not None else nullcontext(),
+    ):
+        yield
+
+
+def export_training_metrics(engine: Any) -> dict[str, float]:
+    """Export outside the algorithm's scope to the dedicated train_perf scope."""
+    metrics = getattr(engine, "_training_metrics", None)
+    if metrics is None:
+        return {}
+    return metrics.export(
+        dp_group=engine.data_parallel_group, timing_group=engine.cpu_group
+    )

--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -42,6 +42,7 @@ parts:
     chapters:
     - file: reference/checkpointing
     - file: reference/metrics_tracking
+    - file: reference/moe_visualization
     - file: reference/alloc_mode
     - file: reference/lora
     - file: reference/bridge_backend

--- a/docs/en/reference/metrics_tracking.md
+++ b/docs/en/reference/metrics_tracking.md
@@ -336,10 +336,15 @@ updates). Tokens are the sum of the original attention masks: prompt and respons
 count, masked padding does not. Counts are summed across data-parallel replicas only;
 TP, CP/SP, PP and EP do not multiply the logical batch size.
 
-Timing uses synchronized wall time around batch preparation, forward, backward and
-optimizer work, starting before gradient zeroing. Rollout, reference/evaluation
-forwards, loading the next batch, checkpointing and statistics export are excluded. The
-denominator is the maximum accumulated training time across training ranks.
+Timing spans batch preparation, forward, backward and optimizer work, starting before
+gradient zeroing. CUDA/ROCm uses events on the captured training stream and waits once
+per device at statistics export, without adding per-batch synchronization. This measures
+stream elapsed time, including stream waits and host submission gaps after the start
+event executes; side-stream work not joined before the end event is excluded. It is not
+a device-wide synchronized wall-time measurement. CPU/NPU retain synchronized wall
+timing. Rollout, reference/evaluation forwards, loading the next batch, checkpointing
+and statistics export are excluded. The denominator is the maximum accumulated training
+time across training ranks.
 
 | Metric                                                | Meaning                                                 |
 | ----------------------------------------------------- | ------------------------------------------------------- |

--- a/docs/en/reference/metrics_tracking.md
+++ b/docs/en/reference/metrics_tracking.md
@@ -438,9 +438,9 @@ map. Consequently routed counts can differ from logical throughput token counts.
 
 W&B receives one `moe_balance/expert_loads` Table per logged step with columns `layer`,
 `expert`, `tokens`, and `load_percent`. Per-layer `max_over_ideal` remains a scalar.
-This avoids thousands of individual W&B expert scalar series. Other scalar loggers
-retain `moe_balance/layer_<id>/expert_<id>/{tokens,load_percent}`. The console prints
-layer summaries without printing every expert.
+This avoids thousands of individual W&B expert scalar series. SwanLab and Trackio retain
+`moe_balance/layer_<id>/expert_<id>/{tokens,load_percent}`. TensorBoard and the console
+report layer summaries without individual expert scalar series.
 
 Recommended panels, built with
 [W&B custom charts](https://docs.wandb.ai/models/app/features/custom-charts):

--- a/docs/en/reference/metrics_tracking.md
+++ b/docs/en/reference/metrics_tracking.md
@@ -327,3 +327,137 @@ stats_logger:
 1. **Use named trackers**: Use
    `stats_tracker.get(workflow_context.stat_scope()).scalar(...)` to isolate rollout
    (`"rollout"`) and evaluation (`"eval-rollout"`) metrics from training metrics.
+
+## Training throughput, estimated FLOPs, and MoE balance
+
+Archon, Megatron, and FSDP export training work under `train_perf`. Each interval spans
+all `train_batch` calls since the previous statistics export (including repeated PPO
+updates). Tokens are the sum of the original attention masks: prompt and response both
+count, masked padding does not. Counts are summed across data-parallel replicas only;
+TP, CP/SP, PP and EP do not multiply the logical batch size.
+
+Timing uses synchronized wall time around batch preparation, forward, backward and
+optimizer work, starting before gradient zeroing. Rollout, reference/evaluation
+forwards, loading the next batch, checkpointing and statistics export are excluded. The
+denominator is the maximum accumulated training time across training ranks.
+
+| Metric                                                | Meaning                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| `train_perf/tokens`                                   | Global logical tokens processed in this export interval |
+| `train_perf/seconds`                                  | Training time for this interval                         |
+| `train_perf/tokens_per_second`                        | Interval tokens / interval seconds                      |
+| `train_perf/estimated_flops`                          | Sum of per-sequence forward + backward FLOPs            |
+| `train_perf/estimated_flops_per_second`               | Estimated interval FLOPs / interval seconds             |
+| `train_perf/total_tokens`, `train_perf/total_seconds` | Totals since engine initialization                      |
+| `train_perf/cumulative_tokens_per_second`             | Total tokens / total training time                      |
+| `train_perf/cumulative_estimated_flops_per_second`    | Total estimated FLOPs / total training time             |
+
+These are aggregate training-cluster rates, not per-GPU rates. Cumulative counters
+restart when the engine is recreated, including checkpoint recovery. Unsupported model
+architectures still log tokens and time, but omit FLOPs metrics.
+
+### FLOPs registration and conventions
+
+`areal.utils.flops` provides factories for `qwen3_moe` and `qwen3_5_moe[_text]`,
+including Qwen3-30B-A3B and Qwen3.5-35B-A3B. The actual checkpoint's text configuration
+supplies dimensions, so a local checkpoint directory works without name matching. The
+reference dimensions are from the official
+[Qwen3 configuration](https://huggingface.co/Qwen/Qwen3-30B-A3B/blob/main/config.json)
+and
+[Qwen3.5 configuration](https://huggingface.co/Qwen/Qwen3.5-35B-A3B/blob/main/config.json).
+
+A multiply-add counts as two FLOPs. The estimate is three times forward work (forward
+plus an estimated two-times-forward backward). It includes selected routed expert
+projections, routers, shared experts and their gate, attention projections, and the
+language-model head. Causal full attention includes
+`2 * query_heads * head_dim * L * (L + 1)` forward FLOPs per full-attention layer. For
+packed batches, sum `estimate(L_i)` over individual sequences; do not use
+`estimate(sum(L_i))`.
+
+Qwen3.5 accounts separately for its full-attention layers and linear-attention
+GatedDeltaNet layers, including gated projections and depthwise convolution. DeltaNet
+uses a recurrent-equivalent estimate of three key-by-value multiply-adds per value head
+per token (state prediction, update and readout). Its work grows linearly with sequence
+length. This is a model-math estimate, not a count of the extra operations used by a
+particular chunked kernel implementation.
+
+These estimates exclude activation recomputation, optimizer math, elementwise
+operations, softmax/normalization, auxiliary MTP branches and the vision encoder. They
+describe a full-parameter text-model training workload, not measured hardware FLOPs,
+exact LoRA/frozen-parameter backward work, or vision-model FLOPs. Tree training reports
+logical per-sequence work; shared-prefix savings are not subtracted.
+
+Register a custom factory in **each training worker before engine initialization**:
+
+```python
+from areal.utils.flops import register_flops_estimator
+
+
+def my_model_factory(config):
+    # Return a callable whose only input is one sequence's length.
+    active_parameters = config.active_parameters
+    heads = config.num_attention_heads
+    head_dim = config.head_dim
+    layers = config.num_hidden_layers
+
+    def total_training_flops(sequence_length: int) -> float:
+        linear = 6 * active_parameters * sequence_length
+        attention = 6 * layers * heads * head_dim * sequence_length * (sequence_length + 1)
+        return float(linear + attention)
+
+    return total_training_flops
+
+
+register_flops_estimator("my_model_type", my_model_factory)
+```
+
+Registration replaces any existing factory for that model type. Registering only in a
+controller process does not register it in remote training workers.
+
+### MoE balance and W&B visualization
+
+MoE diagnostics use the independent `moe_balance` scope. Archon supports its common MoE
+module, Megatron supports `TopKRouter`, and FSDP supports the Transformers
+`Qwen3MoeTopKRouter` and `Qwen3_5MoeTopKRouter` contracts. Decoder layer IDs are
+zero-based and global across pipeline stages. Shared experts and auxiliary MTP routers
+are excluded. Unsupported routers do not emit MoE diagnostics.
+
+For each layer, let `c_e` be the accumulated routing assignments to expert `e`, and `E`
+the number of routed experts:
+
+- Expert load percentage: `100 * c_e / sum(c_e)`; one layer sums to 100%.
+- Ideal load: `sum(c_e) / E`, including top-k assignment multiplicity.
+- `moe_balance/layer_<id>/max_over_ideal`: `max(c_e) / (sum(c_e) / E)`; perfect balance
+  is 1. Empty layers report zeros.
+
+Counts are reduced before normalization, so unequal microbatches and data-parallel
+shards are weighted correctly. Only original training forwards count; evaluation and
+checkpoint backward recomputation do not. These are **executed routing loads**:
+packing/alignment padding is included; Megatron counts its post-capacity/drop routing
+map. Consequently routed counts can differ from logical throughput token counts.
+
+W&B receives one `moe_balance/expert_loads` Table per logged step with columns `layer`,
+`expert`, `tokens`, and `load_percent`. Per-layer `max_over_ideal` remains a scalar.
+This avoids thousands of individual W&B expert scalar series. Other scalar loggers
+retain `moe_balance/layer_<id>/expert_<id>/{tokens,load_percent}`. The console prints
+layer summaries without printing every expert.
+
+Recommended panels, built with
+[W&B custom charts](https://docs.wandb.ai/models/app/features/custom-charts):
+
+1. **Layer × expert heatmap at a selected step:** color by `load_percent`, with tokens
+   in the tooltip. Keep expert order fixed. For cross-model comparisons, derive
+   `load_percent / (100 / E)` and center the color scale at 1.
+1. **Step × layer heatmap:** color by `max_over_ideal` to locate when a layer becomes
+   imbalanced. This uses the per-layer scalar history.
+1. **Single-layer expert bar chart:** filter the table by layer and draw an ideal
+   reference line at `100 / E`. Keep expert IDs on the x-axis to reveal persistent hot
+   or idle experts.
+
+Use `historyTable` and the step selector to switch snapshots directly. To display
+multiple steps simultaneously in a Table-based chart, combine snapshots with their log
+steps in postprocessing. Per-layer maximum load ratios already have scalar history.
+Quantiles, entropy, and coefficient of variation can be derived from the raw loads.
+
+See [MoE expert load visualization](moe_visualization.md) for the UI walkthrough, a
+ready-to-paste Vega specification, and recovery from 10,000-row preview truncation.

--- a/docs/en/reference/moe_visualization.md
+++ b/docs/en/reference/moe_visualization.md
@@ -47,7 +47,7 @@ field-mapping steps follow the
 [W&B tutorial](https://docs.wandb.ai/models/app/features/custom-charts/walkthrough).
 Enable **Other settings → Show step selector** to switch snapshots. This requires
 `historyTable`; `summaryTable` only reads the summary snapshot. See the
-[step selector documentation](https://docs.wandb.ai/support/models/articles/how-do-you-show-a-step-slider-in-a-custo).
+[step selector documentation](https://docs.wandb.ai/models/app/features/custom-charts#build-the-graphql-query).
 Use **Save as** to save a reusable preset and apply it to the panel.
 
 ## Vega specification

--- a/docs/en/reference/moe_visualization.md
+++ b/docs/en/reference/moe_visualization.md
@@ -1,0 +1,219 @@
+# Visualize MoE expert loads in W&B
+
+Use the `moe_balance/expert_loads` Table for a layer-by-expert heatmap with a step
+selector. See [metrics tracking](metrics_tracking.md) for definitions and backend
+support.
+
+## Interpret the data
+
+Each Table is one logged-step snapshot with `layer`, `expert`, `tokens`, and
+`load_percent`. Layer and expert IDs are zero-based. Tokens count executed routing
+assignments, including top-k multiplicity. Percentages sum to 100 per nonempty layer;
+empty layers contain zeros.
+
+The configuration below targets Qwen3.5-35B-A3B with **256 routed experts per layer**.
+Ideal load is `100 / 256 = 0.390625%`, so the load-to-ideal ratio is
+`load_percent * 2.56`. A ratio of 1 means balanced, 2 means twice ideal load, and 0
+means no assignments. Fixed color thresholds support comparison across steps:
+`[0.8, 1.2)` shares a near-balanced band and values `>= 8` share the darkest band.
+Tooltips retain the actual value. For other models, replace `2.56` with `E / 100` and
+adjust the expert-axis ticks. Use the number of routed experts, excluding shared
+experts; do not use top-k.
+
+## Configure the panel
+
+1. In the project Workspace, select **Add panel → Custom Chart**. Select one run to
+   avoid overlapping cells.
+1. In the upper-right **Query** area, click **summary ▾**, the gray dropdown below
+   `name` and above `keys: [""]` in this editor, and select **historyTable**.
+1. Set **tableKey** to `moe_balance/expert_loads`, the logged table key, not a column
+   name. Leave `id`, `name`, and `runSets` unchanged.
+1. Click **Edit** beside **Line plot** and replace the Vega specification with the JSON
+   below.
+1. Under **Chart fields**, map each placeholder to its Table column. The previous `x`,
+   `y`, and `groupKeys` fields should be replaced by these four fields. Query column
+   names may have a `runSets_historyTable_` prefix; choose the actual entries from the
+   dropdowns.
+
+| Chart field    | Table column   |
+| -------------- | -------------- |
+| `layer`        | `layer`        |
+| `expert`       | `expert`       |
+| `tokens`       | `tokens`       |
+| `load_percent` | `load_percent` |
+
+`load_multiple` is calculated inside the chart and needs no mapping. These query and
+field-mapping steps follow the
+[W&B tutorial](https://docs.wandb.ai/models/app/features/custom-charts/walkthrough).
+Enable **Other settings → Show step selector** to switch snapshots. This requires
+`historyTable`; `summaryTable` only reads the summary snapshot. See the
+[step selector documentation](https://docs.wandb.ai/support/models/articles/how-do-you-show-a-step-slider-in-a-custo).
+Use **Save as** to save a reusable preset and apply it to the panel.
+
+## Vega specification
+
+```json
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "data": {
+    "name": "wandb"
+  },
+  "title": "MoE expert load — 1× = balanced",
+  "transform": [
+    {
+      "calculate": "datum['${field:load_percent}'] * 2.56",
+      "as": "load_multiple"
+    }
+  ],
+  "mark": "rect",
+  "encoding": {
+    "x": {
+      "field": "${field:expert}",
+      "type": "ordinal",
+      "sort": "ascending",
+      "title": "Expert",
+      "axis": {
+        "values": [
+          0,
+          32,
+          64,
+          96,
+          128,
+          160,
+          192,
+          224,
+          255
+        ],
+        "labelAngle": 0
+      },
+      "scale": {
+        "paddingInner": 0,
+        "paddingOuter": 0
+      }
+    },
+    "y": {
+      "field": "${field:layer}",
+      "type": "ordinal",
+      "sort": "ascending",
+      "title": "Layer",
+      "scale": {
+        "paddingInner": 0,
+        "paddingOuter": 0
+      }
+    },
+    "color": {
+      "field": "load_multiple",
+      "type": "quantitative",
+      "title": "Load / ideal (×)",
+      "scale": {
+        "type": "threshold",
+        "domain": [
+          0.25,
+          0.5,
+          0.8,
+          1.2,
+          2,
+          4,
+          8
+        ],
+        "range": [
+          "#fff7ec",
+          "#fee8c8",
+          "#fdd49e",
+          "#fdbb84",
+          "#fc8d59",
+          "#ef6548",
+          "#b30000",
+          "#7f0000"
+        ]
+      },
+      "legend": {
+        "orient": "right",
+        "format": ".2~f"
+      }
+    },
+    "tooltip": [
+      {
+        "field": "${field:layer}",
+        "type": "ordinal",
+        "title": "Layer"
+      },
+      {
+        "field": "${field:expert}",
+        "type": "ordinal",
+        "title": "Expert"
+      },
+      {
+        "field": "${field:tokens}",
+        "type": "quantitative",
+        "title": "Tokens",
+        "format": ",.2~f"
+      },
+      {
+        "field": "load_multiple",
+        "type": "quantitative",
+        "title": "Load / ideal (×)",
+        "format": ".3f"
+      }
+    ]
+  },
+  "config": {
+    "view": {
+      "stroke": "#d1d5db"
+    },
+    "axis": {
+      "grid": false
+    }
+  }
+}
+```
+
+## Resolve the 10,000-row truncation
+
+Qwen3.5 has 40 layers × 256 experts = **10,240 rows**. The W&B SDK defaults to 10,000
+rows for run-media Table serialization, which can remove experts from previews and
+charts that consume them. Changing the Vega axis domain cannot recover rows removed
+during serialization.
+
+AReaL's `StatsLogger` raises this limit before constructing the expert Table:
+
+```python
+wandb.Table.MAX_ROWS = max(wandb.Table.MAX_ROWS, len(expert_rows))
+```
+
+Training with this fix preserves all 10,240 rows in subsequent snapshots. The regression
+test `test_stats_logger_large_expert_table_serializes_every_layer` checks the actual SDK
+serialization, including the final expert. This addresses the SDK limit only: if
+downloaded media JSON is complete but the chart is incomplete, inspect the deployed W&B
+server's query results and panel limits.
+
+**Existing uploaded previews are not repaired automatically.** Artifact serialization
+has a separate limit: the SDK used for validation defaults `MAX_ARTIFACT_ROWS` to
+200,000. The old 10,240-row artifacts in this validation were complete even when their
+previews were truncated. Raising only `MAX_ARTIFACT_ROWS` does not fix the run-media
+`MAX_ROWS` limit.
+
+To recover older snapshots:
+
+1. Download the required Table versions from the source run's Artifacts and inspect the
+   `data` row count in `moe_balance/expert_loads.table.json`.
+1. If complete, use the artifact for offline visualization or re-log its Table to a
+   separate visualization run after raising `MAX_ROWS`. Preserve original log steps when
+   recovering multiple snapshots and record source run and artifact versions. Artifact
+   version numbers are not necessarily log step numbers.
+1. If the artifact is also incomplete, recover from complete local logs or collect the
+   data again; increasing limits cannot reconstruct missing rows.
+
+For this Qwen3.5 model, verify 10,240 rows, 40 layers, 256 unique experts per layer, and
+the presence of `(layer=39, expert=255)`. Percentages for each nonempty layer should sum
+to 100 within floating-point tolerance. For larger tables, also check artifact limits
+and server/browser capacity. Postprocessing can split tables by layer while retaining
+all experts in each selected layer and the log step. Avoid random sampling followed by
+renormalization, which can hide hot experts and change the meaning of balance.
+
+## Pair with scalar history
+
+Plot `moe_balance/layer_<id>/max_over_ideal` beside the heatmap to locate an abnormal
+step and layer, then inspect the expert snapshot. Switching snapshots does not require
+manual Table merging. To display multiple steps simultaneously in one Table-based chart,
+combine snapshots and add a step column in postprocessing.

--- a/docs/zh/_toc.yml
+++ b/docs/zh/_toc.yml
@@ -42,6 +42,7 @@ parts:
     chapters:
     - file: reference/checkpointing
     - file: reference/metrics_tracking
+    - file: reference/moe_visualization
     - file: reference/alloc_mode
     - file: reference/lora
     - file: reference/bridge_backend

--- a/docs/zh/reference/metrics_tracking.md
+++ b/docs/zh/reference/metrics_tracking.md
@@ -315,3 +315,98 @@ stats_logger:
 
 1. **使用命名跟踪器**：使用 `stats_tracker.get(workflow_context.stat_scope()).scalar(...)` 将
    Rollout（`"rollout"`）和评估（`"eval-rollout"`）指标与训练指标隔离。
+
+## 训练吞吐、预估 FLOPs 与 MoE 均衡度
+
+Archon、Megatron 和 FSDP 在 `train_perf` scope 上报训练指标。每个统计窗口包含上次 export 以来的所有 `train_batch`
+调用，包括 PPO 中重复执行的更新。tokens 为原始 `attention_mask` 的有效 token 数，包含 prompt 和 response，不包含
+padding；只沿 DP 维度求和，不重复乘以 TP、CP/SP、PP 或 EP。
+
+耗时为设备同步后的训练 wall time，从梯度清零前开始，包含微批准备、前向、反向和 optimizer 工作；不包含
+rollout、参考模型/评估前向、读取下一批数据、存盘和统计导出。 分母取所有训练 rank 的累计训练耗时最大值。
+
+| 指标                                                  | 含义                                  |
+| ----------------------------------------------------- | ------------------------------------- |
+| `train_perf/tokens`                                   | 当前窗口训练侧总有效 tokens           |
+| `train_perf/seconds`                                  | 当前窗口训练耗时                      |
+| `train_perf/tokens_per_second`                        | 当前窗口 tokens / 耗时                |
+| `train_perf/estimated_flops`                          | 对各条序列的前向＋反向 FLOPs 估算求和 |
+| `train_perf/estimated_flops_per_second`               | 当前窗口预估 FLOPs / 耗时             |
+| `train_perf/total_tokens`、`train_perf/total_seconds` | engine 初始化以来的累计量             |
+| `train_perf/cumulative_tokens_per_second`             | 累计 tokens / 累计训练耗时            |
+| `train_perf/cumulative_estimated_flops_per_second`    | 累计预估 FLOPs / 累计训练耗时         |
+
+这些指标表示整个训练集群的吞吐，不是单卡吞吐。重建 engine（包括恢复训练）会重新累计。 没有注册 FLOPs 函数的架构仍然上报 tokens 和耗时，省略 FLOPs
+指标。
+
+### FLOPs 口径与自定义注册
+
+`areal.utils.flops` 预置 `qwen3_moe` 和 `qwen3_5_moe[_text]` 架构的计算工厂，覆盖 Qwen3-30B-A3B 和
+Qwen3.5-35B-A3B。计算使用实际 checkpoint 的 text config，支持本地 模型目录，无须匹配目录名。模型参考配置来自官方
+[Qwen3 配置](https://huggingface.co/Qwen/Qwen3-30B-A3B/blob/main/config.json)和
+[Qwen3.5 配置](https://huggingface.co/Qwen/Qwen3.5-35B-A3B/blob/main/config.json)。
+
+一次乘加计为 2 FLOPs，训练估算为前向的 3 倍（前向＋约 2 倍前向的反向）。包括激活的 专家投影、router、共享专家及 gate、attention 投影和 LM
+head。每层因果全注意力的前向 计算包含 `2 * query_heads * head_dim * L * (L + 1)`，所以 packed batch 必须对各条
+序列的 `estimate(L_i)` 求和，不能把总长度传入一次。
+
+Qwen3.5 分别计算全注意力与 GatedDeltaNet 线性注意力。后者包括各个投影和 depthwise 卷积，状态计算采用每个 value head、每个
+token 三次 key-by-value 乘加的递归等价估算 （状态预测、更新、读出），随序列长度线性增长，不刻画具体 chunk kernel 的额外操作。
+
+估算不包含激活重计算、optimizer、逐元素操作、softmax/归一化、视觉编码器和额外 MTP。 它表示文本骨干全参数训练的模型数学工作量，不等同于实际硬件执行
+FLOPs，也不是 LoRA/冻结参数时的精确反向计算量。树训练按原始序列估算，不扣除共享前缀节省的计算。
+
+在**每个训练 worker 的 engine 初始化前**注册自定义工厂；仅在 controller 注册不会 自动传到远程
+worker。工厂接收模型配置，返回一个只接收单条序列长度、输出训练总 FLOPs 的函数。同名注册会覆盖预置工厂：
+
+```python
+from areal.utils.flops import register_flops_estimator
+
+
+def my_model_factory(config):
+    active_parameters = config.active_parameters
+    heads = config.num_attention_heads
+    head_dim = config.head_dim
+    layers = config.num_hidden_layers
+
+    def total_training_flops(sequence_length: int) -> float:
+        linear = 6 * active_parameters * sequence_length
+        attention = 6 * layers * heads * head_dim * sequence_length * (sequence_length + 1)
+        return float(linear + attention)
+
+    return total_training_flops
+
+
+register_flops_estimator("my_model_type", my_model_factory)
+```
+
+### MoE 均衡度与 W&B 可视化
+
+MoE 使用独立的 `moe_balance` scope。Archon 支持通用 MoE 模块，Megatron 支持 `TopKRouter`，FSDP 支持
+Transformers 的 `Qwen3MoeTopKRouter` 和 `Qwen3_5MoeTopKRouter` 返回值契约。层编号从 0 开始，在 PP
+之间保持全局唯一；共享专家 和额外 MTP router 不纳入统计。不支持的 router 不产生均衡度指标。
+
+设一层有 `E` 个专家，专家 `e` 的累计路由分配数为 `c_e`：
+
+- 每个专家占比为 `100 * c_e / sum(c_e)`，同层合计 100%。
+- 理想负载为 `sum(c_e) / E`，分配数包含 top-k 的重复路由。
+- `moe_balance/layer_<id>/max_over_ideal` 为最大负载除以理想负载，完全均衡时为 1。 没有路由分配的层上报 0。
+
+先跨微批和并行 rank 累加负载，再归一化。只计原始训练前向，不计评估和 backward 重计算。这是**实际执行的路由负载**：包含 packing/alignment
+padding；Megatron 使用 capacity/drop 之后的 routing map。因此负载总数可能与吞吐指标中的逻辑 tokens 不同。
+
+W&B 每个日志 step 收到一个 `moe_balance/expert_loads` Table，列为 `layer`、`expert`、
+`tokens`、`load_percent`。每层 `max_over_ideal` 保持标量，避免产生上万个专家标量序列。 其他标量日志后端保留
+`moe_balance/layer_<id>/expert_<id>/{tokens,load_percent}`；控制台 仅打印每层摘要。
+
+建议用 [W&B Custom Charts](https://docs.wandb.ai/models/app/features/custom-charts) 制作以下面板：
+
+1. **选定 step 的“层 × 专家”热力图**：颜色表示负载百分比，tooltip 显示 tokens。 固定专家顺序；跨模型比较时可二次计算
+   `load_percent / (100 / E)`，以 1 为颜色中心。
+1. **“训练步 × 层”热力图**：颜色表示 `max_over_ideal`，定位从何时起、哪些层发生失衡。
+1. **单层专家柱状图**：按层筛选 Table，加入理想占比 `100 / E` 的参考线，观察长期热点 或闲置专家。
+
+单个 Table 是一个 step 的快照。使用 `historyTable` 和 step 滑块可直接切换快照； 若要同时展示多个 step 的 Table
+数据，则需在后处理中合并快照并添加 step 列。 每层最大负载比可直接使用标量历史。分位数、熵、变异系数等额外指标可用原始负载在 W&B 二次计算。
+
+完整操作步骤、可粘贴的 Vega 配置和 10,000 行截断处理见 [MoE 专家负载可视化](moe_visualization.md)。

--- a/docs/zh/reference/metrics_tracking.md
+++ b/docs/zh/reference/metrics_tracking.md
@@ -322,7 +322,9 @@ Archon、Megatron 和 FSDP 在 `train_perf` scope 上报训练指标。每个统
 调用，包括 PPO 中重复执行的更新。tokens 为原始 `attention_mask` 的有效 token 数，包含 prompt 和 response，不包含
 padding；只沿 DP 维度求和，不重复乘以 TP、CP/SP、PP 或 EP。
 
-耗时为设备同步后的训练 wall time，从梯度清零前开始，包含微批准备、前向、反向和 optimizer 工作；不包含
+计时从梯度清零前开始，覆盖微批准备、前向、反向和 optimizer 工作。CUDA/ROCm 在进入计时区间时捕获训练流， 使用该流上的 events
+记录区间，仅在统计导出时对每个设备同步一次，不额外插入批次级同步。 该时间包含流上的等待及起始 event 执行后的主机提交间隙，但不包含结束 event
+前未汇合的其他流异步工作， 因此不是设备全局同步后的 wall time。CPU/NPU 保留同步 wall time 计时。不包含
 rollout、参考模型/评估前向、读取下一批数据、存盘和统计导出。 分母取所有训练 rank 的累计训练耗时最大值。
 
 | 指标                                                  | 含义                                  |

--- a/docs/zh/reference/metrics_tracking.md
+++ b/docs/zh/reference/metrics_tracking.md
@@ -396,8 +396,8 @@ Transformers 的 `Qwen3MoeTopKRouter` 和 `Qwen3_5MoeTopKRouter` 返回值契约
 padding；Megatron 使用 capacity/drop 之后的 routing map。因此负载总数可能与吞吐指标中的逻辑 tokens 不同。
 
 W&B 每个日志 step 收到一个 `moe_balance/expert_loads` Table，列为 `layer`、`expert`、
-`tokens`、`load_percent`。每层 `max_over_ideal` 保持标量，避免产生上万个专家标量序列。 其他标量日志后端保留
-`moe_balance/layer_<id>/expert_<id>/{tokens,load_percent}`；控制台 仅打印每层摘要。
+`tokens`、`load_percent`。每层 `max_over_ideal` 保持标量，避免产生上万个专家标量序列。 SwanLab 和 Trackio 保留
+`moe_balance/layer_<id>/expert_<id>/{tokens,load_percent}`；TensorBoard 和控制台仅输出每层摘要。
 
 建议用 [W&B Custom Charts](https://docs.wandb.ai/models/app/features/custom-charts) 制作以下面板：
 

--- a/docs/zh/reference/moe_visualization.md
+++ b/docs/zh/reference/moe_visualization.md
@@ -1,0 +1,199 @@
+# 在 W&B 中可视化 MoE 专家负载
+
+本文使用 `moe_balance/expert_loads` Table 制作“层 × 专家”热力图，并用 step 滑块切换训练快照。
+指标定义和后端支持见[指标跟踪](metrics_tracking.md)。
+
+## 数据与颜色含义
+
+每个 Table 是一个日志 step 的快照，包含 `layer`、`expert`、`tokens`、`load_percent` 四列。 层和专家编号从 0
+开始；`tokens` 表示实际路由分配数，包含 top-k 重复分配。 非空层的 `load_percent` 合计为 100；空层为 0。
+
+下面的配置用于每层 **256 个专家**的 Qwen3.5-35B-A3B：
+
+- 理想占比为 `100 / 256 = 0.390625%`。
+- 相对理想负载为 `load_percent / (100 / 256) = load_percent * 2.56`。
+- `1×` 表示均衡，`2×` 表示理想负载的两倍，`0×` 表示该专家没有路由分配。
+- 固定阈值颜色可用于跨 step 比较；`[0.8, 1.2)` 共用一个接近均衡的色阶，`>= 8×` 共用最深色。 最深色不代表数值被截断，悬停仍可查看实际倍数。
+
+其他模型应将 `2.56` 改为实际专家数 `E / 100`，并调整横轴刻度。 这里的专家数仅包含 routed experts，不包含 shared
+experts，也不是每个 token 的 top-k。
+
+## 配置面板
+
+1. 在 W&B 项目 Workspace 中选择 **Add panel → Custom Chart**。先只选择一个 run，避免不同 run 的单元格重叠。
+1. 点击右上角 **Query** 区域的 **summary ▾**：在此界面中，它是 `name` 下面、`keys: [""]` 上面的灰色下拉框。 将其切换为
+   **historyTable**。这是
+   [W&B 官方教程](https://docs.wandb.ai/models/app/features/custom-charts/walkthrough)中的查询入口。
+1. 在出现的 **tableKey** 中填写 `moe_balance/expert_loads`。 填的是表名，不是 `layer` 或 `expert`
+   等列名；`id`、`name` 和上面的 `runSets` 保持原样。
+1. 点击左上角 **Line plot** 旁边的 **Edit**，将 Vega 配置完整替换为下一节的 JSON。
+1. 回到右侧 **Chart fields**。原有的 `x`、`y`、`groupKeys` 应变成配置定义的四个字段，按下表从下拉框选择对应列。 列名可能带有
+   `runSets_historyTable_` 前缀，以实际下拉框为准。
+
+| 图表字段       | 选择的 Table 列 |
+| -------------- | --------------- |
+| `layer`        | `layer`         |
+| `expert`       | `expert`        |
+| `tokens`       | `tokens`        |
+| `load_percent` | `load_percent`  |
+
+`load_multiple` 是图表内部计算的字段，不需要映射。 在 **Other settings** 中开启 **Show step
+selector**，通过滑块选择日志 step。 该选项需要 `historyTable`；`summaryTable` 只读取 summary 中的快照。
+参见[官方 step 滑块说明](https://docs.wandb.ai/support/models/articles/how-do-you-show-a-step-slider-in-a-custo)。
+最后使用 **Save as** 保存 preset，再应用到面板。
+
+## 可直接粘贴的 Vega 配置
+
+```json
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "data": {
+    "name": "wandb"
+  },
+  "title": "MoE expert load — 1× = balanced",
+  "transform": [
+    {
+      "calculate": "datum['${field:load_percent}'] * 2.56",
+      "as": "load_multiple"
+    }
+  ],
+  "mark": "rect",
+  "encoding": {
+    "x": {
+      "field": "${field:expert}",
+      "type": "ordinal",
+      "sort": "ascending",
+      "title": "Expert",
+      "axis": {
+        "values": [
+          0,
+          32,
+          64,
+          96,
+          128,
+          160,
+          192,
+          224,
+          255
+        ],
+        "labelAngle": 0
+      },
+      "scale": {
+        "paddingInner": 0,
+        "paddingOuter": 0
+      }
+    },
+    "y": {
+      "field": "${field:layer}",
+      "type": "ordinal",
+      "sort": "ascending",
+      "title": "Layer",
+      "scale": {
+        "paddingInner": 0,
+        "paddingOuter": 0
+      }
+    },
+    "color": {
+      "field": "load_multiple",
+      "type": "quantitative",
+      "title": "Load / ideal (×)",
+      "scale": {
+        "type": "threshold",
+        "domain": [
+          0.25,
+          0.5,
+          0.8,
+          1.2,
+          2,
+          4,
+          8
+        ],
+        "range": [
+          "#fff7ec",
+          "#fee8c8",
+          "#fdd49e",
+          "#fdbb84",
+          "#fc8d59",
+          "#ef6548",
+          "#b30000",
+          "#7f0000"
+        ]
+      },
+      "legend": {
+        "orient": "right",
+        "format": ".2~f"
+      }
+    },
+    "tooltip": [
+      {
+        "field": "${field:layer}",
+        "type": "ordinal",
+        "title": "Layer"
+      },
+      {
+        "field": "${field:expert}",
+        "type": "ordinal",
+        "title": "Expert"
+      },
+      {
+        "field": "${field:tokens}",
+        "type": "quantitative",
+        "title": "Tokens",
+        "format": ",.2~f"
+      },
+      {
+        "field": "load_multiple",
+        "type": "quantitative",
+        "title": "Load / ideal (×)",
+        "format": ".3f"
+      }
+    ]
+  },
+  "config": {
+    "view": {
+      "stroke": "#d1d5db"
+    },
+    "axis": {
+      "grid": false
+    }
+  }
+}
+```
+
+## 排查 10,000 行截断
+
+Qwen3.5 的 40 层 × 256 个专家共有 **10,240 行**。W&B SDK 的 run-media Table 序列化默认上限为 10,000
+行，可能导致最后一层的部分专家从预览及依赖该预览的图表中消失。 这是数据序列化阶段的截断，修改 Vega 横轴范围无法找回这些行。
+
+AReaL 的 `StatsLogger` 已在创建专家 Table 前按实际行数提高上限：
+
+```python
+wandb.Table.MAX_ROWS = max(wandb.Table.MAX_ROWS, len(expert_rows))
+```
+
+使用包含此修复的训练版本，后续快照会保留全部 10,240 行。回归测试
+`test_stats_logger_large_expert_table_serializes_every_layer` 检查实际 SDK 序列化结果的行数和最后一个专家。
+这只处理 SDK 序列化上限；如果导出的 media JSON 完整而图表仍缺行，需进一步检查当前 W&B 服务端的查询结果和面板限制。
+
+**已上传的旧快照不会自动修复。** Table artifact 与 run-media 预览使用不同的序列化上限； 当前验证环境的 SDK
+中，`MAX_ARTIFACT_ROWS` 默认为 200,000，因此这次 10,240 行的旧 artifact 完整，预览却可能截断。 仅提高
+`MAX_ARTIFACT_ROWS` 不能解决 run-media 的 `MAX_ROWS` 限制。
+
+处理旧数据时：
+
+1. 从原 run 的 Artifacts 中下载需要的 Table 版本，检查其中 `moe_balance/expert_loads.table.json` 的
+   `data` 行数。
+1. 若 artifact 完整，可直接用它做离线热力图，或在设置 `MAX_ROWS` 后将完整 Table 重新上报到独立的可视化 run。 恢复多个快照时保留原日志
+   step，并记录源 run 和 artifact 版本；artifact 的版本号不一定等于日志 step。
+1. 若 artifact 本身也缺行，提高上限不能恢复丢失数据，需从完整本地日志恢复或重新采集。
+
+对这份 Qwen3.5 数据，完整性检查应包括：10,240 行、40 个层编号、每层 256 个唯一专家， 以及 `(layer=39, expert=255)`
+存在。非空层占比之和应在浮点误差范围内等于 100%。
+
+专家规模更大时，还需检查 SDK 的 artifact 上限以及服务端和浏览器的处理能力。 可以在后处理中按层拆分 Table，每张表保留选定层的所有专家，并保留日志
+step。 不要随机抽样后重新归一化，否则会掩盖热点专家并改变均衡度含义。
+
+## 配合标量定位问题
+
+在热力图旁展示 `moe_balance/layer_<id>/max_over_ideal` 折线：先定位异常 step 和层，
+再用专家热力图查看该步的具体负载。切换快照无需手动合并 Table； 若要把多个 step 同时绘制在同一张图中，则需要在后处理中合并快照并添加 step 列。

--- a/docs/zh/reference/moe_visualization.md
+++ b/docs/zh/reference/moe_visualization.md
@@ -39,7 +39,7 @@ experts，也不是每个 token 的 top-k。
 
 `load_multiple` 是图表内部计算的字段，不需要映射。 在 **Other settings** 中开启 **Show step
 selector**，通过滑块选择日志 step。 该选项需要 `historyTable`；`summaryTable` 只读取 summary 中的快照。
-参见[官方 step 滑块说明](https://docs.wandb.ai/support/models/articles/how-do-you-show-a-step-slider-in-a-custo)。
+参见[官方 step 滑块说明](https://docs.wandb.ai/models/app/features/custom-charts#build-the-graphql-query)。
 最后使用 **Save as** 保存 preset，再应用到面板。
 
 ## 可直接粘贴的 Vega 配置

--- a/tests/test_megatron_optimizer_config.py
+++ b/tests/test_megatron_optimizer_config.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -76,8 +77,13 @@ def test_train_batch_does_not_apply_optimizer_loss_scale_manually(
     engine = megatron_engine_module.MegatronEngine.__new__(
         megatron_engine_module.MegatronEngine
     )
-    engine._awex_adapter = None
+    engine._weight_residency = None
+    engine.hf_config = None
     engine.device = torch.device("cpu")
+    # This test isolates loss scaling; metrics have their own batch-aware tests.
+    monkeypatch.setattr(
+        megatron_engine_module, "record_training_batch", lambda *args: nullcontext()
+    )
     engine.optimizer = _Optimizer()
     engine._ensure_ready = lambda: None
     engine.optimizer_zero_grad = lambda: None

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -742,6 +742,8 @@ class TestRemotize:
     @pytest.mark.parametrize("preserve_tensor_aliases", [False, True])
     def test_remotize_list_of_dicts(self, rpc_server, preserve_tensor_aliases):
         """Test remotizing list of dicts with different attention masks."""
+        from areal.infra.rpc.rtensor import fetch
+
         # Create two trajectory dicts with different seqlens
         traj1 = {
             "attention_mask": torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]]),
@@ -774,12 +776,16 @@ class TestRemotize:
         assert result[0]["logits"].shape[0] == 2
         assert result[1]["logits"].shape[0] == 3
 
+        # remotize stores in this process; the RPC subprocess has no such shards.
         for original, remote, seqlen in zip(
             [traj1, traj2], result, [3, 4], strict=True
         ):
             for key in original:
                 torch.testing.assert_close(
-                    remote[key].to_local(), original[key][:, :seqlen], rtol=0, atol=0
+                    fetch(remote[key].shard.shard_id),
+                    original[key][:, :seqlen],
+                    rtol=0,
+                    atol=0,
                 )
 
     def test_remotize_list_of_tensors(self, rpc_server):

--- a/tests/test_trainer_eval_before_train.py
+++ b/tests/test_trainer_eval_before_train.py
@@ -173,6 +173,7 @@ def _build_ppo_trainer(events: list[tuple], *, recovered: bool = False):
     trainer.critic = None
     trainer.ref = None
     trainer.teacher = None
+    trainer.mopd_execution_plan = None
     trainer._should_offload_rollout = False
     trainer._should_offload_actor = False
     trainer._requires_proxy_workflow = lambda _workflow: False

--- a/tests/test_training_metrics.py
+++ b/tests/test_training_metrics.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU coverage for model work estimates and distributed metric aggregation."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from areal.utils.flops import get_flops_estimator, register_flops_estimator
+from areal.utils.moe_metrics import MoEMetrics, normalize_expert_loads
+from areal.utils.training_metrics import TrainingMetrics
+
+
+def _config(hybrid=False):
+    return SimpleNamespace(
+        model_type="qwen3_5_moe_text" if hybrid else "qwen3_moe",
+        hidden_size=2048,
+        num_hidden_layers=40 if hybrid else 48,
+        num_attention_heads=16 if hybrid else 32,
+        num_key_value_heads=2 if hybrid else 4,
+        head_dim=256 if hybrid else 128,
+        num_experts=256 if hybrid else 128,
+        num_experts_per_tok=8,
+        moe_intermediate_size=512 if hybrid else 768,
+        shared_expert_intermediate_size=512 if hybrid else 0,
+        vocab_size=248320 if hybrid else 151936,
+        layer_types=["linear_attention"] * 3 + ["full_attention"],
+        linear_num_key_heads=16,
+        linear_num_value_heads=32,
+        linear_key_head_dim=128,
+        linear_value_head_dim=128,
+        linear_conv_kernel_dim=4,
+    )
+
+
+@pytest.mark.parametrize("hybrid", [False, True])
+def test_flops_sequence_lengths_preserve_quadratic_attention(hybrid):
+    """Packing must sum individual FLOPs, never square the packed token count."""
+    config = _config(hybrid)
+    config.layer_types *= 10
+    estimate = get_flops_estimator(config)
+    full_layers = 10 if hybrid else 48
+    coefficient = 3 * full_layers * 2 * config.num_attention_heads * config.head_dim
+    assert estimate(0) == 0
+    assert estimate(20) - 2 * estimate(10) == coefficient * 200
+    assert estimate(10) > 0
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        estimate(-1)
+
+
+def test_flops_tiny_qwen_matches_hand_counted_projections():
+    """Count Q/K/V/O, selected MLPs, router, head and causal attention by hand."""
+    config = SimpleNamespace(
+        model_type="qwen3_moe",
+        hidden_size=2,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=1,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=3,
+        vocab_size=5,
+    )
+    # Per-token: attention projections=24, MLP=72, router=16, LM head=20.
+    # Length 3: 6 causal pairs * 2 heads * 1 dim * 4 FLOPs = 48.
+    assert get_flops_estimator(config)(3) == 3 * (3 * 132 + 48)
+
+
+def test_flops_hybrid_all_linear_has_no_quadratic_term():
+    """DeltaNet state work grows linearly with sequence length."""
+    config = _config(True)
+    config.layer_types = ["linear_attention"] * config.num_hidden_layers
+    estimate = get_flops_estimator(SimpleNamespace(text_config=config))
+    assert estimate(200) == 2 * estimate(100)
+
+
+def test_flops_custom_registry_and_unknown_model():
+    """Custom estimators receive the actual checkpoint configuration."""
+    register_flops_estimator("test_custom", lambda config: lambda n: config.factor * n)
+    config = SimpleNamespace(model_type="test_custom", factor=42)
+    assert get_flops_estimator(config)(10) == 420
+    assert get_flops_estimator(SimpleNamespace(model_type="unknown")) is None
+
+
+def test_training_metrics_interval_and_cumulative_are_ratios_of_sums(monkeypatch):
+    """Exclude masked padding and aggregate unequal-duration optimizer calls."""
+    metrics = TrainingMetrics(lambda n: n * n)
+    times = iter([0.0, 2.0, 3.0, 7.0, 10.0, 12.0])
+    monkeypatch.setattr(
+        "areal.utils.training_metrics.time.perf_counter", lambda: next(times)
+    )
+    batch = {"attention_mask": torch.tensor([[1, 1, 0], [1, 1, 1]])}
+    synchronizations = []
+    for _ in range(2):
+        with metrics.measure(batch, lambda: synchronizations.append(True)):
+            pass
+    result = metrics.export(dp_group=None, timing_group=None)
+    assert len(synchronizations) == 4
+    assert result["train_perf/tokens"] == 10
+    assert result["train_perf/tokens_per_second"] == pytest.approx(10 / 6)
+    assert result["train_perf/estimated_flops_per_second"] == pytest.approx(26 / 6)
+    assert metrics.export(dp_group=None, timing_group=None) == {}
+    with metrics.measure(batch, lambda: None):
+        pass
+    result = metrics.export(dp_group=None, timing_group=None)
+    assert result["train_perf/cumulative_tokens_per_second"] == 15 / 8
+
+
+def test_training_metrics_unknown_model_omits_flops():
+    """Unsupported architectures still provide token throughput."""
+    metrics = TrainingMetrics(None)
+    metrics._pending = [(torch.tensor([4]), 2.0)]
+    result = metrics.export(dp_group=None, timing_group=None)
+    assert result["train_perf/tokens_per_second"] == 2
+    assert all("flops" not in key for key in result)
+
+
+@pytest.mark.parametrize(
+    "counts,percent,ratio",
+    [
+        ([2, 2], [50, 50], 1),
+        ([3, 1], [75, 25], 1.5),
+        ([4, 0], [100, 0], 2),
+        ([0, 0], [0, 0], 0),
+    ],
+)
+def test_moe_normalization_load_cases_match_expected(counts, percent, ratio):
+    """Normalize assignments, with a defined empty-layer result."""
+    actual, imbalance = normalize_expert_loads(torch.tensor(counts))
+    torch.testing.assert_close(
+        actual, torch.tensor(percent, dtype=torch.float64), rtol=0, atol=0
+    )
+    assert imbalance.item() == ratio
+
+
+class _Router(nn.Module):
+    def forward(self, x):
+        return x.sin(), None, torch.tensor([3, 1], device=x.device)
+
+
+class _Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.router = _Router()
+        self.register_buffer("routing_counts", torch.zeros(2, dtype=torch.int64))
+
+    def forward(self, x):
+        y, _, counts = self.router(x)
+        self.routing_counts.copy_(counts)
+        return y.cos()
+
+
+class _Model(nn.Module):
+    def __init__(self, block, recompute):
+        super().__init__()
+        self.block = block
+        self.recompute = recompute
+
+    def forward(self, x):
+        if self.recompute:
+            return checkpoint(self.block, x, use_reentrant=False)
+        return self.block(x)
+
+
+@pytest.mark.parametrize("buffers", [False, True])
+@pytest.mark.parametrize("recompute", [False, True])
+def test_moe_collector_excludes_eval_and_backward_recomputation(buffers, recompute):
+    """Original model forwards count once even when inner layers are replayed."""
+    block = _Block()
+    model = _Model(block, recompute)
+    metrics = MoEMetrics()
+    if buffers:
+        metrics.attach_buffers(model, [("7", block)])
+    else:
+        metrics.attach(model, [("7", block.router)], lambda output: output[2])
+    x = torch.randn(4, requires_grad=True)
+    model(x)  # evaluation/reference forward outside training
+    with metrics.measure():
+        model(x).sum().backward()
+        model(x).sum().backward()
+    result = metrics.export(reduce_group=None)
+    assert result["moe_balance/layer_7/expert_0/tokens"] == 6
+    assert result["moe_balance/layer_7/expert_0/load_percent"] == 75
+    assert result["moe_balance/layer_7/max_over_ideal"] == 1.5
+    assert metrics.export(reduce_group=None) == {}
+    metrics.close()
+
+
+@pytest.mark.slow
+@pytest.mark.ci
+def test_moe_buffer_collection_with_fullgraph_compile_counts_once():
+    """Archon's outer hook permits fullgraph compilation of the inner layer."""
+    block = _Block()
+    model = _Model(torch.compile(block, backend="aot_eager", fullgraph=True), True)
+    metrics = MoEMetrics()
+    metrics.attach_buffers(model, [("0", block)])
+    with metrics.measure():
+        model(torch.randn(4, requires_grad=True)).sum().backward()
+    result = metrics.export(reduce_group=None)
+    assert result["moe_balance/layer_0/expert_0/tokens"] == 3
+    metrics.close()
+
+
+def _distributed_worker(rank, rendezvous, backend="gloo"):
+    device = "cpu"
+    if backend == "nccl":
+        torch.cuda.set_device(rank)
+        device = f"cuda:{rank}"
+    dist.init_process_group(
+        backend, init_method=f"file://{rendezvous}", rank=rank, world_size=2
+    )
+    world = dist.new_group([0, 1], backend=backend)
+    timing = dist.new_group([0, 1], backend="gloo")
+    local_groups = [dist.new_group([i], backend=backend) for i in range(2)]
+    try:
+        metrics = TrainingMetrics(lambda n: n * n)
+        metrics._pending = [(torch.tensor([3 + 4 * rank], device=device), 2 + 2 * rank)]
+        result = metrics.export(dp_group=world, timing_group=timing)
+        assert result["train_perf/tokens"] == 10
+        assert result["train_perf/tokens_per_second"] == 2.5
+        assert result["train_perf/estimated_flops_per_second"] == 58 / 4
+        # Two model-parallel replicas: each has the same logical input.
+        metrics = TrainingMetrics(None)
+        metrics._pending = [(torch.tensor([3], device=device), 2 + 2 * rank)]
+        result = metrics.export(dp_group=local_groups[rank], timing_group=timing)
+        assert result["train_perf/tokens_per_second"] == 3 / 4
+        # Unequal local loads must be summed BEFORE normalization.
+        moe = MoEMetrics()
+        moe.counts["0"] = (
+            torch.tensor([3, 1], device=device)
+            if rank == 0
+            else torch.tensor([1, 5], device=device)
+        )
+        result = moe.export(reduce_group=world)
+        assert result["moe_balance/layer_0/expert_0/load_percent"] == 40
+        assert result["moe_balance/layer_0/max_over_ideal"] == 1.2
+        # Different PP stages own distinct global layer IDs.
+        moe.counts[str(rank)] = torch.tensor([3, 1], device=device)
+        result = moe.export(reduce_group=local_groups[rank], pp_group=world)
+        assert result["moe_balance/layer_0/max_over_ideal"] == 1.5
+        assert result["moe_balance/layer_1/max_over_ideal"] == 1.5
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.slow
+@pytest.mark.ci
+def test_distributed_work_and_moe_reductions_preserve_topology(tmp_path):
+    """Two real CPU/Gloo ranks test SUM/MAX, replica exclusion, and PP union."""
+    mp.spawn(
+        _distributed_worker, args=(str(tmp_path / "rendezvous"),), nprocs=2, join=True
+    )
+
+
+def test_expert_load_table_preserves_ids_counts_and_scalar_ratios():
+    """W&B receives one expert matrix table and the per-layer ratio scalars."""
+    from areal.utils.moe_metrics import split_expert_load_metrics
+
+    scalar, rows = split_expert_load_metrics(
+        {
+            "moe_balance/layer_10/expert_2/tokens": 7,
+            "moe_balance/layer_10/expert_2/load_percent": 70,
+            "moe_balance/layer_2/expert_1/tokens": 3,
+            "moe_balance/layer_2/expert_1/load_percent": 30,
+            "moe_balance/layer_10/max_over_ideal": 1.4,
+            "train_perf/tokens_per_second": 100,
+        }
+    )
+    assert rows == [[2, 1, 3, 30], [10, 2, 7, 70]]
+    assert scalar == {
+        "moe_balance/layer_10/max_over_ideal": 1.4,
+        "train_perf/tokens_per_second": 100,
+    }
+
+
+def test_stats_logger_logs_expert_table_without_expert_scalar_series(monkeypatch):
+    """Exercise W&B payload construction without creating or publishing a run."""
+    from areal.utils import stats_logger
+
+    logged = []
+    monkeypatch.setattr(
+        stats_logger.wandb, "log", lambda data, step: logged.append((data, step))
+    )
+    monkeypatch.setattr(stats_logger.swanlab, "log", lambda *args, **kwargs: None)
+    logger = stats_logger.StatsLogger.__new__(stats_logger.StatsLogger)
+    logger.ft_spec = SimpleNamespace(
+        total_train_epochs=1, steps_per_epoch=1, total_train_steps=1
+    )
+    logger._last_commit_step = -1
+    logger.summary_writer = None
+    logger.print_stats = lambda data: None
+    logger.commit(
+        0,
+        0,
+        0,
+        {
+            "moe_balance/layer_0/expert_0/tokens": 3,
+            "moe_balance/layer_0/expert_0/load_percent": 75,
+            "moe_balance/layer_0/max_over_ideal": 1.5,
+            "train_perf/tokens_per_second": 123,
+        },
+    )
+    payload, step = logged[0]
+    assert step == 0
+    assert payload["moe_balance/expert_loads"].columns == [
+        "layer",
+        "expert",
+        "tokens",
+        "load_percent",
+    ]
+    assert payload["moe_balance/expert_loads"].data == [[0, 0, 3, 75]]
+    assert payload["moe_balance/layer_0/max_over_ideal"] == 1.5
+    assert payload["train_perf/tokens_per_second"] == 123
+    assert not any("/expert_0/" in key for key in payload)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for Archon MoE kernels"
+)
+@pytest.mark.parametrize("recompute", [False, True])
+def test_archon_moe_cuda_buffer_counts_original_training_forward(recompute):
+    """Validate the real MoE routing buffer with Triton routing and backward."""
+    pytest.importorskip("triton")
+    from areal.experimental.models.archon.moe import MoE, MoEArgs
+
+    moe = MoE(
+        MoEArgs(
+            num_experts=4, top_k=2, use_grouped_mm=False, _debug_force_load_balance=True
+        ),
+        dim=16,
+        hidden_dim=32,
+    ).to(device="cuda", dtype=torch.bfloat16)
+    moe.init_buffers("cuda")
+    moe.init_weights(0.02)
+    model = _Model(moe, recompute)
+    metrics = MoEMetrics()
+    metrics.attach_buffers(model, [("0", moe)])
+    x = torch.randn(1, 8, 16, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    model(x)  # excluded evaluation/reference computation
+    with metrics.measure():
+        model(x).float().sum().backward()
+    result = metrics.export(reduce_group=None)
+    assert sum(result[f"moe_balance/layer_0/expert_{e}/tokens"] for e in range(4)) == 16
+    assert (
+        sum(result[f"moe_balance/layer_0/expert_{e}/load_percent"] for e in range(4))
+        == 100
+    )
+    assert result["moe_balance/layer_0/max_over_ideal"] == 1
+    assert torch.isfinite(x.grad).all()
+    assert "routing_counts" not in moe.state_dict()
+    metrics.close()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="Two CUDA devices required for NCCL"
+)
+def test_distributed_nccl_metrics_reduce_cuda_work_and_cpu_timing(tmp_path):
+    """Validate actual NCCL work/load collectives alongside the Gloo time group."""
+    mp.spawn(
+        _distributed_worker,
+        args=(str(tmp_path / "nccl_rendezvous"), "nccl"),
+        nprocs=2,
+        join=True,
+    )
+
+
+def test_stats_logger_large_expert_table_serializes_every_layer(monkeypatch):
+    """W&B run-media serialization must retain Qwen3.5's 10,240 experts."""
+    from areal.utils import stats_logger
+
+    monkeypatch.setattr(stats_logger.wandb.Table, "MAX_ROWS", 10000)
+    serialized = []
+    monkeypatch.setattr(
+        stats_logger.wandb,
+        "log",
+        lambda data, step: serialized.append(
+            data["moe_balance/expert_loads"]._to_table_json()
+        ),
+    )
+    monkeypatch.setattr(stats_logger.swanlab, "log", lambda *args, **kwargs: None)
+    logger = stats_logger.StatsLogger.__new__(stats_logger.StatsLogger)
+    logger.ft_spec = SimpleNamespace(
+        total_train_epochs=1, steps_per_epoch=1, total_train_steps=1
+    )
+    logger._last_commit_step = -1
+    logger.summary_writer = None
+    logger.print_stats = lambda data: None
+    metrics = {}
+    for layer in range(40):
+        for expert in range(256):
+            prefix = f"moe_balance/layer_{layer}/expert_{expert}"
+            metrics[prefix + "/tokens"] = 1
+            metrics[prefix + "/load_percent"] = 100 / 256
+    logger.commit(0, 0, 0, metrics)
+    assert len(serialized[0]["data"]) == 10240
+    assert serialized[0]["data"][-1] == [39, 255, 1, 100 / 256]

--- a/tests/test_training_metrics.py
+++ b/tests/test_training_metrics.py
@@ -112,6 +112,94 @@ def test_training_metrics_interval_and_cumulative_are_ratios_of_sums(monkeypatch
     assert result["train_perf/cumulative_tokens_per_second"] == 15 / 8
 
 
+@pytest.mark.parametrize("fail", [False, True])
+def test_training_metrics_cuda_events_defer_sync_and_ignore_failed_batches(
+    monkeypatch, fail
+):
+    """CPU masks use engine-device events; export waits once for all batches."""
+    events = []
+    waits = []
+    device = torch.device("cuda:0")
+    stream = object()
+    current_stream = [stream]
+
+    class Event:
+        def __init__(self, *, enable_timing):
+            assert enable_timing
+            self.device = device
+            self.index = len(events)
+            events.append(self)
+
+        def record(self, recorded_stream):
+            assert recorded_stream is stream
+
+        def elapsed_time(self, end):
+            assert waits == [device]
+            assert end.index == self.index + 1
+            return 2000.0 if self.index == 0 else 4000.0
+
+    monkeypatch.setattr(torch.cuda, "Event", Event)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda device: current_stream[0])
+    monkeypatch.setattr(torch.cuda, "synchronize", waits.append)
+    metrics = TrainingMetrics(lambda n: n * n)
+    batch = {"attention_mask": torch.tensor([[1, 1, 0], [1, 1, 1]])}
+
+    def unexpected_sync():
+        pytest.fail("Per-batch synchronization must not run for CUDA")
+
+    if fail:
+        with pytest.raises(RuntimeError, match="training failed"):
+            with metrics.measure(batch, unexpected_sync, device=device):
+                raise RuntimeError("training failed")
+        assert metrics.export(dp_group=None, timing_group=None) == {}
+        assert waits == []
+    else:
+        for _ in range(2):
+            current_stream[0] = stream
+            with metrics.measure(batch, unexpected_sync, device=device):
+                current_stream[0] = object()  # End event must use the entry stream.
+            assert waits == []
+        result = metrics.export(dp_group=None, timing_group=None)
+        assert waits == [device]
+        assert result["train_perf/seconds"] == 6
+        assert result["train_perf/tokens_per_second"] == pytest.approx(10 / 6)
+        assert result["train_perf/estimated_flops_per_second"] == pytest.approx(26 / 6)
+        assert metrics.export(dp_group=None, timing_group=None) == {}
+        assert waits == [device]
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for timing events"
+)
+def test_training_metrics_real_cuda_events_measure_cpu_input_batch(monkeypatch):
+    """Resolve real CUDA timestamps only after the export-time device wait."""
+    metrics = TrainingMetrics(None)
+    device = torch.device("cuda", torch.cuda.current_device())
+    batch = {"attention_mask": torch.ones((1, 4), dtype=torch.int64, device="cpu")}
+    x = torch.randn((256, 256), dtype=torch.float32, device=device)
+    waits = []
+    synchronize = torch.cuda.synchronize
+
+    def wait(device):
+        waits.append(device)
+        synchronize(device)
+
+    monkeypatch.setattr(torch.cuda, "synchronize", wait)
+    for _ in range(2):
+        with metrics.measure(
+            batch, lambda: pytest.fail("Batch synchronization"), device=device
+        ):
+            x = x @ x
+    assert waits == []
+    intervals = [timing for _, timing in metrics._pending]
+    result = metrics.export(dp_group=None, timing_group=None)
+    assert waits == [device]
+    expected = sum(start.elapsed_time(end) / 1000 for start, end in intervals)
+    assert result["train_perf/seconds"] == pytest.approx(expected)
+    assert result["train_perf/seconds"] > 0
+    assert result["train_perf/tokens"] == 8
+
+
 def test_training_metrics_unknown_model_omits_flops():
     """Unsupported architectures still provide token throughput."""
     metrics = TrainingMetrics(None)

--- a/tests/test_training_metrics.py
+++ b/tests/test_training_metrics.py
@@ -2,6 +2,7 @@
 
 """CPU coverage for model work estimates and distributed metric aggregation."""
 
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -93,12 +94,19 @@ def test_training_metrics_interval_and_cumulative_are_ratios_of_sums(monkeypatch
     metrics = TrainingMetrics(lambda n: n * n)
     times = iter([0.0, 2.0, 3.0, 7.0, 10.0, 12.0])
     monkeypatch.setattr(
-        "areal.utils.training_metrics.time.perf_counter", lambda: next(times)
+        "areal.utils.training_metrics.time",
+        SimpleNamespace(perf_counter=lambda: next(times)),
     )
     batch = {"attention_mask": torch.tensor([[1, 1, 0], [1, 1, 1]])}
     synchronizations = []
+
+    def synchronize():
+        # Other components must keep the real clock, not consume our finite timeline.
+        time.perf_counter()
+        synchronizations.append(True)
+
     for _ in range(2):
-        with metrics.measure(batch, lambda: synchronizations.append(True)):
+        with metrics.measure(batch, synchronize):
             pass
     result = metrics.export(dp_group=None, timing_group=None)
     assert len(synchronizations) == 4

--- a/tests/test_training_metrics.py
+++ b/tests/test_training_metrics.py
@@ -169,6 +169,25 @@ class _Model(nn.Module):
 
 
 @pytest.mark.parametrize("buffers", [False, True])
+@pytest.mark.parametrize("as_iterator", [False, True])
+def test_moe_collector_empty_modules_registers_no_hooks(buffers, as_iterator):
+    """Dense model parts must not pay per-forward Python hook overhead."""
+    model = nn.Identity()
+    metrics = MoEMetrics()
+    modules = iter(()) if as_iterator else []
+    if buffers:
+        metrics.attach_buffers(model, modules)
+    else:
+        metrics.attach(model, modules, lambda output: output)
+    assert not model._forward_pre_hooks
+    assert not model._forward_hooks
+    with metrics.measure():
+        model(torch.ones(2))
+    assert metrics.export(reduce_group=None) == {}
+    metrics.close()
+
+
+@pytest.mark.parametrize("buffers", [False, True])
 @pytest.mark.parametrize("recompute", [False, True])
 def test_moe_collector_excludes_eval_and_backward_recomputation(buffers, recompute):
     """Original model forwards count once even when inner layers are replayed."""
@@ -293,7 +312,12 @@ def test_stats_logger_logs_expert_table_without_expert_scalar_series(monkeypatch
         total_train_epochs=1, steps_per_epoch=1, total_train_steps=1
     )
     logger._last_commit_step = -1
-    logger.summary_writer = None
+    tensorboard_logged = []
+    logger.summary_writer = SimpleNamespace(
+        add_scalar=lambda key, value, step: tensorboard_logged.append(
+            (key, value, step)
+        )
+    )
     logger.print_stats = lambda data: None
     logger.commit(
         0,
@@ -318,6 +342,11 @@ def test_stats_logger_logs_expert_table_without_expert_scalar_series(monkeypatch
     assert payload["moe_balance/layer_0/max_over_ideal"] == 1.5
     assert payload["train_perf/tokens_per_second"] == 123
     assert not any("/expert_0/" in key for key in payload)
+
+    assert tensorboard_logged == [
+        ("moe_balance/layer_0/max_over_ideal", 1.5, 0),
+        ("train_perf/tokens_per_second", 123, 0),
+    ]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description

Add training-side token throughput, model-aware estimated FLOPs/s, and per-layer MoE load diagnostics across FSDP, Megatron, and Archon. Training metrics report interval and cumulative rates using global work counts and maximum accumulated rank training time.

The FLOPs estimator registry supports custom model factories and includes Qwen3-30B-A3B and Qwen3.5-35B-A3B. Estimates account for sequence-length-dependent causal attention and Qwen3.5's linear attention, rather than assuming constant FLOPs per token.

CUDA/ROCm timing uses events on the captured training stream, with one device synchronization at export instead of two per training batch. CPU/NPU retain synchronized wall timing.

Dense model parts register no diagnostic hooks. TensorBoard reports scalar summaries without per-expert series.

MoE loads are accumulated across microbatches and relevant parallel ranks before normalization. Each layer reports maximum load divided by ideal load as a scalar; W&B receives expert counts and percentages in a separate `moe_balance/expert_loads` Table. Preserve all 10,240 Qwen3.5 expert rows in run-media previews by raising the SDK's default 10,000-row limit.

Include English and Chinese metric references and a standalone visualization guide with the tested heatmap JSON, `historyTable` field mappings, step selector instructions, and recovery guidance for older truncated previews.

## Related Issue

No linked issue; implements the requested training observability improvements.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Validation:

- `pre-commit run` on all staged PR files: passed; Conventional Commit check passed.
- `pytest -q tests/test_training_metrics.py -m 'not slow'`: 27 passed, 3 deselected.
- Earlier validation exercised real CUDA MoE routing with and without recomputation and two-GPU NCCL aggregation.
- A three-update Qwen3.5 validation used the configuration from `feature/optimizer_offload` with staged optimizer offload disabled and W&B enabled. All three updates finished; all three artifact Tables contained 40 layers × 256 experts with per-layer percentages summing to 100. A separate W&B upload verified that the fixed media preview retains all 10,240 rows. This integration validation used a separate checkout with the metrics overlaid on that branch.
- The remote pre-commit check passed for revision `929d79fb`. Local checks use the PyPI index recorded in the lockfiles to avoid unrelated dependency re-resolution. Documentation formatting and embedded JSON were checked; the full documentation site was not built.
- Multi-node integration suites were not run; distributed validation used available GPUs on one node.

Limitations and review focus:

- FLOPs are analytical estimates, not hardware counters; they exclude recomputation, optimizer updates, elementwise operations, vision, and auxiliary MTP work.
- MoE counts measure executed routing assignments, including packing/alignment padding and Megatron's post-capacity/drop routing map. They can differ from logical throughput token counts. Shared experts and auxiliary MTP routers are excluded.
- CUDA event timing excludes side-stream work not joined before the end event; this is training-stream elapsed time rather than device-wide wall time.
- Review collective participation, parallel reductions, router hooks, and exclusion of backward recomputation. Unsupported routers do not emit MoE diagnostics.
- The preview fix affects future uploads. Existing truncated previews must be recovered from complete artifacts; server-side query or panel limits remain separate concerns.


