### PR TITLE
feat(v2): enable multimodal processor in the data proxy

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -459,7 +459,9 @@ def _validate_multimodal_agent_backend(
         if isinstance(backend, str) and backend
         else type(engine).__name__.lower()
     )
-    if "vllm" in backend_name:
+    # v2 InfBridge keeps the concrete backend on .backend, without engine.config.
+    backend_impl = getattr(engine, "backend", None)
+    if "vllm" in backend_name or "vllm" in type(backend_impl).__name__.lower():
         raise ValueError(
             "Multimodal agent trajectories are currently supported only with "
             "the SGLang rollout backend; vLLM support is deferred."

--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -244,10 +244,12 @@ def _create_areal_client(
     return ArealOpenAI(
         engine=inf_bridge,
         tokenizer=tok._tok,
+        processor=tok.processor,
         tool_call_parser=config.tool_call_parser,
         reasoning_parser=config.reasoning_parser,
         engine_max_tokens=config.engine_max_tokens,
         chat_template_type=config.chat_template_type,
+        require_multimodal_processor=True,
     )
 
 

--- a/areal/v2/inference_service/data_proxy/tokenizer_proxy.py
+++ b/areal/v2/inference_service/data_proxy/tokenizer_proxy.py
@@ -3,17 +3,24 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 from areal.utils.hf_utils import apply_chat_template as _apply_chat_template
+
+if TYPE_CHECKING:
+    from transformers import ProcessorMixin
 
 
 class TokenizerProxy:
     """Wraps HuggingFace tokenizer with async-safe methods for the data proxy."""
 
     def __init__(self, tokenizer_path: str):
-        from areal.utils.hf_utils import load_hf_tokenizer
+        from areal.utils.hf_utils import load_hf_processor_and_tokenizer
 
-        self._tok = load_hf_tokenizer(tokenizer_path)
+        processor, self._tok = load_hf_processor_and_tokenizer(tokenizer_path)
+        self._processor: ProcessorMixin | None = None
+        if processor is not None and hasattr(processor, "image_processor"):
+            self._processor = processor
 
     async def tokenize(self, text: str) -> list[int]:
         """Tokenize string -> token IDs. Runs in executor (non-blocking)."""
@@ -46,3 +53,7 @@ class TokenizerProxy:
     @property
     def pad_token_id(self) -> int:
         return self._tok.pad_token_id or self._tok.eos_token_id
+
+    @property
+    def processor(self) -> ProcessorMixin | None:
+        return self._processor

--- a/tests/v2/inference_service/test_multimodal_processor.py
+++ b/tests/v2/inference_service/test_multimodal_processor.py
@@ -1,0 +1,76 @@
+"""Unit tests for v2 Data Proxy multimodal processor wiring."""
+
+from unittest.mock import MagicMock, patch
+
+from areal.v2.inference_service.data_proxy.app import _create_areal_client
+from areal.v2.inference_service.data_proxy.config import DataProxyConfig
+from areal.v2.inference_service.data_proxy.tokenizer_proxy import TokenizerProxy
+
+
+class TestTokenizerProxyMultimodal:
+    def test_loads_image_processor_and_tokenizer(self):
+        tokenizer = MagicMock()
+        processor = MagicMock(image_processor=MagicMock())
+
+        with patch(
+            "areal.utils.hf_utils.load_hf_processor_and_tokenizer",
+            return_value=(processor, tokenizer),
+        ) as load_processor:
+            proxy = TokenizerProxy("mock-vlm")
+
+        load_processor.assert_called_once_with("mock-vlm")
+        assert proxy._tok is tokenizer
+        assert proxy.processor is processor
+
+    def test_ignores_processor_without_image_processor(self):
+        tokenizer = MagicMock()
+        processor = object()
+
+        with patch(
+            "areal.utils.hf_utils.load_hf_processor_and_tokenizer",
+            return_value=(processor, tokenizer),
+        ):
+            proxy = TokenizerProxy("mock-text-model")
+
+        assert proxy._tok is tokenizer
+        assert proxy.processor is None
+
+
+class TestDataProxyMultimodalClient:
+    def test_client_requires_processor_for_image_requests(self):
+        bridge = MagicMock()
+        tokenizer = MagicMock()
+        tok = MagicMock(_tok=tokenizer, processor=None)
+        config = DataProxyConfig()
+
+        with patch(
+            "areal.v2.inference_service.data_proxy.app.ArealOpenAI"
+        ) as areal_openai:
+            _create_areal_client(bridge, tok, config)
+
+        assert areal_openai.call_args.kwargs["processor"] is None
+        assert areal_openai.call_args.kwargs["require_multimodal_processor"] is True
+
+    def test_multimodal_client_injects_processor_and_requires_it(self):
+        bridge = MagicMock()
+        tokenizer = MagicMock()
+        processor = MagicMock()
+        tok = MagicMock(_tok=tokenizer, processor=processor)
+        config = DataProxyConfig()
+
+        with patch(
+            "areal.v2.inference_service.data_proxy.app.ArealOpenAI"
+        ) as areal_openai:
+            client = _create_areal_client(bridge, tok, config)
+
+        assert client is areal_openai.return_value
+        areal_openai.assert_called_once_with(
+            engine=bridge,
+            tokenizer=tokenizer,
+            processor=processor,
+            tool_call_parser=config.tool_call_parser,
+            reasoning_parser=config.reasoning_parser,
+            engine_max_tokens=config.engine_max_tokens,
+            chat_template_type=config.chat_template_type,
+            require_multimodal_processor=True,
+        )

--- a/tests/v2/inference_service/test_multimodal_processor.py
+++ b/tests/v2/inference_service/test_multimodal_processor.py
@@ -1,9 +1,19 @@
 """Unit tests for v2 Data Proxy multimodal processor wiring."""
 
-from unittest.mock import MagicMock, patch
+import base64
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from areal.v2.inference_service.data_proxy.app import _create_areal_client
+import pytest
+import torch
+from PIL import Image
+
+from areal.v2.inference_service.data_proxy.app import (
+    _create_areal_client,
+    _create_inf_bridge,
+)
 from areal.v2.inference_service.data_proxy.config import DataProxyConfig
+from areal.v2.inference_service.data_proxy.pause import PauseState
 from areal.v2.inference_service.data_proxy.tokenizer_proxy import TokenizerProxy
 
 
@@ -37,7 +47,7 @@ class TestTokenizerProxyMultimodal:
 
 
 class TestDataProxyMultimodalClient:
-    def test_client_requires_processor_for_image_requests(self):
+    def test_client_without_processor_injects_strict_mode(self):
         bridge = MagicMock()
         tokenizer = MagicMock()
         tok = MagicMock(_tok=tokenizer, processor=None)
@@ -74,3 +84,125 @@ class TestDataProxyMultimodalClient:
             chat_template_type=config.chat_template_type,
             require_multimodal_processor=True,
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_type", ["chat", "responses"])
+    @pytest.mark.parametrize(
+        "backend_type,has_image,has_processor,error",
+        [
+            ("vllm", True, True, "supported only with.*SGLang"),
+            ("sglang", True, False, "require a multimodal processor"),
+            ("sglang", True, True, None),
+            ("vllm", False, False, None),
+            ("sglang", False, False, None),
+            ("vllm", False, True, None),
+            ("sglang", False, True, None),
+        ],
+    )
+    async def test_generation_with_inf_bridge_enforces_multimodal_boundary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        api_type: str,
+        backend_type: str,
+        has_image: bool,
+        has_processor: bool,
+        error: str | None,
+    ) -> None:
+        """Exercise real v2 client/bridge wiring, mocking only HF objects and HTTP."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://test.invalid/v1")
+        tokenizer = MagicMock(eos_token_id=2, pad_token_id=0)
+        tokenizer.apply_chat_template.side_effect = (
+            lambda *args, tokenize=True, **kwargs: (
+                {"input_ids": [10, 2, 20]} if tokenize else "describe"
+            )
+        )
+        tokenizer.decode.return_value = "answer"
+        processor = MagicMock(
+            image_processor=MagicMock(),
+            return_value={
+                "input_ids": torch.tensor(
+                    [[10, 2, 20]], dtype=torch.long, device="cpu"
+                ),
+                "pixel_values": torch.ones(
+                    1, 3, 2, 2, dtype=torch.float32, device="cpu"
+                ),
+                "image_grid_thw": torch.tensor(
+                    [[1, 1, 1]], dtype=torch.long, device="cpu"
+                ),
+            },
+        )
+        tok = MagicMock(_tok=tokenizer, processor=processor if has_processor else None)
+        config = DataProxyConfig(backend_type=backend_type)
+        bridge = _create_inf_bridge("http://test.invalid", PauseState(), config)
+        response = (
+            {
+                "meta_info": {
+                    "finish_reason": {"type": "length"},
+                    "output_token_logprobs": [(-0.1, 77)],
+                }
+            }
+            if backend_type == "sglang"
+            else {
+                "choices": [
+                    {
+                        "finish_reason": "length",
+                        "logprobs": {
+                            "tokens": ["token:77"],
+                            "token_logprobs": [-0.1],
+                        },
+                    }
+                ]
+            }
+        )
+        with patch.object(
+            bridge, "_send_request", new_callable=AsyncMock, return_value=response
+        ) as send_request:
+            client = _create_areal_client(bridge, tok, config)
+            try:
+                if has_image:
+                    with BytesIO() as buffer:
+                        Image.new("RGB", (2, 2), color="red").save(buffer, format="PNG")
+                        encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+                    image_url = f"data:image/png;base64,{encoded}"
+                    content = (
+                        [{"type": "image_url", "image_url": {"url": image_url}}]
+                        if api_type == "chat"
+                        else [{"type": "input_image", "image_url": image_url}]
+                    )
+                else:
+                    content = "describe"
+
+                messages = [{"role": "user", "content": content}]
+                request = (
+                    client.chat.completions.create(
+                        messages=messages, max_completion_tokens=1
+                    )
+                    if api_type == "chat"
+                    else client.responses.create(input=messages, max_output_tokens=1)
+                )
+                if error is not None:
+                    with pytest.raises(ValueError, match=error):
+                        await request
+                    send_request.assert_not_awaited()
+                    processor.assert_not_called()
+                else:
+                    completion = await request
+                    send_request.assert_awaited_once()
+                    interaction = client.get_interaction(completion.id)
+                    assert interaction is not None
+                    trajectory = interaction.to_tensor_dict()
+                    assert trajectory["input_ids"].tolist() == [[10, 2, 20, 77]]
+                    if has_image:
+                        processor.assert_called_once()
+                        torch.testing.assert_close(
+                            trajectory["multi_modal_input"][0]["pixel_values"],
+                            processor.return_value["pixel_values"],
+                            rtol=0,
+                            atol=0,
+                        )
+                    else:
+                        processor.assert_not_called()
+            finally:
+                await client.close()
+                await bridge.aclose()


### PR DESCRIPTION
## Background

The v2 Data Proxy previously loaded only a tokenizer and did not provide a multimodal processor to `ArealOpenAI`. Although the shared agent interaction code already supports exporting visual tensors, that processing path was not wired into v2. Image-based agent requests therefore could not produce the processor-backed multimodal inputs needed by training through this path.

## Changes

Load the Hugging Face processor alongside the tokenizer and pass image-capable processors to the Data Proxy's `ArealOpenAI` client. This enables the existing multimodal prompt-processing and trajectory-export logic to include visual tensors in v2 agent trajectories. Image requests are rejected early when no compatible processor is available.

## Files

- **Modified:** `areal/v2/inference_service/data_proxy/tokenizer_proxy.py` — use `load_hf_processor_and_tokenizer`, retain processors that expose `image_processor`, and expose a `processor` property.
- **Modified:** `areal/v2/inference_service/data_proxy/app.py` — inject the processor into `ArealOpenAI` and enable `require_multimodal_processor`.
- **Added:** `tests/v2/inference_service/test_multimodal_processor.py` — cover processor loading, filtering processors without image support, and client parameter wiring.

## Impact

The change is limited to v2 Data Proxy initialization and processor wiring for agent requests. It adds no configuration fields. Text-only requests retain their tokenizer-based processing, although startup now also attempts processor loading. Existing multimodal processing and trajectory-export implementations are reused.

This PR does not change v1 workflows, training engines, inference-server processing, or AWEX weight conversion. The Megatron/SGLang AWEX integration is handled separately in #1684; this PR supplies the Data Proxy portion of v2 VLM RL support.
