### PR TITLE
feat(reward): support composable reasoning rewards with format verification and length regulation

### DIFF
--- a/areal/reward/__init__.py
+++ b/areal/reward/__init__.py
@@ -108,6 +108,16 @@ __all__ = [
     "geometry3k_reward_fn",
     "clevr_count_70k_reward_fn",
     "if_gap_reward_fn",
+    "FormatRewardConfig",
+    "FormatReward",
+    "LengthPenaltyConfig",
+    "LengthPenalty",
+    "CompositeReward",
+    "extract_boxed_content",
+    "extract_tag_content",
+    "extract_hash_answer",
+    "extract_reasoning_and_answer",
+    "get_deepseek_r1_math_reward",
 ]
 
 
@@ -116,6 +126,16 @@ _LAZY_IMPORTS = {
     "geometry3k_reward_fn": "areal.reward.geometry3k",
     "clevr_count_70k_reward_fn": "areal.reward.clevr_count_70k",
     "if_gap_reward_fn": "areal.reward.if_gap",
+    "FormatRewardConfig": "areal.reward.reasoning",
+    "FormatReward": "areal.reward.reasoning",
+    "LengthPenaltyConfig": "areal.reward.reasoning",
+    "LengthPenalty": "areal.reward.reasoning",
+    "CompositeReward": "areal.reward.reasoning",
+    "extract_boxed_content": "areal.reward.reasoning",
+    "extract_tag_content": "areal.reward.reasoning",
+    "extract_hash_answer": "areal.reward.reasoning",
+    "extract_reasoning_and_answer": "areal.reward.reasoning",
+    "get_deepseek_r1_math_reward": "areal.reward.reasoning",
 }
 
 

--- a/areal/reward/reasoning.py
+++ b/areal/reward/reasoning.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composable reasoning rewards for LLM post-training (DeepSeek-R1 style RLVR).
+
+Provides format verification for thinking/reasoning tags (<think>...</think>),
+answer delimiter extraction (\\boxed{}, <answer>, ####), anti-length-hacking
+penalties, and a composite reward wrapper that combines task accuracy, format
+compliance, and length regulation with stats_tracker integration.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from areal.utils import logging, stats_tracker
+
+logger = logging.getLogger("ReasoningReward")
+
+
+def extract_boxed_content(text: str) -> str | None:
+    """Extract content from the last \\boxed{...} with balanced brace matching.
+
+    Handles nested braces properly (e.g. ``\\boxed{\\frac{1}{2}}``).
+
+    Parameters
+    ----------
+    text : str
+        Input string containing LaTeX boxed expressions.
+
+    Returns
+    -------
+    str | None
+        Extracted content within the last \\boxed{}, or None if no valid
+        boxed expression is found.
+    """
+    idx = text.rfind("\\boxed{")
+    if idx == -1:
+        return None
+
+    brace_start = idx + len("\\boxed{")
+    depth = 1
+    i = brace_start
+    while i < len(text) and depth > 0:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+
+    if depth == 0:
+        return text[brace_start : i - 1].strip()
+    return None
+
+
+def extract_tag_content(text: str, tag: str = "answer") -> str | None:
+    """Extract content from an XML-like tag (e.g. <answer>...</answer>).
+
+    Parameters
+    ----------
+    text : str
+        Input string.
+    tag : str, optional
+        Tag name to match, by default "answer".
+
+    Returns
+    -------
+    str | None
+        Content of the last matching tag pair, or None if not found.
+    """
+    pattern = rf"<{tag}>(.*?)</{tag}>"
+    matches = list(re.finditer(pattern, text, flags=re.DOTALL))
+    if matches:
+        return matches[-1].group(1).strip()
+    return None
+
+
+def extract_hash_answer(text: str) -> str | None:
+    """Extract answer following GSM8K-style '####' delimiter.
+
+    Parameters
+    ----------
+    text : str
+        Input string.
+
+    Returns
+    -------
+    str | None
+        Answer string following the final '####', or None if not found.
+    """
+    if "####" not in text:
+        return None
+    return text.split("####")[-1].strip()
+
+
+def extract_reasoning_and_answer(
+    text: str,
+    think_start_tag: str = "<think>",
+    think_end_tag: str = "</think>",
+) -> tuple[str, str]:
+    """Separate reasoning chain and visible answer from a completion.
+
+    Handles complete, unclosed, and missing thinking tags gracefully.
+
+    Parameters
+    ----------
+    text : str
+        Model output text.
+    think_start_tag : str, optional
+        Opening thinking tag, by default "<think>".
+    think_end_tag : str, optional
+        Closing thinking tag, by default "</think>".
+
+    Returns
+    -------
+    tuple[str, str]
+        (reasoning_text, answer_text)
+    """
+    has_start = think_start_tag in text
+    has_end = think_end_tag in text
+
+    if has_start and has_end:
+        start_idx = text.find(think_start_tag) + len(think_start_tag)
+        end_idx = text.rfind(think_end_tag)
+        if start_idx <= end_idx:
+            reasoning = text[start_idx:end_idx].strip()
+            answer = text[end_idx + len(think_end_tag) :].strip()
+            return reasoning, answer
+        # Malformed ordering (end before start)
+        return "", text.strip()
+
+    if has_start and not has_end:
+        # Generation truncated inside thinking block
+        start_idx = text.find(think_start_tag) + len(think_start_tag)
+        return text[start_idx:].strip(), ""
+
+    if not has_start and has_end:
+        # Implicit thinking before closing tag
+        end_idx = text.find(think_end_tag)
+        reasoning = text[:end_idx].strip()
+        answer = text[end_idx + len(think_end_tag) :].strip()
+        return reasoning, answer
+
+    # No thinking tags
+    return "", text.strip()
+
+
+@dataclass
+class FormatRewardConfig:
+    """Configuration for reasoning format reward verification."""
+
+    think_start_tag: str = "<think>"
+    think_end_tag: str = "</think>"
+    require_think_tags: bool = True
+    require_closed_think: bool = True
+    allow_empty_think: bool = False
+    answer_format: str = "boxed"  # "boxed", "xml", "hash", or "any"
+    answer_tag: str = "answer"  # Used when answer_format == "xml"
+    structure_reward: float = 0.5
+    answer_format_reward: float = 0.5
+    malformed_penalty: float = -0.5
+
+
+class FormatReward:
+    """Evaluates format compliance for reasoning models."""
+
+    def __init__(self, config: FormatRewardConfig | None = None):
+        self.config = config or FormatRewardConfig()
+
+    def evaluate_detailed(self, completion: str) -> dict[str, Any]:
+        """Evaluate format and return detailed breakdown and extracted contents."""
+        cfg = self.config
+        text = str(completion)
+
+        start_count = text.count(cfg.think_start_tag)
+        end_count = text.count(cfg.think_end_tag)
+
+        # Check for multiple/mismatched tags
+        if start_count > 1 or end_count > 1:
+            return {
+                "reward": cfg.malformed_penalty,
+                "valid_think": False,
+                "valid_answer_format": False,
+                "reasoning": "",
+                "extracted_answer": None,
+                "error": "multiple_tags",
+            }
+
+        if cfg.require_think_tags:
+            if start_count == 0:
+                return {
+                    "reward": cfg.malformed_penalty,
+                    "valid_think": False,
+                    "valid_answer_format": False,
+                    "reasoning": "",
+                    "extracted_answer": None,
+                    "error": "missing_start_tag",
+                }
+            if cfg.require_closed_think and end_count == 0:
+                return {
+                    "reward": cfg.malformed_penalty,
+                    "valid_think": False,
+                    "valid_answer_format": False,
+                    "reasoning": "",
+                    "extracted_answer": None,
+                    "error": "unclosed_think",
+                }
+
+        reasoning, answer = extract_reasoning_and_answer(
+            text, cfg.think_start_tag, cfg.think_end_tag
+        )
+
+        if cfg.require_think_tags and not cfg.allow_empty_think and not reasoning:
+            return {
+                "reward": cfg.malformed_penalty,
+                "valid_think": False,
+                "valid_answer_format": False,
+                "reasoning": "",
+                "extracted_answer": None,
+                "error": "empty_think",
+            }
+
+        # Check tag ordering if both exist
+        if start_count == 1 and end_count == 1:
+            if text.find(cfg.think_start_tag) > text.find(cfg.think_end_tag):
+                return {
+                    "reward": cfg.malformed_penalty,
+                    "valid_think": False,
+                    "valid_answer_format": False,
+                    "reasoning": "",
+                    "extracted_answer": None,
+                    "error": "reversed_tags",
+                }
+
+        # Validate answer format
+        extracted_ans: str | None = None
+        valid_ans = False
+
+        if cfg.answer_format == "boxed":
+            extracted_ans = extract_boxed_content(answer or text)
+            valid_ans = extracted_ans is not None
+        elif cfg.answer_format == "xml":
+            extracted_ans = extract_tag_content(answer or text, cfg.answer_tag)
+            valid_ans = extracted_ans is not None
+        elif cfg.answer_format == "hash":
+            extracted_ans = extract_hash_answer(answer or text)
+            valid_ans = extracted_ans is not None
+        elif cfg.answer_format == "any":
+            extracted_ans = answer if answer else text
+            valid_ans = bool(extracted_ans.strip())
+        else:
+            raise ValueError(f"Unknown answer_format: {cfg.answer_format!r}")
+
+        reward = 0.0
+        if not cfg.require_think_tags or (start_count == 1 and end_count == 1):
+            reward += cfg.structure_reward
+        if valid_ans:
+            reward += cfg.answer_format_reward
+
+        return {
+            "reward": reward,
+            "valid_think": True,
+            "valid_answer_format": valid_ans,
+            "reasoning": reasoning,
+            "extracted_answer": extracted_ans,
+            "error": None,
+        }
+
+    def evaluate(self, completion: str) -> float:
+        """Evaluate format and return format reward score."""
+        return float(self.evaluate_detailed(completion)["reward"])
+
+    def __call__(
+        self,
+        prompt: Any,
+        completions: Any,
+        prompt_ids: Any = None,
+        completion_ids: Any = None,
+        **kwargs: Any,
+    ) -> float:
+        return self.evaluate(str(completions))
+
+
+@dataclass
+class LengthPenaltyConfig:
+    """Configuration for output length regulation."""
+
+    target_length: int = 1024
+    penalty_type: str = "threshold"  # "threshold", "linear", "soft_tanh"
+    penalty_factor: float = 0.001
+    max_penalty: float = 1.0
+
+
+class LengthPenalty:
+    """Penalizes excessively verbose reasoning to prevent length hacking."""
+
+    def __init__(self, config: LengthPenaltyConfig | None = None):
+        self.config = config or LengthPenaltyConfig()
+        if self.config.target_length < 0:
+            raise ValueError("target_length must be non-negative")
+        if self.config.penalty_factor < 0:
+            raise ValueError("penalty_factor must be non-negative")
+        if self.config.max_penalty < 0:
+            raise ValueError("max_penalty must be non-negative")
+
+    def evaluate_length(self, length: int) -> float:
+        """Compute penalty given a sequence length."""
+        cfg = self.config
+        if cfg.penalty_type == "threshold":
+            excess = max(0, length - cfg.target_length)
+            penalty = -cfg.penalty_factor * excess
+        elif cfg.penalty_type == "linear":
+            penalty = -cfg.penalty_factor * length
+        elif cfg.penalty_type == "soft_tanh":
+            excess = max(0, length - cfg.target_length)
+            penalty = -cfg.max_penalty * math.tanh(cfg.penalty_factor * excess)
+        else:
+            raise ValueError(f"Unknown penalty_type: {cfg.penalty_type!r}")
+
+        return max(-cfg.max_penalty, penalty)
+
+    def evaluate(self, completion: Any, completion_ids: Any = None) -> float:
+        """Evaluate length penalty from tokens or string."""
+        if completion_ids is not None:
+            length = len(completion_ids)
+        elif isinstance(completion, (list, tuple)):
+            length = len(completion)
+        else:
+            # Fallback to word count
+            length = len(str(completion).split())
+        return self.evaluate_length(length)
+
+    def __call__(
+        self,
+        prompt: Any,
+        completions: Any,
+        prompt_ids: Any = None,
+        completion_ids: Any = None,
+        **kwargs: Any,
+    ) -> float:
+        return self.evaluate(completions, completion_ids=completion_ids)
+
+
+class CompositeReward:
+    """Composites task accuracy, format verification, and length regulation.
+
+    Computes:
+        R = w_acc * R_acc + w_format * R_format + w_length * R_length
+
+    Automatically reports sub-reward components to stats_tracker.
+    """
+
+    def __init__(
+        self,
+        accuracy_fn: Callable[..., Any] | None = None,
+        format_reward: FormatReward | None = None,
+        length_penalty: LengthPenalty | None = None,
+        acc_weight: float = 1.0,
+        format_weight: float = 1.0,
+        length_weight: float = 1.0,
+        log_stats: bool = True,
+    ):
+        self.accuracy_fn = accuracy_fn
+        self.format_reward = format_reward
+        self.length_penalty = length_penalty
+        self.acc_weight = acc_weight
+        self.format_weight = format_weight
+        self.length_weight = length_weight
+        self.log_stats = log_stats
+
+    def __call__(
+        self,
+        prompt: Any,
+        completions: Any,
+        prompt_ids: Any = None,
+        completion_ids: Any = None,
+        **kwargs: Any,
+    ) -> float:
+        acc_reward = 0.0
+        if self.accuracy_fn is not None:
+            try:
+                sig = inspect.signature(self.accuracy_fn)
+                # Filter kwargs matching the accuracy_fn signature if not **kwargs
+                has_var_keyword = any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    for p in sig.parameters.values()
+                )
+                if has_var_keyword:
+                    call_kwargs = kwargs
+                else:
+                    call_kwargs = {
+                        k: v for k, v in kwargs.items() if k in sig.parameters
+                    }
+
+                acc_result = self.accuracy_fn(
+                    prompt,
+                    completions,
+                    prompt_ids,
+                    completion_ids,
+                    **call_kwargs,
+                )
+                acc_reward = float(acc_result)
+            except Exception:
+                logger.warning("Exception in accuracy_fn", exc_info=True)
+                acc_reward = 0.0
+
+        format_reward_val = 0.0
+        if self.format_reward is not None:
+            format_reward_val = self.format_reward(
+                prompt,
+                completions,
+                prompt_ids=prompt_ids,
+                completion_ids=completion_ids,
+                **kwargs,
+            )
+
+        length_penalty_val = 0.0
+        if self.length_penalty is not None:
+            length_penalty_val = self.length_penalty(
+                prompt,
+                completions,
+                prompt_ids=prompt_ids,
+                completion_ids=completion_ids,
+                **kwargs,
+            )
+
+        total_reward = (
+            self.acc_weight * acc_reward
+            + self.format_weight * format_reward_val
+            + self.length_weight * length_penalty_val
+        )
+
+        if self.log_stats:
+            try:
+                stats_tracker.scalar(
+                    reward_accuracy=float(acc_reward),
+                    reward_format=float(format_reward_val),
+                    reward_length_penalty=float(length_penalty_val),
+                    reward_composite=float(total_reward),
+                )
+            except Exception:
+                pass
+
+        return float(total_reward)
+
+
+def get_deepseek_r1_math_reward(
+    accuracy_fn: Callable[..., Any],
+    target_length: int = 2048,
+    acc_weight: float = 1.0,
+    format_weight: float = 0.5,
+    length_weight: float = 0.1,
+) -> CompositeReward:
+    """Helper creating a standard DeepSeek-R1 style math reasoning reward.
+
+    Enforces <think>...</think> with \\boxed{} answers and bounded length penalties.
+    """
+    format_reward = FormatReward(
+        FormatRewardConfig(
+            think_start_tag="<think>",
+            think_end_tag="</think>",
+            require_think_tags=True,
+            require_closed_think=True,
+            allow_empty_think=False,
+            answer_format="boxed",
+            structure_reward=0.5,
+            answer_format_reward=0.5,
+            malformed_penalty=-0.5,
+        )
+    )
+    length_penalty = LengthPenalty(
+        LengthPenaltyConfig(
+            target_length=target_length,
+            penalty_type="threshold",
+            penalty_factor=0.0005,
+            max_penalty=0.5,
+        )
+    )
+    return CompositeReward(
+        accuracy_fn=accuracy_fn,
+        format_reward=format_reward,
+        length_penalty=length_penalty,
+        acc_weight=acc_weight,
+        format_weight=format_weight,
+        length_weight=length_weight,
+    )

--- a/tests/test_reasoning_reward.py
+++ b/tests/test_reasoning_reward.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+from areal.reward import (
+    CompositeReward,
+    FormatReward,
+    FormatRewardConfig,
+    LengthPenalty,
+    LengthPenaltyConfig,
+    extract_boxed_content,
+    extract_hash_answer,
+    extract_reasoning_and_answer,
+    extract_tag_content,
+    get_deepseek_r1_math_reward,
+)
+
+
+def test_extract_boxed_content():
+    assert extract_boxed_content(r"The result is \boxed{42}.") == "42"
+    assert extract_boxed_content(r"\boxed{\frac{1}{2}}") == r"\frac{1}{2}"
+    assert (
+        extract_boxed_content(r"\boxed{\sqrt{\frac{a}{b}}}")
+        == r"\sqrt{\frac{a}{b}}"
+    )
+    assert (
+        extract_boxed_content(r"First \boxed{10}, then finally \boxed{20}")
+        == "20"
+    )
+    assert extract_boxed_content("No boxed here") is None
+    assert extract_boxed_content(r"\boxed{unclosed brace") is None
+
+
+def test_extract_tag_content():
+    assert (
+        extract_tag_content("<answer>42</answer>", tag="answer")
+        == "42"
+    )
+    assert (
+        extract_tag_content(
+            "<answer>\nline 1\nline 2\n</answer>", tag="answer"
+        )
+        == "line 1\nline 2"
+    )
+    assert (
+        extract_tag_content(
+            "<custom>my answer</custom>", tag="custom"
+        )
+        == "my answer"
+    )
+    assert extract_tag_content("No tag here", tag="answer") is None
+
+
+def test_extract_hash_answer():
+    assert extract_hash_answer("The final answer is #### 42") == "42"
+    assert extract_hash_answer("Step 1 #### 10 \n Step 2 #### 20") == "20"
+    assert extract_hash_answer("No delimiter") is None
+
+
+def test_extract_reasoning_and_answer():
+    # Normal case with <think> and </think>
+    text = "<think>\nLet's calculate 2 + 2 = 4.\n</think>\nTherefore the answer is 4."
+    reasoning, answer = extract_reasoning_and_answer(text)
+    assert reasoning == "Let's calculate 2 + 2 = 4."
+    assert answer == "Therefore the answer is 4."
+
+    # Truncated inside thinking block
+    text_unclosed = "<think>\nLet's calculate step 1..."
+    reasoning_u, answer_u = extract_reasoning_and_answer(text_unclosed)
+    assert reasoning_u == "Let's calculate step 1..."
+    assert answer_u == ""
+
+    # Implicit thinking before </think>
+    text_implicit = "Let me think.\n</think>\nAnswer is 42."
+    reasoning_i, answer_i = extract_reasoning_and_answer(text_implicit)
+    assert reasoning_i == "Let me think."
+    assert answer_i == "Answer is 42."
+
+    # No thinking tags
+    text_none = "Direct answer without tags."
+    reasoning_n, answer_n = extract_reasoning_and_answer(text_none)
+    assert reasoning_n == ""
+    assert answer_n == "Direct answer without tags."
+
+
+def test_format_reward_valid_boxed():
+    formatter = FormatReward(
+        FormatRewardConfig(
+            think_start_tag="<think>",
+            think_end_tag="</think>",
+            require_think_tags=True,
+            require_closed_think=True,
+            answer_format="boxed",
+            structure_reward=0.5,
+            answer_format_reward=0.5,
+            malformed_penalty=-0.5,
+        )
+    )
+    completion = "<think>\nStep by step reasoning.\n</think>\nThe answer is \\boxed{42}."
+    detail = formatter.evaluate_detailed(completion)
+    assert detail["valid_think"] is True
+    assert detail["valid_answer_format"] is True
+    assert detail["extracted_answer"] == "42"
+    assert detail["reward"] == 1.0
+    assert formatter.evaluate(completion) == 1.0
+
+
+def test_format_reward_unclosed_or_missing_think():
+    formatter = FormatReward(
+        FormatRewardConfig(
+            require_think_tags=True,
+            require_closed_think=True,
+            malformed_penalty=-0.5,
+        )
+    )
+    # Missing tags entirely
+    assert (
+        formatter.evaluate("Direct answer \\boxed{42}") == -0.5
+    )
+    # Unclosed think tag
+    assert (
+        formatter.evaluate("<think>Let's think \\boxed{42}")
+        == -0.5
+    )
+    # Multiple start tags
+    assert (
+        formatter.evaluate("<think>A</think><think>B</think> \\boxed{42}")
+        == -0.5
+    )
+
+
+def test_format_reward_empty_think_rejected():
+    formatter = FormatReward(
+        FormatRewardConfig(
+            require_think_tags=True,
+            allow_empty_think=False,
+            malformed_penalty=-0.5,
+        )
+    )
+    assert (
+        formatter.evaluate("<think></think> \\boxed{42}") == -0.5
+    )
+    assert (
+        formatter.evaluate("<think>   \n  </think> \\boxed{42}")
+        == -0.5
+    )
+
+
+def test_format_reward_xml_and_hash_formats():
+    xml_formatter = FormatReward(
+        FormatRewardConfig(
+            answer_format="xml",
+            answer_tag="solution",
+            structure_reward=0.3,
+            answer_format_reward=0.7,
+        )
+    )
+    comp_xml = "<think>reasoning</think><solution>x=5</solution>"
+    assert xml_formatter.evaluate(comp_xml) == 1.0
+
+    hash_formatter = FormatReward(
+        FormatRewardConfig(
+            answer_format="hash",
+            structure_reward=0.4,
+            answer_format_reward=0.6,
+        )
+    )
+    comp_hash = "<think>reasoning</think>Final: #### 100"
+    assert hash_formatter.evaluate(comp_hash) == 1.0
+
+
+def test_length_penalty_threshold():
+    penalty = LengthPenalty(
+        LengthPenaltyConfig(
+            target_length=100,
+            penalty_type="threshold",
+            penalty_factor=0.01,
+            max_penalty=1.0,
+        )
+    )
+    # Under or equal to target length -> 0 penalty
+    assert penalty.evaluate_length(50) == 0.0
+    assert penalty.evaluate_length(100) == 0.0
+
+    # Over target length -> linear excess penalty
+    assert math.isclose(penalty.evaluate_length(150), -0.5)
+    # Capped at max_penalty
+    assert penalty.evaluate_length(300) == -1.0
+
+
+def test_length_penalty_linear_and_soft_tanh():
+    linear_penalty = LengthPenalty(
+        LengthPenaltyConfig(
+            penalty_type="linear",
+            penalty_factor=0.005,
+            max_penalty=1.0,
+        )
+    )
+    assert math.isclose(linear_penalty.evaluate_length(100), -0.5)
+
+    tanh_penalty = LengthPenalty(
+        LengthPenaltyConfig(
+            target_length=50,
+            penalty_type="soft_tanh",
+            penalty_factor=0.02,
+            max_penalty=0.8,
+        )
+    )
+    assert tanh_penalty.evaluate_length(30) == 0.0
+    expected = -0.8 * math.tanh(0.02 * (100 - 50))
+    assert math.isclose(tanh_penalty.evaluate_length(100), expected)
+
+
+def test_length_penalty_with_token_ids():
+    penalty = LengthPenalty(
+        LengthPenaltyConfig(
+            target_length=5,
+            penalty_type="threshold",
+            penalty_factor=0.1,
+            max_penalty=1.0,
+        )
+    )
+    tokens = [101, 102, 103, 104, 105, 106, 107]  # len = 7, excess = 2
+    res = penalty(prompt="Q", completions="A", completion_ids=tokens)
+    assert math.isclose(res, -0.2)
+
+
+def test_composite_reward_combination():
+    def mock_accuracy(prompt, completions, *args, **kwargs):
+        return 1.0 if "42" in completions else 0.0
+
+    format_r = FormatReward(
+        FormatRewardConfig(
+            structure_reward=0.5,
+            answer_format_reward=0.5,
+            malformed_penalty=-0.5,
+        )
+    )
+    length_p = LengthPenalty(
+        LengthPenaltyConfig(
+            target_length=10,
+            penalty_type="threshold",
+            penalty_factor=0.01,
+        )
+    )
+
+    composite = CompositeReward(
+        accuracy_fn=mock_accuracy,
+        format_reward=format_r,
+        length_penalty=length_p,
+        acc_weight=1.0,
+        format_weight=0.5,
+        length_weight=1.0,
+        log_stats=True,
+    )
+
+    # Correct answer, correct format, short length
+    comp_good = "<think>ok</think> \\boxed{42}"
+    tokens = [1, 2, 3]  # len=3 <= 10
+    score = composite("Q", comp_good, completion_ids=tokens)
+    # acc (1.0 * 1.0) + format (1.0 * 0.5) + length (0.0 * 1.0) = 1.5
+    assert math.isclose(score, 1.5)
+
+    # Wrong answer, correct format
+    comp_wrong = "<think>ok</think> \\boxed{99}"
+    score_wrong = composite("Q", comp_wrong, completion_ids=tokens)
+    # acc (0.0) + format (0.5) + length (0.0) = 0.5
+    assert math.isclose(score_wrong, 0.5)
+
+
+def test_get_deepseek_r1_math_reward_factory():
+    def mock_acc(prompt, completions, *args, **kwargs):
+        return 1.0
+
+    r1_reward = get_deepseek_r1_math_reward(
+        accuracy_fn=mock_acc,
+        target_length=100,
+        acc_weight=1.0,
+        format_weight=0.5,
+        length_weight=0.1,
+    )
+    assert isinstance(r1_reward, CompositeReward)
+    comp = "<think>reasoning</think>\\boxed{10}"
+    val = r1_reward("Q", comp, completion_ids=[1] * 50)
+    # acc (1.0 * 1.0) + format (1.0 * 0.5) - length (0) = 1.5
+    assert math.isclose(val, 1.5)


### PR DESCRIPTION
## Description

In reasoning RL post-training and RLVR (Reinforcement Learning with Verifiable Rewards, e.g. DeepSeek-R1 style training on GSM8K, MATH, and Olympiad tasks), models trained exclusively on binary task accuracy suffer from two critical failure modes:
1. **Format Degradation**: Models frequently drop closing reasoning tags (`</think>`), generate multiple unclosed `<think>` blocks, output empty thinking traces, or fail to structure their final answer into standard delimiters (`\boxed{...}`, `<answer>...</answer>`, `####`).
2. **Length Hacking / Verbosity Exploitation**: Under policy gradient algorithms (PPO, GRPO), models often discover that generating repetitive, rambling tokens artificially delays penalty or exploits length biases.

As highlighted in community discussion (#162), AReaL previously lacked modular support for format rewards, length penalties, and composable reward functions.

This PR introduces a clean, composable reasoning reward module in `areal.reward`:
1. **`FormatReward` & `FormatRewardConfig`**:
   - Validates `<think>...</think>` tag structure (detects unclosed, missing, duplicate, or reversed tags).
   - Validates and extracts answers from LaTeX boxed expressions (`\boxed{...}` with robust balanced brace parsing), XML tags (`<answer>...</answer>`), and GSM8K delimiters (`####`).
   - Computes configurable structure rewards, answer format rewards, and malformed tag penalties.
   - Provides `extract_reasoning_and_answer` utility to isolate the reasoning chain from the scoreable final answer.
2. **`LengthPenalty` & `LengthPenaltyConfig`**:
   - Implements bounded anti-length-hacking penalties supporting `threshold` ($-\alpha \max(0, L - L_{\text{target}})$), `linear`, and `soft_tanh` modes.
   - Operates on token IDs (`completion_ids`) or decoded text.
3. **`CompositeReward`**:
   - Computes $R = w_{\text{acc}} R_{\text{acc}} + w_{\text{format}} R_{\text{format}} + w_{\text{len}} R_{\text{len}}$.
   - Automatically reports sub-reward breakdown (`reward_accuracy`, `reward_format`, `reward_length_penalty`, `reward_composite`) to `stats_tracker` for real-time training observability.
   - Works seamlessly with `RLVRWorkflow` and `MultiTurnWorkflow`.
4. **`get_deepseek_r1_math_reward`**:
   - Out-of-the-box factory helper matching the canonical DeepSeek-R1 math reasoning reward specification.

## Related Issue

Relates to #162

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

- 13/13 new unit tests in `tests/test_reasoning_reward.py` passing cleanly.
- Full reward test suite (98/98 tests) passing cleanly.
- All 16 pre-commit hooks passing across the entire repository.