### PR TITLE
fix(engine): normalize nested vLLM expert names for AWEX

### DIFF
--- a/areal/engine/patch_awex.py
+++ b/areal/engine/patch_awex.py
@@ -5,8 +5,26 @@ import importlib
 import os
 import pkgutil
 import time
+from functools import wraps
 
 import torch
+
+
+def _patch_vllm_expert_names():
+    from awex.converter.vllm_converter import VLLMToHFWeightConverter
+
+    original = VLLMToHFWeightConverter._normalize_name
+    if getattr(original, "_areal_expert_names", False):
+        return
+
+    @wraps(original)
+    def normalize_name(self, name: str) -> str:
+        # vLLM 0.26 nests fused expert parameters under RoutedExperts.
+        name = name.replace(".experts.routed_experts.", ".experts.")
+        return original(self, name)
+
+    normalize_name._areal_expert_names = True
+    VLLMToHFWeightConverter._normalize_name = normalize_name
 
 
 def _patch_vllm_adapter():
@@ -482,6 +500,7 @@ def _patch_gpu_sub_command():
 
 
 def patch_awex():
+    _patch_vllm_expert_names()
     _registry_models()
     _patch_vllm_adapter()
     _patch_nccl_comm()

--- a/tests/test_awex_expert_names.py
+++ b/tests/test_awex_expert_names.py
@@ -1,0 +1,57 @@
+import sys
+from types import ModuleType
+
+import pytest
+
+from areal.engine.patch_awex import _patch_vllm_expert_names
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (
+            "model.layers.0.mlp.experts.routed_experts.w13_weight",
+            "model.layers.0.mlp.experts.w13_weight",
+        ),
+        (
+            "model.layers.47.mlp.experts.routed_experts.w2_weight",
+            "model.layers.47.mlp.experts.w2_weight",
+        ),
+        (
+            "model.layers.0.mlp.experts.routed_experts.w13_weight_scale_inv",
+            "model.layers.0.mlp.experts.w13_weight_scale_inv",
+        ),
+        (
+            "model.layers.0.mlp.experts.w13_weight",
+            "model.layers.0.mlp.experts.w13_weight",
+        ),
+        (
+            "model.layers.0.mlp.shared_experts.gate_proj.weight",
+            "model.layers.0.mlp.shared_experts.gate_proj.weight",
+        ),
+        (
+            "model.layers.0.self_attn.qkv_proj.weight",
+            "model.layers.0.self_attn.qkv_proj.weight",
+        ),
+    ],
+)
+def test_vllm_expert_names_patch_preserves_normalizer(monkeypatch, name, expected):
+    """Normalize nested experts once and delegate to the original converter."""
+    calls = []
+
+    class Converter:
+        def _normalize_name(self, value):
+            calls.append(value)
+            return "normalized:" + value
+
+    module = ModuleType("awex.converter.vllm_converter")
+    module.VLLMToHFWeightConverter = Converter
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    _patch_vllm_expert_names()
+    installed = Converter._normalize_name
+    _patch_vllm_expert_names()
+
+    assert Converter._normalize_name is installed
+    assert Converter()._normalize_name(name) == "normalized:" + expected
+    assert calls == [expected]


### PR DESCRIPTION
## Description

Fix AWEX weight-update metadata mismatches with vLLM 0.26, which nests fused expert parameters under `routed_experts`. Normalize `.experts.routed_experts.` to `.experts.` at AReaL's AWEX integration boundary before the existing converter runs. Preserve existing names and normalization behavior, and make patch installation idempotent.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):** None. This PR targets `ascend` and is based on its latest head.

## Additional Context

Validation: `python -m pytest tests/test_awex_expert_names.py tests/test_awex_runtime.py -q` passed all 11 tests; `pre-commit run --all-files` passed. The new regression test is selected by the existing CPU CI selector. An isolated CPU-tensor probe against installed AWEX 0.7.0 verified that nested and legacy expert paths produce identical gate/up/down names and tensor values with nonzero expert-parallel rank offsets. Distributed weight transfer and a full training restart have not been validated after this fix; the probe does not establish end-to-end correctness. No dependency changes are required.
